### PR TITLE
feat(expenses): add expense CRUD and additional payments (2/5)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -27,6 +27,7 @@ import { OrganizationStatusGuard } from './common/guards/organization-status.gua
 import { CashRegistersModule } from './cash-registers/cash-registers.module';
 import { BillingModule } from './billing/billing.module';
 import { ExpenseCategoriesModule } from './expenses/expense-categories.module';
+import { ExpensesModule } from './expenses/expenses.module';
 
 @Module({
   imports: [
@@ -61,6 +62,7 @@ import { ExpenseCategoriesModule } from './expenses/expense-categories.module';
     CashRegistersModule,
     BillingModule,
     ExpenseCategoriesModule,
+    ExpensesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/expenses/dto/create-expense-payment.dto.ts
+++ b/backend/src/expenses/dto/create-expense-payment.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PaymentMethod } from '@prisma/client';
+import { IsDateString, IsEnum, IsNumber, Min } from 'class-validator';
+
+export class CreateExpensePaymentDto {
+  @ApiProperty({ example: 500000, minimum: 0.01 })
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0.01)
+  amount: number;
+
+  @ApiProperty({ enum: PaymentMethod, example: PaymentMethod.CASH })
+  @IsEnum(PaymentMethod)
+  method: PaymentMethod;
+
+  @ApiProperty({ example: '2026-08-15' })
+  @IsDateString()
+  date: string;
+}

--- a/backend/src/expenses/dto/create-expense.dto.ts
+++ b/backend/src/expenses/dto/create-expense.dto.ts
@@ -1,0 +1,53 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsDateString,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { CreateExpensePaymentDto } from './create-expense-payment.dto';
+
+export class CreateExpenseDto {
+  @ApiProperty({ example: 'uuid-category-id' })
+  @IsUUID()
+  categoryId: string;
+
+  @ApiPropertyOptional({ example: 'uuid-supplier-id' })
+  @IsOptional()
+  @IsUUID()
+  supplierId?: string;
+
+  @ApiPropertyOptional({ example: 'uuid-purchase-order-id' })
+  @IsOptional()
+  @IsUUID()
+  purchaseOrderId?: string;
+
+  @ApiPropertyOptional({ example: 'Arriendo agosto' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+
+  @ApiProperty({ example: '2026-08-15' })
+  @IsDateString()
+  date: string;
+
+  @ApiProperty({ example: 500000, minimum: 0.01 })
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0.01)
+  total: number;
+
+  @ApiProperty({ type: [CreateExpensePaymentDto] })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => CreateExpensePaymentDto)
+  payments: CreateExpensePaymentDto[];
+}

--- a/backend/src/expenses/dto/query-expenses.dto.ts
+++ b/backend/src/expenses/dto/query-expenses.dto.ts
@@ -1,0 +1,55 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ExpensePaymentStatus } from '@prisma/client';
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Matches,
+  Min,
+} from 'class-validator';
+
+export class QueryExpensesDto {
+  @ApiPropertyOptional({ example: 1, default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({ example: 10, default: 10 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number;
+
+  @ApiPropertyOptional({ example: '2026-08', pattern: '^\\d{4}-\\d{2}$' })
+  @IsOptional()
+  @Matches(/^\d{4}-\d{2}$/, {
+    message: 'El formato del mes debe ser YYYY-MM',
+  })
+  month?: string;
+
+  @ApiPropertyOptional({ example: 'uuid-category-id' })
+  @IsOptional()
+  @IsUUID()
+  categoryId?: string;
+
+  @ApiPropertyOptional({ example: 'uuid-supplier-id' })
+  @IsOptional()
+  @IsUUID()
+  supplierId?: string;
+
+  @ApiPropertyOptional({ enum: ExpensePaymentStatus })
+  @IsOptional()
+  @IsEnum(ExpensePaymentStatus)
+  status?: ExpensePaymentStatus;
+
+  @ApiPropertyOptional({ example: 'arriendo' })
+  @IsOptional()
+  @IsString()
+  search?: string;
+}

--- a/backend/src/expenses/dto/update-expense.dto.spec.ts
+++ b/backend/src/expenses/dto/update-expense.dto.spec.ts
@@ -1,0 +1,35 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UpdateExpenseDto } from './update-expense.dto';
+
+describe('UpdateExpenseDto', () => {
+  it('allows null to clear supplierId, purchaseOrderId and description', async () => {
+    const dto = plainToInstance(UpdateExpenseDto, {
+      supplierId: null,
+      purchaseOrderId: null,
+      description: null,
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toEqual([]);
+  });
+
+  it('rejects a non-UUID supplierId', async () => {
+    const dto = plainToInstance(UpdateExpenseDto, { supplierId: 'no-uuid' });
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a non-UUID purchaseOrderId', async () => {
+    const dto = plainToInstance(UpdateExpenseDto, {
+      purchaseOrderId: 'no-uuid',
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/backend/src/expenses/dto/update-expense.dto.ts
+++ b/backend/src/expenses/dto/update-expense.dto.ts
@@ -25,11 +25,11 @@ export class UpdateExpenseDto {
   @IsUUID()
   purchaseOrderId?: string | null;
 
-  @ApiPropertyOptional({ example: 'Arriendo agosto' })
+  @ApiPropertyOptional({ example: 'Arriendo agosto', nullable: true })
   @IsOptional()
   @IsString()
   @MaxLength(500)
-  description?: string;
+  description?: string | null;
 
   @ApiPropertyOptional({ example: '2026-08-15' })
   @IsOptional()

--- a/backend/src/expenses/dto/update-expense.dto.ts
+++ b/backend/src/expenses/dto/update-expense.dto.ts
@@ -1,0 +1,44 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsDateString,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  Min,
+} from 'class-validator';
+
+export class UpdateExpenseDto {
+  @ApiPropertyOptional({ example: 'uuid-category-id' })
+  @IsOptional()
+  @IsUUID()
+  categoryId?: string;
+
+  @ApiPropertyOptional({ example: 'uuid-supplier-id', nullable: true })
+  @IsOptional()
+  @IsUUID()
+  supplierId?: string | null;
+
+  @ApiPropertyOptional({ example: 'uuid-purchase-order-id', nullable: true })
+  @IsOptional()
+  @IsUUID()
+  purchaseOrderId?: string | null;
+
+  @ApiPropertyOptional({ example: 'Arriendo agosto' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+
+  @ApiPropertyOptional({ example: '2026-08-15' })
+  @IsOptional()
+  @IsDateString()
+  date?: string;
+
+  @ApiPropertyOptional({ example: 500000, minimum: 0.01 })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0.01)
+  total?: number;
+}

--- a/backend/src/expenses/expenses.controller.spec.ts
+++ b/backend/src/expenses/expenses.controller.spec.ts
@@ -1,0 +1,114 @@
+import { ForbiddenException, type ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { OrgRole } from '@prisma/client';
+import { ROLES_KEY } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import type { RequestUser } from '../common/interfaces/request-user.interface';
+import { ExpensesController } from './expenses.controller';
+
+describe('ExpensesController', () => {
+  const serviceMock = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  const adminUser: RequestUser = {
+    userId: 'user-1',
+    email: 'admin@example.com',
+    organizationId: 'org-1',
+    role: OrgRole.ADMIN,
+    tokenVersion: 1,
+    isSuperAdmin: false,
+  };
+
+  const createContext = (
+    handler: (...args: unknown[]) => unknown,
+    role: OrgRole,
+  ): ExecutionContext =>
+    ({
+      getHandler: () => handler,
+      getClass: () => ExpensesController,
+      switchToHttp: () => ({
+        getRequest: () => ({ user: { role } }),
+      }),
+    }) as unknown as ExecutionContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('requires ADMIN on every handler', () => {
+    const controller = new ExpensesController(serviceMock as never);
+    const handlers = [
+      controller.create,
+      controller.findAll,
+      controller.findOne,
+      controller.update,
+      controller.remove,
+    ];
+
+    for (const handler of handlers) {
+      expect(Reflect.getMetadata(ROLES_KEY, handler)).toEqual([OrgRole.ADMIN]);
+    }
+  });
+
+  it('allows OWNER through RolesGuard because OWNER inherits ADMIN', () => {
+    const controller = new ExpensesController(serviceMock as never);
+    const guard = new RolesGuard(new Reflector());
+
+    expect(
+      guard.canActivate(createContext(controller.findAll, OrgRole.OWNER)),
+    ).toBe(true);
+  });
+
+  it('denies CASHIER access through RolesGuard', () => {
+    const controller = new ExpensesController(serviceMock as never);
+    const guard = new RolesGuard(new Reflector());
+
+    expect(() =>
+      guard.canActivate(createContext(controller.findAll, OrgRole.CASHIER)),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('delegates CRUD with organizationId and userId from the token only', async () => {
+    const controller = new ExpensesController(serviceMock as never);
+    const body = { categoryId: 'cat-1', date: '2026-08-15', total: 500 };
+    const expense = { id: 'exp-1', organizationId: 'org-1' };
+
+    serviceMock.create.mockResolvedValue(expense);
+    serviceMock.findAll.mockResolvedValue({ data: [expense], meta: {} });
+    serviceMock.findOne.mockResolvedValue(expense);
+    serviceMock.update.mockResolvedValue(expense);
+    serviceMock.remove.mockResolvedValue({ ...expense, active: false });
+
+    await expect(controller.create(body, adminUser)).resolves.toEqual(expense);
+    await expect(controller.findAll({}, adminUser)).resolves.toEqual({
+      data: [expense],
+      meta: {},
+    });
+    await expect(controller.findOne('exp-1', adminUser)).resolves.toEqual(
+      expense,
+    );
+    await expect(controller.update('exp-1', body, adminUser)).resolves.toEqual(
+      expense,
+    );
+    await expect(controller.remove('exp-1', adminUser)).resolves.toEqual({
+      ...expense,
+      active: false,
+    });
+
+    expect(serviceMock.create).toHaveBeenCalledWith(body, 'user-1', 'org-1');
+    expect(serviceMock.findAll).toHaveBeenCalledWith({}, 'org-1');
+    expect(serviceMock.findOne).toHaveBeenCalledWith('exp-1', 'org-1');
+    expect(serviceMock.update).toHaveBeenCalledWith(
+      'exp-1',
+      body,
+      'user-1',
+      'org-1',
+    );
+    expect(serviceMock.remove).toHaveBeenCalledWith('exp-1', 'user-1', 'org-1');
+  });
+});

--- a/backend/src/expenses/expenses.controller.spec.ts
+++ b/backend/src/expenses/expenses.controller.spec.ts
@@ -13,6 +13,7 @@ describe('ExpensesController', () => {
     findOne: jest.fn(),
     update: jest.fn(),
     remove: jest.fn(),
+    addPayment: jest.fn(),
   };
 
   const adminUser: RequestUser = {
@@ -48,6 +49,7 @@ describe('ExpensesController', () => {
       controller.findOne,
       controller.update,
       controller.remove,
+      controller.addPayment,
     ];
 
     for (const handler of handlers) {
@@ -110,5 +112,24 @@ describe('ExpensesController', () => {
       'org-1',
     );
     expect(serviceMock.remove).toHaveBeenCalledWith('exp-1', 'user-1', 'org-1');
+  });
+
+  it('delegates addPayment with expense id, payment body, userId and organizationId from the token only', async () => {
+    const controller = new ExpensesController(serviceMock as never);
+    const payment = { amount: 100000, method: 'CASH', date: '2026-08-20' };
+    const expense = { id: 'exp-1', organizationId: 'org-1', status: 'PAID' };
+
+    serviceMock.addPayment.mockResolvedValue(expense);
+
+    await expect(
+      controller.addPayment('exp-1', payment, adminUser),
+    ).resolves.toEqual(expense);
+
+    expect(serviceMock.addPayment).toHaveBeenCalledWith(
+      'exp-1',
+      payment,
+      'user-1',
+      'org-1',
+    );
   });
 });

--- a/backend/src/expenses/expenses.controller.ts
+++ b/backend/src/expenses/expenses.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { OrgRole } from '@prisma/client';
+import { JwtAuthGuard } from '../auth/jwt.strategy';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { Roles } from '../common/decorators/roles.decorator';
+import { OrganizationRequiredGuard } from '../common/guards/organization-required.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
+import type { RequestUser } from '../common/interfaces/request-user.interface';
+import { CreateExpenseDto } from './dto/create-expense.dto';
+import { QueryExpensesDto } from './dto/query-expenses.dto';
+import { UpdateExpenseDto } from './dto/update-expense.dto';
+import { ExpensesService } from './expenses.service';
+
+@ApiTags('Expenses')
+@Controller('expenses')
+@UseGuards(JwtAuthGuard, RolesGuard, OrganizationRequiredGuard)
+@UseInterceptors(AdminOrganizationInterceptor)
+@ApiBearerAuth()
+export class ExpensesController {
+  constructor(private readonly expensesService: ExpensesService) {}
+
+  @Post()
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Crear una salida con su primer pago' })
+  create(@Body() dto: CreateExpenseDto, @CurrentUser() user: RequestUser) {
+    return this.expensesService.create(dto, user.userId, user.organizationId);
+  }
+
+  @Get()
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Listar salidas de la organización' })
+  findAll(@Query() query: QueryExpensesDto, @CurrentUser() user: RequestUser) {
+    return this.expensesService.findAll(query, user.organizationId);
+  }
+
+  @Get(':id')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Obtener una salida por ID' })
+  findOne(@Param('id') id: string, @CurrentUser() user: RequestUser) {
+    return this.expensesService.findOne(id, user.organizationId);
+  }
+
+  @Patch(':id')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Actualizar una salida' })
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdateExpenseDto,
+    @CurrentUser() user: RequestUser,
+  ) {
+    return this.expensesService.update(
+      id,
+      dto,
+      user.userId,
+      user.organizationId,
+    );
+  }
+
+  @Delete(':id')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Desactivar una salida (borrado lógico)' })
+  remove(@Param('id') id: string, @CurrentUser() user: RequestUser) {
+    return this.expensesService.remove(id, user.userId, user.organizationId);
+  }
+}

--- a/backend/src/expenses/expenses.controller.ts
+++ b/backend/src/expenses/expenses.controller.ts
@@ -20,6 +20,7 @@ import { RolesGuard } from '../common/guards/roles.guard';
 import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
 import type { RequestUser } from '../common/interfaces/request-user.interface';
 import { CreateExpenseDto } from './dto/create-expense.dto';
+import { CreateExpensePaymentDto } from './dto/create-expense-payment.dto';
 import { QueryExpensesDto } from './dto/query-expenses.dto';
 import { UpdateExpenseDto } from './dto/update-expense.dto';
 import { ExpensesService } from './expenses.service';
@@ -62,6 +63,22 @@ export class ExpensesController {
     @CurrentUser() user: RequestUser,
   ) {
     return this.expensesService.update(
+      id,
+      dto,
+      user.userId,
+      user.organizationId,
+    );
+  }
+
+  @Post(':id/payments')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Registrar un pago adicional a una salida' })
+  addPayment(
+    @Param('id') id: string,
+    @Body() dto: CreateExpensePaymentDto,
+    @CurrentUser() user: RequestUser,
+  ) {
+    return this.expensesService.addPayment(
       id,
       dto,
       user.userId,

--- a/backend/src/expenses/expenses.module.ts
+++ b/backend/src/expenses/expenses.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { OrganizationRequiredGuard } from '../common/guards/organization-required.guard';
+import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
+import { ExpensesController } from './expenses.controller';
+import { ExpensesService } from './expenses.service';
+
+@Module({
+  controllers: [ExpensesController],
+  providers: [
+    ExpensesService,
+    OrganizationRequiredGuard,
+    AdminOrganizationInterceptor,
+  ],
+  exports: [ExpensesService],
+})
+export class ExpensesModule {}

--- a/backend/src/expenses/expenses.service.spec.ts
+++ b/backend/src/expenses/expenses.service.spec.ts
@@ -16,6 +16,9 @@ describe('ExpensesService', () => {
       create: jest.fn(),
       update: jest.fn(),
     },
+    expensePayment: {
+      create: jest.fn(),
+    },
     auditLog: {
       create: jest.fn(),
     },
@@ -409,6 +412,167 @@ describe('ExpensesService', () => {
       await expect(
         service.update('exp-x', { description: 'Nuevo' }, userId, orgId),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('clears supplier, purchase order and description links when null is passed', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue({
+        ...buildExisting(),
+        supplierId: 'sup-1',
+        purchaseOrderId: 'po-1',
+      });
+      txMock.expense.update.mockResolvedValue({
+        id: 'exp-1',
+        status: 'PAID',
+        total: new Prisma.Decimal(500000),
+        description: null,
+        supplierId: null,
+        purchaseOrderId: null,
+        date: new Date('2026-08-15T00:00:00.000Z'),
+      });
+
+      const result = await service.update(
+        'exp-1',
+        { supplierId: null, purchaseOrderId: null, description: null },
+        userId,
+        orgId,
+      );
+
+      expect(txMock.expense.update).toHaveBeenCalledWith({
+        where: { id: 'exp-1' },
+        data: expect.objectContaining({
+          supplierId: null,
+          purchaseOrderId: null,
+          description: null,
+        }),
+        include: { category: true, supplier: true, payments: true },
+      });
+      expect(result).toMatchObject({
+        supplierId: null,
+        purchaseOrderId: null,
+        description: null,
+      });
+    });
+  });
+
+  describe('addPayment', () => {
+    const buildExisting = () => ({
+      id: 'exp-1',
+      organizationId: orgId,
+      active: true,
+      total: new Prisma.Decimal(500000),
+      status: 'PARTIAL',
+      payments: [
+        { id: 'pay-1', amount: new Prisma.Decimal(300000) },
+        { id: 'pay-2', amount: new Prisma.Decimal(100000) },
+      ],
+    });
+    const buildPaymentDto = () => ({
+      amount: 100000,
+      method: 'CASH',
+      date: '2026-08-20',
+    });
+
+    it('transitions PARTIAL to PAID inside one transaction when the new payment covers the remaining total', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(buildExisting());
+      txMock.expensePayment.create.mockResolvedValue({ id: 'pay-3' });
+      txMock.expense.update.mockResolvedValue({ id: 'exp-1', status: 'PAID' });
+
+      const result = await service.addPayment(
+        'exp-1',
+        buildPaymentDto(),
+        userId,
+        orgId,
+      );
+
+      expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+      expect(txMock.expensePayment.create).toHaveBeenCalledWith({
+        data: {
+          expenseId: 'exp-1',
+          organizationId: orgId,
+          amount: new Prisma.Decimal(100000),
+          method: 'CASH',
+          date: new Date('2026-08-20'),
+        },
+      });
+      expect(txMock.expense.update).toHaveBeenCalledWith({
+        where: { id: 'exp-1' },
+        data: { status: 'PAID' },
+        include: { category: true, supplier: true, payments: true },
+      });
+      expect(txMock.auditLog.create).toHaveBeenCalledTimes(1);
+      expect(txMock.auditLog.create.mock.calls[0][0].data).toMatchObject({
+        userId,
+        action: 'EXPENSE_PAYMENT_ADDED',
+        resource: 'Expense',
+        resourceId: 'exp-1',
+        organizationId: orgId,
+      });
+      expect(result).toEqual({ id: 'exp-1', status: 'PAID' });
+    });
+
+    it('keeps PARTIAL when the new payment still leaves a remainder', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(buildExisting());
+      txMock.expensePayment.create.mockResolvedValue({ id: 'pay-3' });
+      txMock.expense.update.mockResolvedValue({
+        id: 'exp-1',
+        status: 'PARTIAL',
+      });
+
+      const result = await service.addPayment(
+        'exp-1',
+        { ...buildPaymentDto(), amount: 50000 },
+        userId,
+        orgId,
+      );
+
+      expect(txMock.expense.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { status: 'PARTIAL' } }),
+      );
+      expect(result.status).toBe('PARTIAL');
+    });
+
+    it('rejects a payment that would exceed the total with 400 and never opens a transaction', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(buildExisting());
+
+      await expect(
+        service.addPayment(
+          'exp-1',
+          { ...buildPaymentDto(), amount: 150000 },
+          userId,
+          orgId,
+        ),
+      ).rejects.toThrow(
+        'La suma de los pagos no puede superar el total de la salida',
+      );
+
+      expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException for unknown or cross-org expense ids', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.addPayment('exp-x', buildPaymentDto(), userId, orgId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects payments on an inactive expense with 400 and never opens a transaction', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue({
+        ...buildExisting(),
+        active: false,
+      });
+
+      await expect(
+        service.addPayment('exp-1', buildPaymentDto(), userId, orgId),
+      ).rejects.toThrow('No se pueden registrar pagos en una salida eliminada');
+
+      expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when organizationId is missing', async () => {
+      await expect(
+        service.addPayment('exp-1', buildPaymentDto(), userId, undefined),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/backend/src/expenses/expenses.service.spec.ts
+++ b/backend/src/expenses/expenses.service.spec.ts
@@ -1,0 +1,449 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import {
+  ExpensesService,
+  buildMonthRange,
+  deriveExpensePaymentStatus,
+} from './expenses.service';
+
+describe('ExpensesService', () => {
+  let service: ExpensesService;
+  const orgId = 'org-1';
+  const userId = 'user-1';
+
+  const txMock = {
+    expense: {
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    auditLog: {
+      create: jest.fn(),
+    },
+  };
+
+  const prismaMock = {
+    $transaction: jest.fn(),
+    expense: {
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+    expenseCategory: {
+      findFirst: jest.fn(),
+    },
+    supplier: {
+      findFirst: jest.fn(),
+    },
+    purchaseOrder: {
+      findFirst: jest.fn(),
+    },
+  };
+
+  const buildValidCreateDto = () => ({
+    categoryId: 'cat-1',
+    supplierId: 'sup-1',
+    purchaseOrderId: 'po-1',
+    description: 'Arriendo agosto',
+    date: '2026-08-15',
+    total: 500000,
+    payments: [{ amount: 500000, method: 'CASH', date: '2026-08-15' }],
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prismaMock.$transaction.mockImplementation(
+      async (callback: (tx: typeof txMock) => unknown) => callback(txMock),
+    );
+    service = new ExpensesService(prismaMock as never);
+  });
+
+  describe('deriveExpensePaymentStatus', () => {
+    it('returns PAID when the payments sum equals the total', () => {
+      expect(
+        deriveExpensePaymentStatus(
+          new Prisma.Decimal(500000),
+          new Prisma.Decimal(500000),
+        ),
+      ).toBe('PAID');
+    });
+
+    it('returns PARTIAL when the payments sum is lower than the total', () => {
+      expect(
+        deriveExpensePaymentStatus(
+          new Prisma.Decimal(500000),
+          new Prisma.Decimal(200000),
+        ),
+      ).toBe('PARTIAL');
+    });
+
+    it('returns PAID when the payments sum covers the total exactly after multiple payments', () => {
+      expect(
+        deriveExpensePaymentStatus(
+          new Prisma.Decimal(500000),
+          new Prisma.Decimal(500000.01),
+        ),
+      ).toBe('PAID');
+    });
+  });
+
+  describe('buildMonthRange', () => {
+    it('maps a YYYY-MM month to Bogota day boundaries', () => {
+      const { start, end } = buildMonthRange('2026-08');
+
+      expect(start.toISOString()).toBe('2026-08-01T05:00:00.000Z');
+      expect(end.toISOString()).toBe('2026-09-01T04:59:59.999Z');
+    });
+
+    it('rejects malformed month strings', () => {
+      expect(() => buildMonthRange('2026-8')).toThrow(BadRequestException);
+      expect(() => buildMonthRange('nope')).toThrow(BadRequestException);
+    });
+  });
+
+  describe('create', () => {
+    it('creates a PAID expense when the first payment equals the total', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue({ id: 'cat-1' });
+      prismaMock.supplier.findFirst.mockResolvedValue({ id: 'sup-1' });
+      prismaMock.purchaseOrder.findFirst.mockResolvedValue({ id: 'po-1' });
+      txMock.expense.create.mockResolvedValue({ id: 'exp-1', status: 'PAID' });
+
+      const result = await service.create(buildValidCreateDto(), userId, orgId);
+
+      expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+      const createArgs = txMock.expense.create.mock.calls[0][0];
+      expect(createArgs.data.status).toBe('PAID');
+      expect(createArgs.data.total).toEqual(new Prisma.Decimal(500000));
+      expect(createArgs.data.createdById).toBe(userId);
+      expect(createArgs.data.organizationId).toBe(orgId);
+      expect(createArgs.data.payments.create).toHaveLength(1);
+      expect(createArgs.data.payments.create[0]).toMatchObject({
+        amount: new Prisma.Decimal(500000),
+        method: 'CASH',
+        date: new Date('2026-08-15'),
+        organizationId: orgId,
+      });
+      expect(txMock.auditLog.create).toHaveBeenCalledTimes(1);
+      const auditArgs = txMock.auditLog.create.mock.calls[0][0];
+      expect(auditArgs.data).toMatchObject({
+        userId,
+        action: 'EXPENSE_CREATED',
+        resource: 'Expense',
+        resourceId: 'exp-1',
+        organizationId: orgId,
+      });
+      expect(result).toEqual({ id: 'exp-1', status: 'PAID' });
+    });
+
+    it('creates a PARTIAL expense when the first payment is lower than the total', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue({ id: 'cat-1' });
+      prismaMock.supplier.findFirst.mockResolvedValue(null);
+      prismaMock.purchaseOrder.findFirst.mockResolvedValue(null);
+      txMock.expense.create.mockResolvedValue({
+        id: 'exp-2',
+        status: 'PARTIAL',
+      });
+
+      const result = await service.create(
+        {
+          ...buildValidCreateDto(),
+          supplierId: undefined,
+          purchaseOrderId: undefined,
+          payments: [
+            { amount: 200000, method: 'TRANSFER', date: '2026-08-15' },
+          ],
+        },
+        userId,
+        orgId,
+      );
+
+      expect(txMock.expense.create.mock.calls[0][0].data.status).toBe(
+        'PARTIAL',
+      );
+      expect(result.status).toBe('PARTIAL');
+    });
+
+    it('rejects zero payments with 400 and never opens a transaction', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue({ id: 'cat-1' });
+      prismaMock.supplier.findFirst.mockResolvedValue({ id: 'sup-1' });
+      prismaMock.purchaseOrder.findFirst.mockResolvedValue({ id: 'po-1' });
+
+      await expect(
+        service.create(
+          { ...buildValidCreateDto(), payments: [] },
+          userId,
+          orgId,
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('rejects a payment that exceeds the total with 400', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue({ id: 'cat-1' });
+      prismaMock.supplier.findFirst.mockResolvedValue({ id: 'sup-1' });
+      prismaMock.purchaseOrder.findFirst.mockResolvedValue({ id: 'po-1' });
+
+      await expect(
+        service.create(
+          {
+            ...buildValidCreateDto(),
+            payments: [{ amount: 600000, method: 'CASH', date: '2026-08-15' }],
+          },
+          userId,
+          orgId,
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('rejects a category that does not belong to the organization with 404', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.create(buildValidCreateDto(), userId, orgId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects a supplier that does not belong to the organization with 404', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue({ id: 'cat-1' });
+      prismaMock.supplier.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.create(buildValidCreateDto(), userId, orgId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects a purchase order that does not belong to the organization with 404', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue({ id: 'cat-1' });
+      prismaMock.supplier.findFirst.mockResolvedValue({ id: 'sup-1' });
+      prismaMock.purchaseOrder.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.create(buildValidCreateDto(), userId, orgId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BadRequestException when organizationId is missing', async () => {
+      await expect(
+        service.create(buildValidCreateDto(), userId, undefined),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('paginates active org-scoped expenses with filters and related data', async () => {
+      prismaMock.expense.findMany.mockResolvedValue([{ id: 'exp-1' }]);
+      prismaMock.expense.count.mockResolvedValue(42);
+
+      const result = await service.findAll(
+        {
+          page: 2,
+          limit: 10,
+          month: '2026-08',
+          categoryId: 'cat-1',
+          supplierId: 'sup-1',
+          status: 'PARTIAL',
+          search: 'arriendo',
+        },
+        orgId,
+      );
+
+      expect(prismaMock.expense.findMany).toHaveBeenCalledWith({
+        where: {
+          organizationId: orgId,
+          active: true,
+          date: {
+            gte: new Date('2026-08-01T05:00:00.000Z'),
+            lte: new Date('2026-09-01T04:59:59.999Z'),
+          },
+          categoryId: 'cat-1',
+          supplierId: 'sup-1',
+          status: 'PARTIAL',
+          description: { contains: 'arriendo', mode: 'insensitive' },
+        },
+        skip: 10,
+        take: 10,
+        orderBy: { date: 'desc' },
+        include: { category: true, supplier: true, payments: true },
+      });
+      expect(prismaMock.expense.count).toHaveBeenCalledWith({
+        where: expect.objectContaining({ organizationId: orgId, active: true }),
+      });
+      expect(result).toEqual({
+        data: [{ id: 'exp-1' }],
+        meta: { total: 42, page: 2, limit: 10, totalPages: 5 },
+      });
+    });
+
+    it('throws BadRequestException when organizationId is missing', async () => {
+      await expect(service.findAll({}, undefined)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('returns the org-scoped expense with payments, category and supplier', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue({
+        id: 'exp-1',
+        organizationId: orgId,
+      });
+
+      const result = await service.findOne('exp-1', orgId);
+
+      expect(prismaMock.expense.findFirst).toHaveBeenCalledWith({
+        where: { id: 'exp-1', organizationId: orgId },
+        include: {
+          category: true,
+          supplier: true,
+          purchaseOrder: true,
+          payments: { orderBy: { date: 'asc' } },
+        },
+      });
+      expect(result).toEqual({ id: 'exp-1', organizationId: orgId });
+    });
+
+    it('throws NotFoundException for unknown or cross-org ids', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(null);
+
+      await expect(service.findOne('exp-x', orgId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    const buildExisting = () => ({
+      id: 'exp-1',
+      organizationId: orgId,
+      total: new Prisma.Decimal(500000),
+      status: 'PAID',
+      description: 'Arriendo agosto',
+      date: new Date('2026-08-15T00:00:00.000Z'),
+      payments: [{ id: 'pay-1', amount: new Prisma.Decimal(500000) }],
+    });
+
+    it('recomputes status to PARTIAL when the total grows beyond payments', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(buildExisting());
+      txMock.expense.update.mockResolvedValue({
+        id: 'exp-1',
+        status: 'PARTIAL',
+        total: new Prisma.Decimal(800000),
+        description: 'Arriendo agosto',
+        date: new Date('2026-08-15T00:00:00.000Z'),
+      });
+
+      const result = await service.update(
+        'exp-1',
+        { total: 800000 },
+        userId,
+        orgId,
+      );
+
+      expect(txMock.expense.update).toHaveBeenCalledWith({
+        where: { id: 'exp-1' },
+        data: expect.objectContaining({ status: 'PARTIAL' }),
+        include: { category: true, supplier: true, payments: true },
+      });
+      expect(txMock.auditLog.create).toHaveBeenCalledTimes(1);
+      expect(txMock.auditLog.create.mock.calls[0][0].data).toMatchObject({
+        userId,
+        action: 'EXPENSE_UPDATED',
+        resource: 'Expense',
+        resourceId: 'exp-1',
+        organizationId: orgId,
+      });
+      expect(result).toEqual({
+        id: 'exp-1',
+        status: 'PARTIAL',
+        total: new Prisma.Decimal(800000),
+        description: 'Arriendo agosto',
+        date: new Date('2026-08-15T00:00:00.000Z'),
+      });
+    });
+
+    it('keeps PAID when the total shrinks to the payments sum', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(buildExisting());
+      txMock.expense.update.mockResolvedValue({
+        id: 'exp-1',
+        status: 'PAID',
+        total: new Prisma.Decimal(500000),
+        description: 'Arriendo agosto',
+        date: new Date('2026-08-15T00:00:00.000Z'),
+      });
+
+      const result = await service.update(
+        'exp-1',
+        { total: 500000 },
+        userId,
+        orgId,
+      );
+
+      expect(txMock.expense.update.mock.calls[0][0].data.status).toBe('PAID');
+      expect(result.status).toBe('PAID');
+    });
+
+    it('rejects a new total below the payments sum with 400', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(buildExisting());
+
+      await expect(
+        service.update('exp-1', { total: 400000 }, userId, orgId),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('rejects a category that does not belong to the organization with 404', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(buildExisting());
+      prismaMock.expenseCategory.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.update('exp-1', { categoryId: 'cat-x' }, userId, orgId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException for unknown or cross-org ids', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.update('exp-x', { description: 'Nuevo' }, userId, orgId),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('remove', () => {
+    it('soft-deletes with active=false and writes an audit log in the same transaction', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue({
+        id: 'exp-1',
+        organizationId: orgId,
+        total: new Prisma.Decimal(500000),
+      });
+      txMock.expense.update.mockResolvedValue({ id: 'exp-1', active: false });
+
+      const result = await service.remove('exp-1', userId, orgId);
+
+      expect(txMock.expense.update).toHaveBeenCalledWith({
+        where: { id: 'exp-1' },
+        data: { active: false },
+      });
+      expect(txMock.auditLog.create).toHaveBeenCalledTimes(1);
+      expect(txMock.auditLog.create.mock.calls[0][0].data).toMatchObject({
+        userId,
+        action: 'EXPENSE_DELETED',
+        resource: 'Expense',
+        resourceId: 'exp-1',
+        organizationId: orgId,
+      });
+      expect(result).toEqual({ id: 'exp-1', active: false });
+    });
+
+    it('throws NotFoundException for unknown or cross-org ids', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(null);
+
+      await expect(service.remove('exp-x', userId, orgId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/backend/src/expenses/expenses.service.ts
+++ b/backend/src/expenses/expenses.service.ts
@@ -1,0 +1,378 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { ExpensePaymentStatus, Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateExpenseDto } from './dto/create-expense.dto';
+import { QueryExpensesDto } from './dto/query-expenses.dto';
+import { UpdateExpenseDto } from './dto/update-expense.dto';
+
+const MONTH_REGEX = /^\d{4}-\d{2}$/;
+const BOGOTA_OFFSET_UTC_HOURS = 5;
+
+export function deriveExpensePaymentStatus(
+  total: Prisma.Decimal,
+  paymentsSum: Prisma.Decimal,
+): ExpensePaymentStatus {
+  return paymentsSum.gte(total) ? 'PAID' : 'PARTIAL';
+}
+
+export function buildMonthRange(month: string): {
+  start: Date;
+  end: Date;
+} {
+  if (!MONTH_REGEX.test(month)) {
+    throw new BadRequestException('El formato del mes debe ser YYYY-MM');
+  }
+
+  const [year, monthIndex] = month.split('-').map(Number);
+  const start = new Date(
+    Date.UTC(year, monthIndex - 1, 1, BOGOTA_OFFSET_UTC_HOURS, 0, 0, 0),
+  );
+  const end = new Date(
+    Date.UTC(year, monthIndex, 1, BOGOTA_OFFSET_UTC_HOURS, 0, 0, 0) - 1,
+  );
+
+  return { start, end };
+}
+
+@Injectable()
+export class ExpensesService {
+  constructor(private prisma: PrismaService) {}
+
+  private requireOrganizationId(organizationId: string | undefined): string {
+    if (!organizationId) {
+      throw new BadRequestException(
+        'Organization ID is required for this operation',
+      );
+    }
+    return organizationId;
+  }
+
+  private async assertCategoryInOrganization(
+    categoryId: string,
+    organizationId: string,
+  ): Promise<void> {
+    const category = await this.prisma.expenseCategory.findFirst({
+      where: { id: categoryId, organizationId },
+    });
+    if (!category) {
+      throw new NotFoundException('Categoría de salidas no encontrada');
+    }
+  }
+
+  private async assertSupplierInOrganization(
+    supplierId: string,
+    organizationId: string,
+  ): Promise<void> {
+    const supplier = await this.prisma.supplier.findFirst({
+      where: { id: supplierId, organizationId },
+    });
+    if (!supplier) {
+      throw new NotFoundException('Proveedor no encontrado');
+    }
+  }
+
+  private async assertPurchaseOrderInOrganization(
+    purchaseOrderId: string,
+    organizationId: string,
+  ): Promise<void> {
+    const purchaseOrder = await this.prisma.purchaseOrder.findFirst({
+      where: { id: purchaseOrderId, organizationId },
+    });
+    if (!purchaseOrder) {
+      throw new NotFoundException('Orden de compra no encontrada');
+    }
+  }
+
+  private sumPayments(payments: { amount: Prisma.Decimal }[]): Prisma.Decimal {
+    return payments.reduce(
+      (sum, payment) => sum.add(payment.amount),
+      new Prisma.Decimal(0),
+    );
+  }
+
+  async create(
+    dto: CreateExpenseDto,
+    userId: string,
+    organizationId: string | undefined,
+  ) {
+    const orgId = this.requireOrganizationId(organizationId);
+
+    await this.assertCategoryInOrganization(dto.categoryId, orgId);
+    if (dto.supplierId) {
+      await this.assertSupplierInOrganization(dto.supplierId, orgId);
+    }
+    if (dto.purchaseOrderId) {
+      await this.assertPurchaseOrderInOrganization(dto.purchaseOrderId, orgId);
+    }
+
+    if (dto.payments.length === 0) {
+      throw new BadRequestException(
+        'Cada salida debe registrarse con al menos un pago',
+      );
+    }
+
+    const total = new Prisma.Decimal(dto.total);
+    const paymentsSum = this.sumPayments(
+      dto.payments.map((payment) => ({
+        amount: new Prisma.Decimal(payment.amount),
+      })),
+    );
+
+    if (paymentsSum.gt(total)) {
+      throw new BadRequestException(
+        'La suma de los pagos no puede superar el total de la salida',
+      );
+    }
+
+    const status = deriveExpensePaymentStatus(total, paymentsSum);
+
+    return this.prisma.$transaction(async (tx) => {
+      const expense = await tx.expense.create({
+        data: {
+          organizationId: orgId,
+          categoryId: dto.categoryId,
+          supplierId: dto.supplierId ?? null,
+          purchaseOrderId: dto.purchaseOrderId ?? null,
+          description: dto.description ?? null,
+          date: new Date(dto.date),
+          total,
+          status,
+          createdById: userId,
+          payments: {
+            create: dto.payments.map((payment) => ({
+              organizationId: orgId,
+              amount: new Prisma.Decimal(payment.amount),
+              method: payment.method,
+              date: new Date(payment.date),
+            })),
+          },
+        },
+        include: { payments: true, category: true, supplier: true },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          userId,
+          action: 'EXPENSE_CREATED',
+          resource: 'Expense',
+          resourceId: expense.id,
+          organizationId: orgId,
+          metadata: {
+            summary: `Salida creada por ${total.toString()}`,
+            total: total.toString(),
+            status,
+            payments: dto.payments.map((payment) => ({
+              amount: new Prisma.Decimal(payment.amount).toString(),
+              method: payment.method,
+              date: payment.date,
+            })),
+            timestamp: new Date().toISOString(),
+          },
+        },
+      });
+
+      return expense;
+    });
+  }
+
+  async findAll(query: QueryExpensesDto, organizationId: string | undefined) {
+    const orgId = this.requireOrganizationId(organizationId);
+
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 10;
+    const skip = (page - 1) * limit;
+
+    const where: Prisma.ExpenseWhereInput = {
+      organizationId: orgId,
+      active: true,
+    };
+
+    if (query.month) {
+      const { start, end } = buildMonthRange(query.month);
+      where.date = { gte: start, lte: end };
+    }
+    if (query.categoryId) {
+      where.categoryId = query.categoryId;
+    }
+    if (query.supplierId) {
+      where.supplierId = query.supplierId;
+    }
+    if (query.status) {
+      where.status = query.status;
+    }
+
+    const search = query.search?.trim();
+    if (search) {
+      where.description = { contains: search, mode: 'insensitive' };
+    }
+
+    const [data, total] = await Promise.all([
+      this.prisma.expense.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: { date: 'desc' },
+        include: { category: true, supplier: true, payments: true },
+      }),
+      this.prisma.expense.count({ where }),
+    ]);
+
+    return {
+      data,
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  async findOne(id: string, organizationId: string | undefined) {
+    const orgId = this.requireOrganizationId(organizationId);
+
+    const expense = await this.prisma.expense.findFirst({
+      where: { id, organizationId: orgId },
+      include: {
+        category: true,
+        supplier: true,
+        purchaseOrder: true,
+        payments: { orderBy: { date: 'asc' } },
+      },
+    });
+
+    if (!expense) {
+      throw new NotFoundException('Salida no encontrada');
+    }
+
+    return expense;
+  }
+
+  async update(
+    id: string,
+    dto: UpdateExpenseDto,
+    userId: string,
+    organizationId: string | undefined,
+  ) {
+    const orgId = this.requireOrganizationId(organizationId);
+
+    const existing = await this.prisma.expense.findFirst({
+      where: { id, organizationId: orgId },
+      include: { payments: true },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Salida no encontrada');
+    }
+
+    if (dto.categoryId) {
+      await this.assertCategoryInOrganization(dto.categoryId, orgId);
+    }
+    if (dto.supplierId) {
+      await this.assertSupplierInOrganization(dto.supplierId, orgId);
+    }
+    if (dto.purchaseOrderId) {
+      await this.assertPurchaseOrderInOrganization(dto.purchaseOrderId, orgId);
+    }
+
+    const newTotal =
+      dto.total !== undefined ? new Prisma.Decimal(dto.total) : existing.total;
+    const paymentsSum = this.sumPayments(existing.payments);
+
+    if (newTotal.lt(paymentsSum)) {
+      throw new BadRequestException(
+        'El nuevo total no puede ser menor que la suma de los pagos registrados',
+      );
+    }
+
+    const status = deriveExpensePaymentStatus(newTotal, paymentsSum);
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.expense.update({
+        where: { id },
+        data: {
+          ...(dto.categoryId !== undefined && { categoryId: dto.categoryId }),
+          ...(dto.supplierId !== undefined && { supplierId: dto.supplierId }),
+          ...(dto.purchaseOrderId !== undefined && {
+            purchaseOrderId: dto.purchaseOrderId,
+          }),
+          ...(dto.description !== undefined && {
+            description: dto.description,
+          }),
+          ...(dto.date !== undefined && { date: new Date(dto.date) }),
+          ...(dto.total !== undefined && { total: newTotal }),
+          status,
+        },
+        include: { category: true, supplier: true, payments: true },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          userId,
+          action: 'EXPENSE_UPDATED',
+          resource: 'Expense',
+          resourceId: id,
+          organizationId: orgId,
+          metadata: {
+            summary: 'Salida actualizada',
+            before: {
+              total: existing.total.toString(),
+              status: existing.status,
+              description: existing.description,
+              date: existing.date.toISOString(),
+            },
+            after: {
+              total: updated.total.toString(),
+              status: updated.status,
+              description: updated.description,
+              date: updated.date.toISOString(),
+            },
+            timestamp: new Date().toISOString(),
+          },
+        },
+      });
+
+      return updated;
+    });
+  }
+
+  async remove(id: string, userId: string, organizationId: string | undefined) {
+    const orgId = this.requireOrganizationId(organizationId);
+
+    const existing = await this.prisma.expense.findFirst({
+      where: { id, organizationId: orgId },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Salida no encontrada');
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.expense.update({
+        where: { id },
+        data: { active: false },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          userId,
+          action: 'EXPENSE_DELETED',
+          resource: 'Expense',
+          resourceId: id,
+          organizationId: orgId,
+          metadata: {
+            summary: 'Salida eliminada (borrado lógico)',
+            total: existing.total.toString(),
+            timestamp: new Date().toISOString(),
+          },
+        },
+      });
+
+      return updated;
+    });
+  }
+}

--- a/backend/src/expenses/expenses.service.ts
+++ b/backend/src/expenses/expenses.service.ts
@@ -6,6 +6,7 @@ import {
 import { ExpensePaymentStatus, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateExpenseDto } from './dto/create-expense.dto';
+import { CreateExpensePaymentDto } from './dto/create-expense-payment.dto';
 import { QueryExpensesDto } from './dto/query-expenses.dto';
 import { UpdateExpenseDto } from './dto/update-expense.dto';
 
@@ -331,6 +332,80 @@ export class ExpensesService {
               description: updated.description,
               date: updated.date.toISOString(),
             },
+            timestamp: new Date().toISOString(),
+          },
+        },
+      });
+
+      return updated;
+    });
+  }
+
+  async addPayment(
+    id: string,
+    dto: CreateExpensePaymentDto,
+    userId: string,
+    organizationId: string | undefined,
+  ) {
+    const orgId = this.requireOrganizationId(organizationId);
+
+    const existing = await this.prisma.expense.findFirst({
+      where: { id, organizationId: orgId },
+      include: { payments: true },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Salida no encontrada');
+    }
+
+    if (!existing.active) {
+      throw new BadRequestException(
+        'No se pueden registrar pagos en una salida eliminada',
+      );
+    }
+
+    const amount = new Prisma.Decimal(dto.amount);
+    const paymentsSum = this.sumPayments(existing.payments).add(amount);
+
+    if (paymentsSum.gt(existing.total)) {
+      throw new BadRequestException(
+        'La suma de los pagos no puede superar el total de la salida',
+      );
+    }
+
+    const status = deriveExpensePaymentStatus(existing.total, paymentsSum);
+
+    return this.prisma.$transaction(async (tx) => {
+      await tx.expensePayment.create({
+        data: {
+          expenseId: id,
+          organizationId: orgId,
+          amount,
+          method: dto.method,
+          date: new Date(dto.date),
+        },
+      });
+
+      const updated = await tx.expense.update({
+        where: { id },
+        data: { status },
+        include: { category: true, supplier: true, payments: true },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          userId,
+          action: 'EXPENSE_PAYMENT_ADDED',
+          resource: 'Expense',
+          resourceId: id,
+          organizationId: orgId,
+          metadata: {
+            summary: `Pago de ${amount.toString()} registrado`,
+            amount: amount.toString(),
+            method: dto.method,
+            date: dto.date,
+            beforeStatus: existing.status,
+            afterStatus: status,
             timestamp: new Date().toISOString(),
           },
         },


### PR DESCRIPTION
Closes #10

## Chain Context

- Strategy: **Feature Branch Chain** (5 slices) — `chained-pr` contract
- Slice: **2 of 5 — expense CRUD + payments** 📍
- Base: `feat/expenses` (tracker, do not merge to main yet)
- Prior dependencies: slice 1 (data models + categories) — merged via #9
- Follow-up: slice 3 (aux endpoints + integration tests) → slice 4 (frontend hooks/gating) → slice 5 (frontend UI)
- Out of scope in this slice: monthly summary, export, frontend

```
master
  └─ feat/expenses (tracker)
       ├─ feat/expenses-unit-1 (merged via #9)
       └─ feat/expenses-unit-2 📍
```

## Summary

- Org-scoped **Expense CRUD** (create/list/get/update/soft-delete), ADMIN-only
- Create requires **≥1 inline payment** inside a single `$transaction` (business rule: an expense is never created without a payment)
- Derived **PARTIAL/PAID** status (`deriveExpensePaymentStatus`); overpayment rejected on create
- `POST /expenses/:id/payments`: additional payments with overpayment guard, status recompute, and audit log in one transaction
- Optional `supplierId` / `purchaseOrderId` links validated org-scoped; update allows clearing them (`null`)
- Audit log on every mutation; soft delete via `active`; paginated list with filters (month with Bogotá boundaries, category, supplier, status, search)
- Money via `Prisma.Decimal` (`Decimal(12,2)`), COP

## Changes

| File | Change |
|------|--------|
| `backend/src/expenses/expenses.service.ts` | Expense CRUD + payments logic, derived status, org-scoped validations |
| `backend/src/expenses/expenses.controller.ts` | Endpoints (ADMIN-only) |
| `backend/src/expenses/dto/create-expense.dto.ts` | Create DTO with inline payments validation |
| `backend/src/expenses/dto/update-expense.dto.ts` | Update DTO incl. nullable link clearing |
| `backend/src/expenses/dto/query-expenses.dto.ts` | Pagination/filter DTO |
| `backend/src/expenses/dto/create-expense-payment.dto.ts` | Payment DTO |
| `backend/src/expenses/expenses.module.ts` | Module wiring |
| `backend/src/expenses/*.spec.ts` | Unit tests (service + controller) |
| `backend/src/app.module.ts` | Register `ExpensesModule` |

## Test Plan

- [x] Backend suite **373/373** (36 suites); `npm run build` exit 0
- [x] RED→GREEN coverage: create with payment, overpayment rejection on create, add-payment happy path, overpayment rejection on add, partial→paid transition, org isolation, inactive-expense rejection, null-clearing of supplier/PO/description
- [x] Scoped ESLint 0 errors on new/changed files (repo-wide `npm run lint` intentionally not used — its `--fix` pollutes unrelated files)
- [ ] Integration tests against PostgreSQL: scheduled for slice 3

## Contributor Checklist

- [x] Issue linked (`Closes #10`)
- [x] Conventional commits, no `Co-Authored-By`
- [x] Tests kept with the work unit
- [x] N/A shellcheck (no shell scripts changed)
