### PR TITLE
feat(expenses): add expense data models, categories CRUD and seeding (1/5)

### DIFF
--- a/backend/prisma/migrations/20260815000000_add_expenses/migration.sql
+++ b/backend/prisma/migrations/20260815000000_add_expenses/migration.sql
@@ -1,0 +1,94 @@
+-- CreateEnum
+CREATE TYPE "ExpensePaymentStatus" AS ENUM ('PARTIAL', 'PAID');
+
+-- CreateTable
+CREATE TABLE "ExpenseCategory" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ExpenseCategory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Expense" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "categoryId" TEXT NOT NULL,
+    "supplierId" TEXT,
+    "purchaseOrderId" TEXT,
+    "description" TEXT,
+    "date" TIMESTAMP(3) NOT NULL,
+    "total" DECIMAL(12,2) NOT NULL,
+    "status" "ExpensePaymentStatus" NOT NULL,
+    "receiptUrl" TEXT,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Expense_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ExpensePayment" (
+    "id" TEXT NOT NULL,
+    "expenseId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "amount" DECIMAL(12,2) NOT NULL,
+    "method" "PaymentMethod" NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ExpensePayment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ExpenseCategory_organizationId_name_key" ON "ExpenseCategory"("organizationId", "name");
+
+-- CreateIndex
+CREATE INDEX "ExpenseCategory_organizationId_active_idx" ON "ExpenseCategory"("organizationId", "active");
+
+-- CreateIndex
+CREATE INDEX "Expense_organizationId_date_idx" ON "Expense"("organizationId", "date");
+
+-- CreateIndex
+CREATE INDEX "Expense_organizationId_categoryId_idx" ON "Expense"("organizationId", "categoryId");
+
+-- CreateIndex
+CREATE INDEX "ExpensePayment_organizationId_expenseId_idx" ON "ExpensePayment"("organizationId", "expenseId");
+
+-- AddForeignKey
+ALTER TABLE "ExpenseCategory" ADD CONSTRAINT "ExpenseCategory_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Expense" ADD CONSTRAINT "Expense_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Expense" ADD CONSTRAINT "Expense_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "ExpenseCategory"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Expense" ADD CONSTRAINT "Expense_supplierId_fkey" FOREIGN KEY ("supplierId") REFERENCES "Supplier"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Expense" ADD CONSTRAINT "Expense_purchaseOrderId_fkey" FOREIGN KEY ("purchaseOrderId") REFERENCES "PurchaseOrder"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Expense" ADD CONSTRAINT "Expense_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ExpensePayment" ADD CONSTRAINT "ExpensePayment_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ExpensePayment" ADD CONSTRAINT "ExpensePayment_expenseId_fkey" FOREIGN KEY ("expenseId") REFERENCES "Expense"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Data backfill: five default expense categories (Spanish) for every existing organization
+INSERT INTO "ExpenseCategory" ("id", "organizationId", "name", "active", "createdAt", "updatedAt")
+SELECT gen_random_uuid(), o."id", n."name", TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM "Organization" AS o
+CROSS JOIN (
+    VALUES ('Arriendo'), ('Pago mensual'), ('Seguridad'), ('Salida de empleados'), ('Caja menor')
+) AS n("name");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -28,6 +28,9 @@ model Organization {
   cashRegisters      CashRegister[]
   categories         Category[]
   customers          Customer[]
+  expenseCategories  ExpenseCategory[]
+  expensePayments    ExpensePayment[]
+  expenses           Expense[]
   inventoryMovements InventoryMovement[]
   sequences          OrganizationSequence[]
   users              OrganizationUser[]
@@ -56,6 +59,7 @@ model User {
   tokenVersion       Int                 @default(0)
   isSuperAdmin       Boolean             @default(false)
   auditLogs          AuditLog[]
+  expensesCreated    Expense[]           @relation("ExpenseCreatedBy")
   inventoryMovements InventoryMovement[]
   organizationUsers  OrganizationUser[]
   purchaseOrders     PurchaseOrder[]
@@ -329,6 +333,7 @@ model Supplier {
   createdAt      DateTime        @default(now())
   updatedAt      DateTime        @updatedAt
   organizationId String
+  expenses       Expense[]
   preferredBy    Product[]       @relation("PreferredSupplier")
   purchaseOrders PurchaseOrder[]
   organization   Organization    @relation(fields: [organizationId], references: [id], onDelete: Cascade)
@@ -358,6 +363,7 @@ model PurchaseOrder {
   createdBy      User                @relation(fields: [createdById], references: [id])
   organization   Organization        @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   supplier       Supplier            @relation(fields: [supplierId], references: [id])
+  expenses       Expense[]
   items          PurchaseOrderItem[]
 
   @@unique([organizationId, orderNumber])
@@ -418,6 +424,60 @@ model PaymentRecord {
   @@index([organizationId, date])
 }
 
+model ExpenseCategory {
+  id             String       @id @default(uuid())
+  organizationId String
+  name           String
+  active         Boolean      @default(true)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  expenses       Expense[]
+
+  @@unique([organizationId, name])
+  @@index([organizationId, active])
+}
+
+model Expense {
+  id              String              @id @default(uuid())
+  organizationId  String
+  categoryId      String
+  supplierId      String?
+  purchaseOrderId String?
+  description     String?
+  date            DateTime
+  total           Decimal             @db.Decimal(12, 2)
+  status          ExpensePaymentStatus
+  receiptUrl      String?
+  active          Boolean             @default(true)
+  createdById     String
+  createdAt       DateTime            @default(now())
+  updatedAt       DateTime            @updatedAt
+  organization    Organization        @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  category        ExpenseCategory     @relation(fields: [categoryId], references: [id])
+  supplier        Supplier?           @relation(fields: [supplierId], references: [id], onDelete: SetNull)
+  purchaseOrder   PurchaseOrder?      @relation(fields: [purchaseOrderId], references: [id], onDelete: SetNull)
+  createdBy       User                @relation("ExpenseCreatedBy", fields: [createdById], references: [id])
+  payments        ExpensePayment[]
+
+  @@index([organizationId, date])
+  @@index([organizationId, categoryId])
+}
+
+model ExpensePayment {
+  id             String        @id @default(uuid())
+  expenseId      String
+  organizationId String
+  amount         Decimal       @db.Decimal(12, 2)
+  method         PaymentMethod
+  date           DateTime
+  createdAt      DateTime      @default(now())
+  organization   Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  expense        Expense       @relation(fields: [expenseId], references: [id], onDelete: Cascade)
+
+  @@index([organizationId, expenseId])
+}
+
 enum OrgStatus {
   TRIAL
   ACTIVE
@@ -464,6 +524,11 @@ enum PaymentMethod {
   CASH
   CARD
   TRANSFER
+}
+
+enum ExpensePaymentStatus {
+  PARTIAL
+  PAID
 }
 
 enum PaymentRecordStatus {

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,6 +1,7 @@
 import { PrismaClient, Prisma, OrgRole, PlanType, OrgStatus, BillingStatus } from '@prisma/client';
 import * as bcrypt from 'bcryptjs';
 import { faker } from '@faker-js/faker';
+import { DEFAULT_EXPENSE_CATEGORY_NAMES } from '../src/expenses/default-expense-categories';
 
 const prisma = new PrismaClient();
 
@@ -345,6 +346,19 @@ async function createDemoSales(
   });
 }
 
+async function createDemoExpenseCategories(orgId: string): Promise<number> {
+  const result = await prisma.expenseCategory.createMany({
+    data: DEFAULT_EXPENSE_CATEGORY_NAMES.map((name) => ({
+      name,
+      organizationId: orgId,
+    })),
+    skipDuplicates: true,
+  });
+
+  console.log(`  🏷️  ${result.count} categorías de salidas creadas`);
+  return result.count;
+}
+
 async function seedDemoOrganization(
   name: string,
   slug: string,
@@ -362,6 +376,9 @@ async function seedDemoOrganization(
   // Categorías
   const categoryCount = plan === PlanType.PRO ? 10 : 5;
   const categoryIds = await createDemoCategories(orgId, categoryCount);
+
+  // Categorías de salidas
+  await createDemoExpenseCategories(orgId);
 
   // Productos
   const productCount = plan === PlanType.PRO ? 30 : 20;

--- a/backend/src/admin/admin.service.spec.ts
+++ b/backend/src/admin/admin.service.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { AdminService } from './admin.service';
 import { OrgRole, OrgStatus, PlanType } from '@prisma/client';
+import { DEFAULT_EXPENSE_CATEGORY_NAMES } from '../expenses/default-expense-categories';
 
 describe('AdminService', () => {
   let service: AdminService;
@@ -47,6 +48,9 @@ describe('AdminService', () => {
     cashRegister: {
       create: jest.fn(),
       findMany: jest.fn(),
+    },
+    expenseCategory: {
+      createMany: jest.fn(),
     },
     refreshToken: {
       updateMany: jest.fn(),
@@ -175,6 +179,39 @@ describe('AdminService', () => {
       expect(prismaMock.cashRegister.create).toHaveBeenCalled();
       expect(result.tempPassword).toBeUndefined();
       expect(result.message).toContain('Existing user assigned');
+    });
+
+    it('seeds the five default expense categories inside the creation transaction', async () => {
+      prismaMock.organization.findFirst.mockResolvedValue(null);
+      prismaMock.organization.create.mockResolvedValue({
+        id: 'org-1',
+        name: 'Test Org',
+        slug: 'test-org',
+        plan: PlanType.BASIC,
+        status: OrgStatus.TRIAL,
+      });
+      prismaMock.organizationSequence.createMany.mockResolvedValue({
+        count: 2,
+      });
+      prismaMock.cashRegister.create.mockResolvedValue({
+        id: 'cr-1',
+        organizationId: 'org-1',
+        name: 'Caja Principal',
+        isDefault: true,
+      });
+      prismaMock.expenseCategory.createMany.mockResolvedValue({ count: 5 });
+
+      await service.createOrganization({
+        name: 'Test Org',
+        slug: 'test-org',
+      });
+
+      expect(prismaMock.expenseCategory.createMany).toHaveBeenCalledWith({
+        data: DEFAULT_EXPENSE_CATEGORY_NAMES.map((name) => ({
+          name,
+          organizationId: 'org-1',
+        })),
+      });
     });
 
     it('fails if slug already exists', async () => {

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -15,6 +15,7 @@ import { UpdateOrganizationPlanDto } from './dto/update-organization-plan.dto';
 import { OrgRole, OrgStatus, PlanType, Prisma } from '@prisma/client';
 import { PlanLimitService } from '../plan-limits/plan-limits.service';
 import { PLAN_LIMITS, LimitType } from '../plan-limits/plan-limits.constants';
+import { DEFAULT_EXPENSE_CATEGORY_NAMES } from '../expenses/default-expense-categories';
 
 @Injectable()
 export class AdminService {
@@ -103,6 +104,13 @@ export class AdminService {
           name: 'Caja Principal',
           isDefault: true,
         },
+      });
+
+      await tx.expenseCategory.createMany({
+        data: DEFAULT_EXPENSE_CATEGORY_NAMES.map((name) => ({
+          name,
+          organizationId: organization.id,
+        })),
       });
 
       return {

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -26,6 +26,7 @@ import { PlanLimitsModule } from './plan-limits/plan-limits.module';
 import { OrganizationStatusGuard } from './common/guards/organization-status.guard';
 import { CashRegistersModule } from './cash-registers/cash-registers.module';
 import { BillingModule } from './billing/billing.module';
+import { ExpenseCategoriesModule } from './expenses/expense-categories.module';
 
 @Module({
   imports: [
@@ -59,6 +60,7 @@ import { BillingModule } from './billing/billing.module';
     PlanLimitsModule,
     CashRegistersModule,
     BillingModule,
+    ExpenseCategoriesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/expenses/default-expense-categories.ts
+++ b/backend/src/expenses/default-expense-categories.ts
@@ -1,0 +1,7 @@
+export const DEFAULT_EXPENSE_CATEGORY_NAMES = [
+  'Arriendo',
+  'Pago mensual',
+  'Seguridad',
+  'Salida de empleados',
+  'Caja menor',
+] as const;

--- a/backend/src/expenses/dto/create-expense-category.dto.ts
+++ b/backend/src/expenses/dto/create-expense-category.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class CreateExpenseCategoryDto {
+  @ApiProperty({ example: 'Servicios públicos' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+}

--- a/backend/src/expenses/dto/update-expense-category.dto.ts
+++ b/backend/src/expenses/dto/update-expense-category.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateExpenseCategoryDto {
+  @ApiProperty({ required: false, example: 'Servicios públicos' })
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  name?: string;
+}

--- a/backend/src/expenses/expense-categories.controller.spec.ts
+++ b/backend/src/expenses/expense-categories.controller.spec.ts
@@ -1,0 +1,103 @@
+import { ForbiddenException, type ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { OrgRole } from '@prisma/client';
+import { ROLES_KEY } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { ExpenseCategoriesController } from './expense-categories.controller';
+import type { RequestUser } from '../common/interfaces/request-user.interface';
+
+describe('ExpenseCategoriesController', () => {
+  const serviceMock = {
+    findAll: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  const adminUser: RequestUser = {
+    userId: 'user-1',
+    email: 'admin@example.com',
+    organizationId: 'org-1',
+    role: OrgRole.ADMIN,
+    tokenVersion: 1,
+    isSuperAdmin: false,
+  };
+
+  const createContext = (
+    handler: (...args: unknown[]) => unknown,
+    role: OrgRole,
+  ): ExecutionContext =>
+    ({
+      getHandler: () => handler,
+      getClass: () => ExpenseCategoriesController,
+      switchToHttp: () => ({
+        getRequest: () => ({ user: { role } }),
+      }),
+    }) as unknown as ExecutionContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('requires ADMIN on every handler', () => {
+    const controller = new ExpenseCategoriesController(serviceMock as never);
+    const handlers = [
+      controller.findAll,
+      controller.create,
+      controller.update,
+      controller.remove,
+    ];
+
+    for (const handler of handlers) {
+      expect(Reflect.getMetadata(ROLES_KEY, handler)).toEqual([OrgRole.ADMIN]);
+    }
+  });
+
+  it('allows OWNER through RolesGuard because OWNER inherits ADMIN', () => {
+    const controller = new ExpenseCategoriesController(serviceMock as never);
+    const guard = new RolesGuard(new Reflector());
+
+    expect(
+      guard.canActivate(createContext(controller.findAll, OrgRole.OWNER)),
+    ).toBe(true);
+  });
+
+  it('denies CASHIER access through RolesGuard', () => {
+    const controller = new ExpenseCategoriesController(serviceMock as never);
+    const guard = new RolesGuard(new Reflector());
+
+    expect(() =>
+      guard.canActivate(createContext(controller.findAll, OrgRole.CASHIER)),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('delegates list/create/update/remove with organizationId from token only', async () => {
+    const controller = new ExpenseCategoriesController(serviceMock as never);
+    const body = { name: 'Servicios' };
+    const category = {
+      id: 'c1',
+      name: 'Servicios',
+      organizationId: 'org-1',
+    };
+
+    serviceMock.findAll.mockResolvedValue([category]);
+    serviceMock.create.mockResolvedValue(category);
+    serviceMock.update.mockResolvedValue(category);
+    serviceMock.remove.mockResolvedValue({ ...category, active: false });
+
+    await expect(controller.findAll(adminUser)).resolves.toEqual([category]);
+    await expect(controller.create(body, adminUser)).resolves.toEqual(category);
+    await expect(controller.update('c1', body, adminUser)).resolves.toEqual(
+      category,
+    );
+    await expect(controller.remove('c1', adminUser)).resolves.toEqual({
+      ...category,
+      active: false,
+    });
+
+    expect(serviceMock.findAll).toHaveBeenCalledWith('org-1');
+    expect(serviceMock.create).toHaveBeenCalledWith(body, 'org-1');
+    expect(serviceMock.update).toHaveBeenCalledWith('c1', body, 'org-1');
+    expect(serviceMock.remove).toHaveBeenCalledWith('c1', 'org-1');
+  });
+});

--- a/backend/src/expenses/expense-categories.controller.ts
+++ b/backend/src/expenses/expense-categories.controller.ts
@@ -1,0 +1,71 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { OrgRole } from '@prisma/client';
+import { JwtAuthGuard } from '../auth/jwt.strategy';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { Roles } from '../common/decorators/roles.decorator';
+import { OrganizationRequiredGuard } from '../common/guards/organization-required.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
+import type { RequestUser } from '../common/interfaces/request-user.interface';
+import { ExpenseCategoriesService } from './expense-categories.service';
+import { CreateExpenseCategoryDto } from './dto/create-expense-category.dto';
+import { UpdateExpenseCategoryDto } from './dto/update-expense-category.dto';
+
+@ApiTags('Expense Categories')
+@Controller('expense-categories')
+@UseGuards(JwtAuthGuard, RolesGuard, OrganizationRequiredGuard)
+@UseInterceptors(AdminOrganizationInterceptor)
+@ApiBearerAuth()
+export class ExpenseCategoriesController {
+  constructor(
+    private readonly expenseCategoriesService: ExpenseCategoriesService,
+  ) {}
+
+  @Get()
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Listar categorías de salidas de la organización' })
+  findAll(@CurrentUser() user: RequestUser) {
+    return this.expenseCategoriesService.findAll(user.organizationId);
+  }
+
+  @Post()
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Crear una categoría de salidas' })
+  create(
+    @Body() dto: CreateExpenseCategoryDto,
+    @CurrentUser() user: RequestUser,
+  ) {
+    return this.expenseCategoriesService.create(dto, user.organizationId);
+  }
+
+  @Patch(':id')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Actualizar una categoría de salidas' })
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdateExpenseCategoryDto,
+    @CurrentUser() user: RequestUser,
+  ) {
+    return this.expenseCategoriesService.update(id, dto, user.organizationId);
+  }
+
+  @Delete(':id')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({
+    summary: 'Desactivar una categoría de salidas (borrado lógico)',
+  })
+  remove(@Param('id') id: string, @CurrentUser() user: RequestUser) {
+    return this.expenseCategoriesService.remove(id, user.organizationId);
+  }
+}

--- a/backend/src/expenses/expense-categories.module.ts
+++ b/backend/src/expenses/expense-categories.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { OrganizationRequiredGuard } from '../common/guards/organization-required.guard';
+import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
+import { ExpenseCategoriesController } from './expense-categories.controller';
+import { ExpenseCategoriesService } from './expense-categories.service';
+
+@Module({
+  controllers: [ExpenseCategoriesController],
+  providers: [
+    ExpenseCategoriesService,
+    OrganizationRequiredGuard,
+    AdminOrganizationInterceptor,
+  ],
+  exports: [ExpenseCategoriesService],
+})
+export class ExpenseCategoriesModule {}

--- a/backend/src/expenses/expense-categories.service.spec.ts
+++ b/backend/src/expenses/expense-categories.service.spec.ts
@@ -1,0 +1,216 @@
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  DEFAULT_EXPENSE_CATEGORY_NAMES,
+  ExpenseCategoriesService,
+} from './expense-categories.service';
+
+describe('ExpenseCategoriesService', () => {
+  let service: ExpenseCategoriesService;
+  const orgId = 'org-1';
+
+  const prismaMock = {
+    expenseCategory: {
+      count: jest.fn(),
+      createMany: jest.fn(),
+      create: jest.fn(),
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ExpenseCategoriesService(prismaMock as never);
+  });
+
+  describe('ensureDefaultCategories', () => {
+    it('seeds the five Spanish defaults when the org has zero categories', async () => {
+      prismaMock.expenseCategory.count.mockResolvedValue(0);
+      prismaMock.expenseCategory.createMany.mockResolvedValue({ count: 5 });
+
+      const result = await service.ensureDefaultCategories(orgId);
+
+      expect(prismaMock.expenseCategory.count).toHaveBeenCalledWith({
+        where: { organizationId: orgId },
+      });
+      expect(prismaMock.expenseCategory.createMany).toHaveBeenCalledWith({
+        data: DEFAULT_EXPENSE_CATEGORY_NAMES.map((name) => ({
+          name,
+          organizationId: orgId,
+        })),
+        skipDuplicates: true,
+      });
+      expect(result).toBe(5);
+    });
+
+    it('is idempotent: does nothing when the org already has categories', async () => {
+      prismaMock.expenseCategory.count.mockResolvedValue(3);
+
+      const result = await service.ensureDefaultCategories(orgId);
+
+      expect(prismaMock.expenseCategory.createMany).not.toHaveBeenCalled();
+      expect(result).toBe(0);
+    });
+  });
+
+  describe('findAll', () => {
+    it('ensures defaults lazily and lists org-scoped active categories', async () => {
+      prismaMock.expenseCategory.count.mockResolvedValue(5);
+      prismaMock.expenseCategory.findMany.mockResolvedValue([
+        { id: 'c1', name: 'Arriendo', active: true, organizationId: orgId },
+      ]);
+
+      const result = await service.findAll(orgId);
+
+      expect(prismaMock.expenseCategory.count).toHaveBeenCalledWith({
+        where: { organizationId: orgId },
+      });
+      expect(prismaMock.expenseCategory.findMany).toHaveBeenCalledWith({
+        where: { organizationId: orgId, active: true },
+        orderBy: { name: 'asc' },
+      });
+      expect(result).toHaveLength(1);
+    });
+
+    it('throws BadRequestException when organizationId is missing', async () => {
+      await expect(service.findAll(undefined)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('create', () => {
+    it('creates a category scoped to the organization', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue(null);
+      prismaMock.expenseCategory.create.mockResolvedValue({
+        id: 'c1',
+        name: 'Servicios',
+        organizationId: orgId,
+        active: true,
+      });
+
+      const result = await service.create({ name: 'Servicios' }, orgId);
+
+      expect(prismaMock.expenseCategory.findFirst).toHaveBeenCalledWith({
+        where: { name: 'Servicios', organizationId: orgId },
+      });
+      expect(prismaMock.expenseCategory.create).toHaveBeenCalledWith({
+        data: { name: 'Servicios', organizationId: orgId },
+      });
+      expect(result.name).toBe('Servicios');
+    });
+
+    it('rejects duplicate names within the same organization (409)', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue({ id: 'c1' });
+
+      await expect(service.create({ name: 'Arriendo' }, orgId)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('allows the same name in another organization', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue(null);
+      prismaMock.expenseCategory.create.mockResolvedValue({
+        id: 'c2',
+        name: 'Arriendo',
+        organizationId: 'org-2',
+      });
+
+      const result = await service.create({ name: 'Arriendo' }, 'org-2');
+
+      expect(prismaMock.expenseCategory.findFirst).toHaveBeenCalledWith({
+        where: { name: 'Arriendo', organizationId: 'org-2' },
+      });
+      expect(result.organizationId).toBe('org-2');
+    });
+
+    it('throws BadRequestException when organizationId is missing', async () => {
+      await expect(service.create({ name: 'X' }, undefined)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('updates a category within the organization', async () => {
+      prismaMock.expenseCategory.findFirst
+        .mockResolvedValueOnce({
+          id: 'c1',
+          name: 'Arriendo',
+          organizationId: orgId,
+        })
+        .mockResolvedValueOnce(null);
+      prismaMock.expenseCategory.update.mockResolvedValue({
+        id: 'c1',
+        name: 'Arriendo Nómina',
+        active: true,
+      });
+
+      const result = await service.update(
+        'c1',
+        { name: 'Arriendo Nómina' },
+        orgId,
+      );
+
+      expect(prismaMock.expenseCategory.update).toHaveBeenCalledWith({
+        where: { id: 'c1' },
+        data: { name: 'Arriendo Nómina' },
+      });
+      expect(result.name).toBe('Arriendo Nómina');
+    });
+
+    it('throws NotFoundException when category is not in the organization', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.update('nope', { name: 'X' }, orgId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects renaming to a duplicate name within the org (409)', async () => {
+      prismaMock.expenseCategory.findFirst
+        .mockResolvedValueOnce({ id: 'c1' })
+        .mockResolvedValueOnce({ id: 'c2' });
+
+      await expect(
+        service.update('c1', { name: 'Seguridad' }, orgId),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('remove', () => {
+    it('soft-deletes the category, keeping expense references intact', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue({
+        id: 'c1',
+        active: true,
+      });
+      prismaMock.expenseCategory.update.mockResolvedValue({
+        id: 'c1',
+        active: false,
+      });
+
+      const result = await service.remove('c1', orgId);
+
+      expect(prismaMock.expenseCategory.update).toHaveBeenCalledWith({
+        where: { id: 'c1' },
+        data: { active: false },
+      });
+      expect(prismaMock.expenseCategory.delete).not.toHaveBeenCalled();
+      expect(result.active).toBe(false);
+    });
+
+    it('throws NotFoundException when category is not in the organization', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue(null);
+
+      await expect(service.remove('nope', orgId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/backend/src/expenses/expense-categories.service.ts
+++ b/backend/src/expenses/expense-categories.service.ts
@@ -1,0 +1,135 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateExpenseCategoryDto } from './dto/create-expense-category.dto';
+import { UpdateExpenseCategoryDto } from './dto/update-expense-category.dto';
+import { DEFAULT_EXPENSE_CATEGORY_NAMES } from './default-expense-categories';
+
+export { DEFAULT_EXPENSE_CATEGORY_NAMES };
+
+@Injectable()
+export class ExpenseCategoriesService {
+  constructor(private prisma: PrismaService) {}
+
+  async ensureDefaultCategories(organizationId: string): Promise<number> {
+    const count = await this.prisma.expenseCategory.count({
+      where: { organizationId },
+    });
+
+    if (count > 0) {
+      return 0;
+    }
+
+    const result = await this.prisma.expenseCategory.createMany({
+      data: DEFAULT_EXPENSE_CATEGORY_NAMES.map((name) => ({
+        name,
+        organizationId,
+      })),
+      skipDuplicates: true,
+    });
+
+    return result.count;
+  }
+
+  async findAll(organizationId: string | undefined) {
+    if (!organizationId) {
+      throw new BadRequestException(
+        'Organization ID is required for this operation',
+      );
+    }
+
+    await this.ensureDefaultCategories(organizationId);
+
+    return this.prisma.expenseCategory.findMany({
+      where: { organizationId, active: true },
+      orderBy: { name: 'asc' },
+    });
+  }
+
+  async create(
+    dto: CreateExpenseCategoryDto,
+    organizationId: string | undefined,
+  ) {
+    if (!organizationId) {
+      throw new BadRequestException(
+        'Organization ID is required for this operation',
+      );
+    }
+
+    const existing = await this.prisma.expenseCategory.findFirst({
+      where: { name: dto.name, organizationId },
+    });
+
+    if (existing) {
+      throw new ConflictException(
+        'Ya existe una categoría de salidas con ese nombre',
+      );
+    }
+
+    return this.prisma.expenseCategory.create({
+      data: { name: dto.name, organizationId },
+    });
+  }
+
+  async update(
+    id: string,
+    dto: UpdateExpenseCategoryDto,
+    organizationId: string | undefined,
+  ) {
+    if (!organizationId) {
+      throw new BadRequestException(
+        'Organization ID is required for this operation',
+      );
+    }
+
+    const category = await this.prisma.expenseCategory.findFirst({
+      where: { id, organizationId },
+    });
+
+    if (!category) {
+      throw new NotFoundException('Categoría de salidas no encontrada');
+    }
+
+    if (dto.name) {
+      const existing = await this.prisma.expenseCategory.findFirst({
+        where: { name: dto.name, organizationId },
+      });
+
+      if (existing && existing.id !== id) {
+        throw new ConflictException(
+          'Ya existe una categoría de salidas con ese nombre',
+        );
+      }
+    }
+
+    return this.prisma.expenseCategory.update({
+      where: { id },
+      data: dto,
+    });
+  }
+
+  async remove(id: string, organizationId: string | undefined) {
+    if (!organizationId) {
+      throw new BadRequestException(
+        'Organization ID is required for this operation',
+      );
+    }
+
+    const category = await this.prisma.expenseCategory.findFirst({
+      where: { id, organizationId },
+    });
+
+    if (!category) {
+      throw new NotFoundException('Categoría de salidas no encontrada');
+    }
+
+    return this.prisma.expenseCategory.update({
+      where: { id },
+      data: { active: false },
+    });
+  }
+}


### PR DESCRIPTION
Closes #8

## Chain Context

- Strategy: **Feature Branch Chain** (5 slices) — `chained-pr` contract
- Slice: **1 of 5 — data layer + expense categories** 📍
- Base: `feat/expenses` (tracker, do not merge to main yet)
- Prior dependencies: none (first slice)
- Follow-up: slice 2 (expense CRUD + payments) → slice 3 (aux endpoints + integration tests) → slice 4 (frontend hooks/gating) → slice 5 (frontend UI)
- Out of scope in this slice: expense CRUD, payments, monthly summary, export, frontend

```
master
  └─ feat/expenses (tracker)
       └─ feat/expenses-unit-1 📍
```

## Summary

- Adds Prisma models `Expense`, `ExpensePayment`, `ExpenseCategory` + `ExpensePaymentStatus` enum, `Decimal(12,2)` money, multi-tenant indexes
- Hand-written migration with Spanish category backfill for existing organizations (**not yet applied** — local PostgreSQL unreachable at the time of this PR)
- Org-scoped expense categories CRUD (ADMIN-only) with lazy default seeding, duplicate detection (409), soft delete
- Seeds 5 Spanish categories for new organizations (inside the `createOrganization` transaction) and demo organizations (`seed.ts`)

## Changes

| File | Change |
|------|--------|
| `backend/prisma/schema.prisma` | 3 new models + enum + relations (incl. opposite `expensePayments` on Organization) |
| `backend/prisma/migrations/20260815000000_add_expenses/migration.sql` | migration + category backfill for existing orgs |
| `backend/src/expenses/*` | `ExpenseCategoriesModule`: controller, service, DTOs, default category names |
| `backend/src/admin/admin.service.ts` | auto-seed categories in `createOrganization` transaction |
| `backend/src/admin/admin.service.spec.ts` | seed coverage for org creation |
| `backend/prisma/seed.ts` | seed categories for demo orgs |
| `backend/src/app.module.ts` | register `ExpenseCategoriesModule` |

## Test Plan

- [x] Backend Jest suite: **332 passing** (314 baseline + 18 new); 2 pre-existing `.int.spec.ts` suites fail while PostgreSQL is down (unrelated to this change)
- [x] New specs written RED→GREEN: `expense-categories.service.spec.ts`, `expense-categories.controller.spec.ts`, updated `admin.service.spec.ts`
- [x] `npx prisma validate` OK
- [x] `npx prisma generate` OK
- [x] `npm run build` OK (backend)
- [x] ESLint clean on all new files
- [ ] Migration applied to a database (blocked: local PostgreSQL unreachable — scheduled before slice 3 integration tests)

## Contributor Checklist

- [x] Issue linked (`Closes #8`)
- [x] Conventional commits, no `Co-Authored-By`
- [x] Tests kept with the work unit
- [x] N/A shellcheck (no shell scripts changed)
- [x] Docs: schema self-documented via Prisma; AGENTS.md conventions followed
