### PR TITLE
feat(pos): allow editing item unit price in the discount modal

### DIFF
--- a/frontend/src/app/pos/page.behavior.test.tsx
+++ b/frontend/src/app/pos/page.behavior.test.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import type { Product, Sale } from "@/types";
+import { formatCurrency } from "@/lib/utils";
 
 type UseProductsParams = {
   page?: number;
@@ -203,7 +204,11 @@ vi.mock("@/contexts/ToastContext", () => ({
 import POSPage from "./page";
 import { printReceipt, printThermalReceipt } from "@/hooks/useReceipt";
 
-function makeProduct(id: string, name: string): Product {
+function makeProduct(
+  id: string,
+  name: string,
+  overrides: Partial<Product> = {},
+): Product {
   return {
     id,
     name,
@@ -221,6 +226,7 @@ function makeProduct(id: string, name: string): Product {
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
     version: 1,
+    ...overrides,
   };
 }
 
@@ -482,5 +488,185 @@ describe("POS behavior evidence (#19, #18)", () => {
 
     const payload = createSaleMutateMock.mock.calls[0]?.[0] as { customerId?: string };
     expect(payload.customerId).toBeUndefined();
+  });
+});
+
+describe("POS item price override (pos-edit-item-price)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  function renderWithSingleProduct(name: string, salePrice: number) {
+    useProductsMock.mockReturnValue({
+      data: {
+        data: [makeProduct("p1", name, { salePrice })],
+        meta: { total: 1, page: 1, limit: 20, totalPages: 1 },
+      },
+      isLoading: false,
+      isFetching: false,
+    });
+    return render(<POSPage />);
+  }
+
+  async function openDiscountModal() {
+    await userEvent.click(screen.getByTitle("Descuento"));
+  }
+
+  it("edits a cart line unit price down, keeping the original struck through", async () => {
+    renderWithSingleProduct("Producto Precio", 50000);
+    await userEvent.click(screen.getByRole("button", { name: "Producto Precio" }));
+
+    await openDiscountModal();
+    const priceInput = screen.getByPlaceholderText("Precio");
+    await userEvent.clear(priceInput);
+    await userEvent.type(priceInput, "45000");
+    await userEvent.click(screen.getByRole("button", { name: "Aplicar precio" }));
+
+    expect(screen.getByTestId("line-unit-price").textContent).toContain(
+      formatCurrency(45000),
+    );
+    expect(screen.getByTestId("original-unit-price").textContent).toContain(
+      formatCurrency(50000),
+    );
+  });
+
+  it("edits a cart line unit price up", async () => {
+    renderWithSingleProduct("Producto Precio", 50000);
+    await userEvent.click(screen.getByRole("button", { name: "Producto Precio" }));
+
+    await openDiscountModal();
+    const priceInput = screen.getByPlaceholderText("Precio");
+    await userEvent.clear(priceInput);
+    await userEvent.type(priceInput, "55000");
+    await userEvent.click(screen.getByRole("button", { name: "Aplicar precio" }));
+
+    expect(screen.getByTestId("line-unit-price").textContent).toContain(
+      formatCurrency(55000),
+    );
+    expect(screen.getByTestId("original-unit-price").textContent).toContain(
+      formatCurrency(50000),
+    );
+  });
+
+  it("rejects a negative price and leaves the unit price unchanged", async () => {
+    renderWithSingleProduct("Producto Precio", 50000);
+    await userEvent.click(screen.getByRole("button", { name: "Producto Precio" }));
+
+    await openDiscountModal();
+    const priceInput = screen.getByPlaceholderText("Precio");
+    await userEvent.clear(priceInput);
+    await userEvent.type(priceInput, "-500");
+    await userEvent.click(screen.getByRole("button", { name: "Aplicar precio" }));
+
+    expect(screen.queryByTestId("original-unit-price")).toBeNull();
+    expect(screen.getByTestId("line-unit-price").textContent).toContain(
+      formatCurrency(50000),
+    );
+  });
+
+  it("recomputes a percentage discount against the edited price", async () => {
+    renderWithSingleProduct("Producto Pct", 50000);
+    await userEvent.click(screen.getByRole("button", { name: "Producto Pct" }));
+    await userEvent.click(screen.getByRole("button", { name: "Producto Pct" }));
+
+    // Apply a 10% percentage discount on quantity 2.
+    await openDiscountModal();
+    await userEvent.click(screen.getByRole("button", { name: "10%" }));
+
+    // Edit price down to 40000.
+    await openDiscountModal();
+    const priceInput = screen.getByPlaceholderText("Precio");
+    await userEvent.clear(priceInput);
+    await userEvent.type(priceInput, "40000");
+    await userEvent.click(screen.getByRole("button", { name: "Aplicar precio" }));
+
+    const discount = screen.getByTestId("line-discount");
+    expect(discount.textContent).toContain(formatCurrency(8000));
+    expect(discount.textContent).toContain("10%");
+  });
+
+  it("retains a fixed-amount discount when the price is edited", async () => {
+    renderWithSingleProduct("Producto Fixed", 50000);
+    await userEvent.click(screen.getByRole("button", { name: "Producto Fixed" }));
+
+    // Apply a fixed 5000 discount.
+    await openDiscountModal();
+    await userEvent.type(screen.getByPlaceholderText("0.00"), "5000");
+    await userEvent.click(screen.getByRole("button", { name: "Aplicar" }));
+
+    // Edit price down to 45000.
+    await openDiscountModal();
+    const priceInput = screen.getByPlaceholderText("Precio");
+    await userEvent.clear(priceInput);
+    await userEvent.type(priceInput, "45000");
+    await userEvent.click(screen.getByRole("button", { name: "Aplicar precio" }));
+
+    const discount = screen.getByTestId("line-discount");
+    expect(discount.textContent).toContain(formatCurrency(5000));
+    expect(discount.textContent).not.toContain("%");
+  });
+
+  it("clamps a fixed discount so the line total never goes negative", async () => {
+    renderWithSingleProduct("Producto Clamp", 50000);
+    await userEvent.click(screen.getByRole("button", { name: "Producto Clamp" }));
+
+    // Apply a fixed 5000 discount.
+    await openDiscountModal();
+    await userEvent.type(screen.getByPlaceholderText("0.00"), "5000");
+    await userEvent.click(screen.getByRole("button", { name: "Aplicar" }));
+
+    // Drop price below the fixed discount (5000) to 3000.
+    await openDiscountModal();
+    const priceInput = screen.getByPlaceholderText("Precio");
+    await userEvent.clear(priceInput);
+    await userEvent.type(priceInput, "3000");
+    await userEvent.click(screen.getByRole("button", { name: "Aplicar precio" }));
+
+    const discount = screen.getByTestId("line-discount");
+    expect(discount.textContent).toContain(formatCurrency(3000));
+  });
+
+  it("shows no strikethrough when the price equals the original", async () => {
+    renderWithSingleProduct("Producto NoEdit", 50000);
+    await userEvent.click(screen.getByRole("button", { name: "Producto NoEdit" }));
+
+    expect(screen.queryByTestId("original-unit-price")).toBeNull();
+    expect(screen.getByTestId("line-unit-price").textContent).toContain(
+      formatCurrency(50000),
+    );
+  });
+
+  it("sends the edited unit price (not the original) in the checkout payload", async () => {
+    createSaleMutateMock.mockResolvedValue(makeSale());
+    renderWithSingleProduct("Producto Ticket", 50000);
+    await userEvent.click(screen.getByRole("button", { name: "Producto Ticket" }));
+
+    // Edit the price down to 45000.
+    await openDiscountModal();
+    const priceInput = screen.getByPlaceholderText("Precio");
+    await userEvent.clear(priceInput);
+    await userEvent.type(priceInput, "45000");
+    await userEvent.click(screen.getByRole("button", { name: "Aplicar precio" }));
+
+    // Complete checkout with a card payment (covers the full total).
+    await userEvent.click(screen.getByRole("button", { name: /tarjeta/i }));
+    await userEvent.click(screen.getByRole("button", { name: /finalizar venta/i }));
+    await userEvent.click(screen.getByRole("button", { name: /confirmar pago/i }));
+
+    await waitFor(() => {
+      expect(createSaleMutateMock).toHaveBeenCalled();
+    });
+
+    const payload = createSaleMutateMock.mock.calls[0]?.[0] as {
+      items: Array<{ productId: string; unitPrice: number; discountAmount: number }>;
+    };
+    expect(payload.items).toHaveLength(1);
+    expect(payload.items[0].unitPrice).toBe(45000);
+    // The original price must not leak into the sale payload.
+    expect(payload.items[0]).not.toHaveProperty("originalUnitPrice");
   });
 });

--- a/frontend/src/app/pos/page.tsx
+++ b/frontend/src/app/pos/page.tsx
@@ -95,6 +95,7 @@ export default function POSPage() {
   const [paymentMethods, setPaymentMethods] = useState<PaymentMethod[]>([]);
   const [editingDiscount, setEditingDiscount] = useState<string | null>(null);
   const [customDiscount, setCustomDiscount] = useState("");
+  const [customPrice, setCustomPrice] = useState("");
   const [showPausedSalesModal, setShowPausedSalesModal] = useState(false);
   const [pausedSaleToDelete, setPausedSaleToDelete] = useState<string | null>(
     null,
@@ -227,6 +228,7 @@ export default function POSPage() {
           product,
           quantity: Math.min(quantity, product.stock),
           unitPrice: product.salePrice,
+          originalUnitPrice: product.salePrice,
           discountAmount: 0,
           availableStock: product.stock,
         },
@@ -307,6 +309,52 @@ export default function POSPage() {
     },
     [],
   );
+
+  /** Override a cart line's unit price, preserving any existing discount */
+  const updateItemPrice = useCallback(
+    (productId: string, price: number) => {
+      setCart((prev) =>
+        prev.map((item) => {
+          if (item.productId !== productId) return item;
+          const newPrice = Math.max(0, price);
+          const itemSubtotal = newPrice * item.quantity;
+          // Percentage discounts recompute against the new price; fixed
+          // amounts stay but clamp so the line total never goes negative.
+          const discountAmount = item.discountPercent
+            ? Math.min(
+                (itemSubtotal * item.discountPercent) / 100,
+                itemSubtotal,
+              )
+            : Math.min(item.discountAmount, itemSubtotal);
+          return {
+            ...item,
+            unitPrice: newPrice,
+            discountAmount: Math.max(0, discountAmount),
+          };
+        }),
+      );
+      setEditingDiscount(null);
+      setCustomDiscount("");
+      setCustomPrice("");
+    },
+    [],
+  );
+
+  const openDiscountModal = useCallback(
+    (productId: string) => {
+      const item = cart.find((i) => i.productId === productId);
+      setEditingDiscount(productId);
+      setCustomDiscount("");
+      setCustomPrice(item ? String(item.unitPrice) : "");
+    },
+    [cart],
+  );
+
+  const handleCloseDiscountModal = useCallback(() => {
+    setEditingDiscount(null);
+    setCustomDiscount("");
+    setCustomPrice("");
+  }, []);
 
   const handleScanSubmit = useCallback(async () => {
     if (isScannerBlocked) {
@@ -741,9 +789,24 @@ export default function POSPage() {
                         {item.product.name}
                       </p>
                       <p className="text-xs text-muted-foreground mb-1.5">
-                        {formatCurrency(item.unitPrice)} × {item.quantity}
+                        {typeof item.originalUnitPrice === "number" &&
+                          item.unitPrice !== item.originalUnitPrice && (
+                            <s
+                              data-testid="original-unit-price"
+                              className="mr-1 text-muted-foreground/60 line-through"
+                            >
+                              {formatCurrency(item.originalUnitPrice)}
+                            </s>
+                          )}
+                        <span data-testid="line-unit-price">
+                          {formatCurrency(item.unitPrice)}
+                        </span>{" "}
+                        × {item.quantity}
                         {item.discountAmount > 0 && (
-                          <span className="ml-1.5 text-emerald-600 dark:text-emerald-400">
+                          <span
+                            data-testid="line-discount"
+                            className="ml-1.5 text-emerald-600 dark:text-emerald-400"
+                          >
                             (-{formatCurrency(item.discountAmount)}
                             {item.discountPercent
                               ? ` · ${item.discountPercent}%`
@@ -786,7 +849,7 @@ export default function POSPage() {
                           </span>
                         )}
                         <button
-                          onClick={() => setEditingDiscount(item.productId)}
+                          onClick={() => openDiscountModal(item.productId)}
                           className="w-7 h-7 rounded-lg border border-accent/30 bg-background/60 flex items-center justify-center text-muted-foreground hover:text-primary transition-colors"
                           title="Descuento"
                         >
@@ -1093,14 +1156,36 @@ export default function POSPage() {
       {editingDiscount && (
         <Modal
           isOpen={!!editingDiscount}
-          onClose={() => {
-            setEditingDiscount(null);
-            setCustomDiscount("");
-          }}
+          onClose={handleCloseDiscountModal}
           title="Agregar Descuento"
           size="sm"
         >
           <div className="space-y-4">
+            <div className="space-y-2">
+              <Input
+                type="number"
+                step="0.01"
+                label="Precio unitario"
+                value={customPrice}
+                onChange={(e) => setCustomPrice(e.target.value)}
+                placeholder="Precio"
+                min="0"
+              />
+              <Button
+                variant="secondary"
+                className="w-full"
+                disabled={!customPrice}
+                onClick={() => {
+                  if (!editingDiscount) return;
+                  const price = Number(customPrice);
+                  if (Number.isNaN(price) || price < 0) return;
+                  updateItemPrice(editingDiscount, price);
+                }}
+              >
+                Aplicar precio
+              </Button>
+            </div>
+
             <Input
               type="number"
               step="0.01"
@@ -1127,10 +1212,7 @@ export default function POSPage() {
             <div className="flex gap-2 pt-2">
               <Button
                 variant="secondary"
-                onClick={() => {
-                  setEditingDiscount(null);
-                  setCustomDiscount("");
-                }}
+                onClick={handleCloseDiscountModal}
                 className="flex-1"
               >
                 Cancelar

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -179,6 +179,8 @@ export interface CartItem {
   product: Product;
   quantity: number;
   unitPrice: number;
+  /** Snapshot of product.salePrice at add-to-cart time — original price before any override */
+  originalUnitPrice: number;
   discountAmount: number;
   /** When set, discount scales with quantity: amount = price × qty × percent / 100 */
   discountPercent?: number;


### PR DESCRIPTION
Add a price-edit input to the POS discount modal so a cashier can override a line's unit price (up or down) without clearing an existing discount. The original price is snapshotted on CartItem and shown struck through in the cart only; checkout and the receipt keep using the edited unit price.