### PR TITLE
feat(expenses): add monthly summary, duplicate, history, upload and export (3/5)

### DIFF
--- a/backend/src/common/utils/bogota-date.spec.ts
+++ b/backend/src/common/utils/bogota-date.spec.ts
@@ -1,0 +1,39 @@
+import { BadRequestException } from '@nestjs/common';
+import { parseBogotaMonthRange } from './bogota-date';
+
+describe('parseBogotaMonthRange', () => {
+  it('maps a YYYY-MM month to Bogota day boundaries', () => {
+    const { start, end } = parseBogotaMonthRange('2026-08');
+
+    expect(start.toISOString()).toBe('2026-08-01T05:00:00.000Z');
+    expect(end.toISOString()).toBe('2026-09-01T04:59:59.999Z');
+  });
+
+  it('handles the December to January year rollover', () => {
+    const { start, end } = parseBogotaMonthRange('2026-12');
+
+    expect(start.toISOString()).toBe('2026-12-01T05:00:00.000Z');
+    expect(end.toISOString()).toBe('2027-01-01T04:59:59.999Z');
+  });
+
+  it('treats 2026-08-01T05:00Z (midnight in Bogota) as the month start boundary', () => {
+    const { start, end } = parseBogotaMonthRange('2026-08');
+
+    expect(new Date('2026-08-01T05:00:00.000Z').getTime()).toBe(
+      start.getTime(),
+    );
+    expect(new Date('2026-08-01T04:59:59.999Z').getTime()).toBeLessThan(
+      start.getTime(),
+    );
+    expect(new Date('2026-09-01T04:59:59.999Z').getTime()).toBe(end.getTime());
+  });
+
+  it('rejects malformed month strings', () => {
+    expect(() => parseBogotaMonthRange('2026-8')).toThrow(BadRequestException);
+    expect(() => parseBogotaMonthRange('nope')).toThrow(BadRequestException);
+    expect(() => parseBogotaMonthRange('')).toThrow(BadRequestException);
+    expect(() => parseBogotaMonthRange(undefined as never)).toThrow(
+      BadRequestException,
+    );
+  });
+});

--- a/backend/src/common/utils/bogota-date.ts
+++ b/backend/src/common/utils/bogota-date.ts
@@ -1,4 +1,7 @@
+import { BadRequestException } from '@nestjs/common';
+
 const DATE_ONLY_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+const MONTH_ONLY_REGEX = /^\d{4}-\d{2}$/;
 const BOGOTA_OFFSET_UTC_HOURS = 5;
 
 const bogotaDateFormatter = new Intl.DateTimeFormat('en-CA', {
@@ -67,4 +70,23 @@ export function formatDateInBogota(date: Date): string {
   }
 
   return `${year}-${month}-${day}`;
+}
+
+export function parseBogotaMonthRange(month: string): {
+  start: Date;
+  end: Date;
+} {
+  if (!MONTH_ONLY_REGEX.test(month ?? '')) {
+    throw new BadRequestException('El formato del mes debe ser YYYY-MM');
+  }
+
+  const [year, monthIndex] = month.split('-').map(Number);
+  const start = new Date(
+    Date.UTC(year, monthIndex - 1, 1, BOGOTA_OFFSET_UTC_HOURS, 0, 0, 0),
+  );
+  const end = new Date(
+    Date.UTC(year, monthIndex, 1, BOGOTA_OFFSET_UTC_HOURS, 0, 0, 0) - 1,
+  );
+
+  return { start, end };
 }

--- a/backend/src/expenses/dto/query-month.dto.ts
+++ b/backend/src/expenses/dto/query-month.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Matches } from 'class-validator';
+
+export class QueryMonthDto {
+  @ApiProperty({ example: '2026-08', pattern: '^\\d{4}-\\d{2}$' })
+  @Matches(/^\d{4}-\d{2}$/, {
+    message: 'El formato del mes debe ser YYYY-MM',
+  })
+  month: string;
+}

--- a/backend/src/expenses/expenses.controller.spec.ts
+++ b/backend/src/expenses/expenses.controller.spec.ts
@@ -14,6 +14,7 @@ describe('ExpensesController', () => {
     update: jest.fn(),
     remove: jest.fn(),
     addPayment: jest.fn(),
+    getMonthlySummary: jest.fn(),
   };
 
   const adminUser: RequestUser = {
@@ -46,6 +47,7 @@ describe('ExpensesController', () => {
     const handlers = [
       controller.create,
       controller.findAll,
+      controller.getMonthlySummary,
       controller.findOne,
       controller.update,
       controller.remove,
@@ -112,6 +114,26 @@ describe('ExpensesController', () => {
       'org-1',
     );
     expect(serviceMock.remove).toHaveBeenCalledWith('exp-1', 'user-1', 'org-1');
+  });
+
+  it('delegates getMonthlySummary with month and organizationId from the token only', async () => {
+    const controller = new ExpensesController(serviceMock as never);
+    const summary = {
+      month: '2026-08',
+      total: 0,
+      categories: [],
+    };
+
+    serviceMock.getMonthlySummary.mockResolvedValue(summary);
+
+    await expect(
+      controller.getMonthlySummary({ month: '2026-08' }, adminUser),
+    ).resolves.toEqual(summary);
+
+    expect(serviceMock.getMonthlySummary).toHaveBeenCalledWith(
+      '2026-08',
+      'org-1',
+    );
   });
 
   it('delegates addPayment with expense id, payment body, userId and organizationId from the token only', async () => {

--- a/backend/src/expenses/expenses.controller.spec.ts
+++ b/backend/src/expenses/expenses.controller.spec.ts
@@ -16,6 +16,7 @@ describe('ExpensesController', () => {
     addPayment: jest.fn(),
     getMonthlySummary: jest.fn(),
     duplicate: jest.fn(),
+    getHistory: jest.fn(),
   };
 
   const adminUser: RequestUser = {
@@ -54,6 +55,7 @@ describe('ExpensesController', () => {
       controller.remove,
       controller.addPayment,
       controller.duplicate,
+      controller.getHistory,
     ];
 
     for (const handler of handlers) {
@@ -153,6 +155,19 @@ describe('ExpensesController', () => {
       'user-1',
       'org-1',
     );
+  });
+
+  it('delegates getHistory with expense id and organizationId from the token only', async () => {
+    const controller = new ExpensesController(serviceMock as never);
+    const entries = [{ id: 'a-1', action: 'EXPENSE_CREATED' }];
+
+    serviceMock.getHistory.mockResolvedValue(entries);
+
+    await expect(controller.getHistory('exp-1', adminUser)).resolves.toEqual(
+      entries,
+    );
+
+    expect(serviceMock.getHistory).toHaveBeenCalledWith('exp-1', 'org-1');
   });
 
   it('delegates addPayment with expense id, payment body, userId and organizationId from the token only', async () => {

--- a/backend/src/expenses/expenses.controller.spec.ts
+++ b/backend/src/expenses/expenses.controller.spec.ts
@@ -15,6 +15,7 @@ describe('ExpensesController', () => {
     remove: jest.fn(),
     addPayment: jest.fn(),
     getMonthlySummary: jest.fn(),
+    duplicate: jest.fn(),
   };
 
   const adminUser: RequestUser = {
@@ -52,6 +53,7 @@ describe('ExpensesController', () => {
       controller.update,
       controller.remove,
       controller.addPayment,
+      controller.duplicate,
     ];
 
     for (const handler of handlers) {
@@ -132,6 +134,23 @@ describe('ExpensesController', () => {
 
     expect(serviceMock.getMonthlySummary).toHaveBeenCalledWith(
       '2026-08',
+      'org-1',
+    );
+  });
+
+  it('delegates duplicate with expense id, userId and organizationId from the token only', async () => {
+    const controller = new ExpensesController(serviceMock as never);
+    const duplicated = { id: 'exp-2', organizationId: 'org-1', status: 'PAID' };
+
+    serviceMock.duplicate.mockResolvedValue(duplicated);
+
+    await expect(controller.duplicate('exp-1', adminUser)).resolves.toEqual(
+      duplicated,
+    );
+
+    expect(serviceMock.duplicate).toHaveBeenCalledWith(
+      'exp-1',
+      'user-1',
       'org-1',
     );
   });

--- a/backend/src/expenses/expenses.controller.spec.ts
+++ b/backend/src/expenses/expenses.controller.spec.ts
@@ -17,6 +17,7 @@ describe('ExpensesController', () => {
     getMonthlySummary: jest.fn(),
     duplicate: jest.fn(),
     getHistory: jest.fn(),
+    uploadReceipt: jest.fn(),
   };
 
   const adminUser: RequestUser = {
@@ -56,6 +57,7 @@ describe('ExpensesController', () => {
       controller.addPayment,
       controller.duplicate,
       controller.getHistory,
+      controller.uploadReceipt,
     ];
 
     for (const handler of handlers) {
@@ -168,6 +170,28 @@ describe('ExpensesController', () => {
     );
 
     expect(serviceMock.getHistory).toHaveBeenCalledWith('exp-1', 'org-1');
+  });
+
+  it('delegates uploadReceipt with expense id, file, userId and organizationId from the token only', async () => {
+    const controller = new ExpensesController(serviceMock as never);
+    const file = {
+      buffer: Buffer.from('fake'),
+      originalname: 'receipt.jpg',
+    } as unknown as Express.Multer.File;
+    const updated = { id: 'exp-1', receiptUrl: 'https://cloud.example/r1.jpg' };
+
+    serviceMock.uploadReceipt.mockResolvedValue(updated);
+
+    await expect(
+      controller.uploadReceipt('exp-1', adminUser, file),
+    ).resolves.toEqual(updated);
+
+    expect(serviceMock.uploadReceipt).toHaveBeenCalledWith(
+      'exp-1',
+      file,
+      'user-1',
+      'org-1',
+    );
   });
 
   it('delegates addPayment with expense id, payment body, userId and organizationId from the token only', async () => {

--- a/backend/src/expenses/expenses.controller.ts
+++ b/backend/src/expenses/expenses.controller.ts
@@ -121,11 +121,7 @@ export class ExpensesController {
   @Roles(OrgRole.ADMIN)
   @ApiOperation({ summary: 'Duplicar una salida (recurrencia manual)' })
   duplicate(@Param('id') id: string, @CurrentUser() user: RequestUser) {
-    return this.expensesService.duplicate(
-      id,
-      user.userId,
-      user.organizationId,
-    );
+    return this.expensesService.duplicate(id, user.userId, user.organizationId);
   }
 
   @Post(':id/upload')

--- a/backend/src/expenses/expenses.controller.ts
+++ b/backend/src/expenses/expenses.controller.ts
@@ -100,6 +100,17 @@ export class ExpensesController {
     );
   }
 
+  @Post(':id/duplicate')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Duplicar una salida (recurrencia manual)' })
+  duplicate(@Param('id') id: string, @CurrentUser() user: RequestUser) {
+    return this.expensesService.duplicate(
+      id,
+      user.userId,
+      user.organizationId,
+    );
+  }
+
   @Delete(':id')
   @Roles(OrgRole.ADMIN)
   @ApiOperation({ summary: 'Desactivar una salida (borrado lógico)' })

--- a/backend/src/expenses/expenses.controller.ts
+++ b/backend/src/expenses/expenses.controller.ts
@@ -3,14 +3,24 @@ import {
   Controller,
   Delete,
   Get,
+  HttpStatus,
   Param,
+  ParseFilePipeBuilder,
   Patch,
   Post,
   Query,
+  UploadedFile,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { FileInterceptor } from '@nestjs/platform-express';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { OrgRole } from '@prisma/client';
 import { JwtAuthGuard } from '../auth/jwt.strategy';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
@@ -113,6 +123,43 @@ export class ExpensesController {
   duplicate(@Param('id') id: string, @CurrentUser() user: RequestUser) {
     return this.expensesService.duplicate(
       id,
+      user.userId,
+      user.organizationId,
+    );
+  }
+
+  @Post(':id/upload')
+  @Roles(OrgRole.ADMIN)
+  @UseInterceptors(FileInterceptor('image'))
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        image: {
+          type: 'string',
+          format: 'binary',
+        },
+      },
+    },
+  })
+  @ApiOperation({ summary: 'Adjuntar comprobante a una salida' })
+  uploadReceipt(
+    @Param('id') id: string,
+    @CurrentUser() user: RequestUser,
+    @UploadedFile(
+      new ParseFilePipeBuilder()
+        .addFileTypeValidator({ fileType: /(jpg|jpeg|png|gif|webp|pdf)$/ })
+        .addMaxSizeValidator({ maxSize: 5 * 1024 * 1024 })
+        .build({
+          errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+        }),
+    )
+    file: Express.Multer.File,
+  ) {
+    return this.expensesService.uploadReceipt(
+      id,
+      file,
       user.userId,
       user.organizationId,
     );

--- a/backend/src/expenses/expenses.controller.ts
+++ b/backend/src/expenses/expenses.controller.ts
@@ -68,6 +68,13 @@ export class ExpensesController {
     return this.expensesService.findOne(id, user.organizationId);
   }
 
+  @Get(':id/history')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Ver historial de cambios de una salida' })
+  getHistory(@Param('id') id: string, @CurrentUser() user: RequestUser) {
+    return this.expensesService.getHistory(id, user.organizationId);
+  }
+
   @Patch(':id')
   @Roles(OrgRole.ADMIN)
   @ApiOperation({ summary: 'Actualizar una salida' })

--- a/backend/src/expenses/expenses.controller.ts
+++ b/backend/src/expenses/expenses.controller.ts
@@ -22,6 +22,7 @@ import type { RequestUser } from '../common/interfaces/request-user.interface';
 import { CreateExpenseDto } from './dto/create-expense.dto';
 import { CreateExpensePaymentDto } from './dto/create-expense-payment.dto';
 import { QueryExpensesDto } from './dto/query-expenses.dto';
+import { QueryMonthDto } from './dto/query-month.dto';
 import { UpdateExpenseDto } from './dto/update-expense.dto';
 import { ExpensesService } from './expenses.service';
 
@@ -45,6 +46,19 @@ export class ExpensesController {
   @ApiOperation({ summary: 'Listar salidas de la organización' })
   findAll(@Query() query: QueryExpensesDto, @CurrentUser() user: RequestUser) {
     return this.expensesService.findAll(query, user.organizationId);
+  }
+
+  @Get('summary/monthly')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Resumen mensual de salidas por categoría' })
+  getMonthlySummary(
+    @Query() query: QueryMonthDto,
+    @CurrentUser() user: RequestUser,
+  ) {
+    return this.expensesService.getMonthlySummary(
+      query.month,
+      user.organizationId,
+    );
   }
 
   @Get(':id')

--- a/backend/src/expenses/expenses.module.ts
+++ b/backend/src/expenses/expenses.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
+import { CloudinaryModule } from '../cloudinary/cloudinary.module';
 import { OrganizationRequiredGuard } from '../common/guards/organization-required.guard';
 import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
 import { ExpensesController } from './expenses.controller';
 import { ExpensesService } from './expenses.service';
 
 @Module({
+  imports: [CloudinaryModule],
   controllers: [ExpensesController],
   providers: [
     ExpensesService,

--- a/backend/src/expenses/expenses.service.int.spec.ts
+++ b/backend/src/expenses/expenses.service.int.spec.ts
@@ -1,0 +1,301 @@
+import { PrismaClient, Prisma, PlanType } from '@prisma/client';
+import { formatDateInBogota } from '../common/utils/bogota-date';
+import { ExpensesService } from './expenses.service';
+
+const prisma = new PrismaClient();
+
+const cloudinaryServiceMock = {
+  uploadImage: jest.fn(),
+  deleteImage: jest.fn(),
+};
+
+describe('ExpensesService — Integration (Isolation + Payments + Summary)', () => {
+  let service: ExpensesService;
+  let orgAId: string;
+  let orgBId: string;
+  let userAId: string;
+  let userBId: string;
+  let catArriendoId: string;
+  let catCajaMenorId: string;
+  let catOrgBId: string;
+
+  const buildCreateDto = (
+    categoryId: string,
+    overrides: Partial<{
+      date: string | Date;
+      total: number;
+      payments: { amount: number; method: 'CASH' | 'CARD' | 'TRANSFER'; date: string }[];
+      description: string;
+    }> = {},
+  ) => ({
+    categoryId,
+    description: overrides.description ?? 'Gasto de integración',
+    date: (overrides.date ?? '2026-08-15') as string,
+    total: overrides.total ?? 500000,
+    payments: overrides.payments ?? [
+      { amount: overrides.total ?? 500000, method: 'CASH' as const, date: '2026-08-15' },
+    ],
+  });
+
+  beforeAll(async () => {
+    service = new ExpensesService(
+      prisma as never,
+      cloudinaryServiceMock as never,
+    );
+
+    const [orgA, orgB] = await Promise.all([
+      prisma.organization.create({
+        data: {
+          name: 'Expenses INT Org A',
+          slug: 'expenses-int-a-' + Date.now(),
+          plan: PlanType.BASIC,
+          active: true,
+        },
+      }),
+      prisma.organization.create({
+        data: {
+          name: 'Expenses INT Org B',
+          slug: 'expenses-int-b-' + Date.now(),
+          plan: PlanType.BASIC,
+          active: true,
+        },
+      }),
+    ]);
+    orgAId = orgA.id;
+    orgBId = orgB.id;
+
+    const [userA, userB] = await Promise.all([
+      prisma.user.create({
+        data: {
+          email: 'expenses-int-user-a@example.com',
+          password: 'hash',
+          name: 'Test User A',
+          tokenVersion: 0,
+        },
+      }),
+      prisma.user.create({
+        data: {
+          email: 'expenses-int-user-b@example.com',
+          password: 'hash',
+          name: 'Test User B',
+          tokenVersion: 0,
+        },
+      }),
+    ]);
+    userAId = userA.id;
+    userBId = userB.id;
+
+    const [catArriendo, catCajaMenor, catOrgB] = await Promise.all([
+      prisma.expenseCategory.create({
+        data: { name: 'Arriendo INT', organizationId: orgAId },
+      }),
+      prisma.expenseCategory.create({
+        data: { name: 'Caja menor INT', organizationId: orgAId },
+      }),
+      prisma.expenseCategory.create({
+        data: { name: 'Categoría org B', organizationId: orgBId },
+      }),
+    ]);
+    catArriendoId = catArriendo.id;
+    catCajaMenorId = catCajaMenor.id;
+    catOrgBId = catOrgB.id;
+  });
+
+  afterAll(async () => {
+    await prisma.expensePayment.deleteMany({
+      where: { organizationId: { in: [orgAId, orgBId] } },
+    });
+    await prisma.auditLog.deleteMany({
+      where: { organizationId: { in: [orgAId, orgBId] } },
+    });
+    await prisma.expense.deleteMany({
+      where: { organizationId: { in: [orgAId, orgBId] } },
+    });
+    await prisma.expenseCategory.deleteMany({
+      where: { organizationId: { in: [orgAId, orgBId] } },
+    });
+    await prisma.user.deleteMany({
+      where: { id: { in: [userAId, userBId] } },
+    });
+    await prisma.organization.deleteMany({
+      where: { id: { in: [orgAId, orgBId] } },
+    });
+    await prisma.$disconnect();
+  });
+
+  it('isolates organizations: cross-org reads 404 and lists never leak', async () => {
+    const created = await service.create(
+      buildCreateDto(catArriendoId),
+      userAId,
+      orgAId,
+    );
+
+    await expect(service.findOne(created.id, orgBId)).rejects.toThrow(
+      'Salida no encontrada',
+    );
+    await expect(service.getHistory(created.id, orgBId)).rejects.toThrow(
+      'Salida no encontrada',
+    );
+    await expect(
+      service.duplicate(created.id, userBId, orgBId),
+    ).rejects.toThrow('Salida no encontrada');
+
+    const listB = await service.findAll({}, orgBId);
+    expect(listB.data).toHaveLength(0);
+    expect(listB.meta.total).toBe(0);
+
+    const summaryB = await service.getMonthlySummary('2026-08', orgBId);
+    expect(summaryB.total.toString()).toBe('0');
+  });
+
+  it('supports the partial to paid payment flow and rejects overpayment', async () => {
+    const created = await service.create(
+      buildCreateDto(catArriendoId, {
+        total: 500000,
+        payments: [{ amount: 200000, method: 'TRANSFER', date: '2026-08-15' }],
+      }),
+      userAId,
+      orgAId,
+    );
+    expect(created.status).toBe('PARTIAL');
+
+    const paid = await service.addPayment(
+      created.id,
+      { amount: 300000, method: 'CASH', date: '2026-08-16' },
+      userAId,
+      orgAId,
+    );
+    expect(paid.status).toBe('PAID');
+
+    await expect(
+      service.addPayment(
+        created.id,
+        { amount: 1, method: 'CASH', date: '2026-08-17' },
+        userAId,
+        orgAId,
+      ),
+    ).rejects.toThrow(
+      'La suma de los pagos no puede superar el total de la salida',
+    );
+
+    const history = await service.getHistory(created.id, orgAId);
+    expect(history.map((entry) => entry.action)).toEqual([
+      'EXPENSE_CREATED',
+      'EXPENSE_PAYMENT_ADDED',
+    ]);
+  });
+
+  it('summarizes the Bogota month per category, honoring month boundaries and org scope', async () => {
+    await service.create(
+      buildCreateDto(catArriendoId, {
+        description: 'Arriendo junio',
+        date: '2026-06-15',
+        total: 500000,
+        payments: [{ amount: 500000, method: 'CASH', date: '2026-06-15' }],
+      }),
+      userAId,
+      orgAId,
+    );
+    await service.create(
+      buildCreateDto(catArriendoId, {
+        description: 'Inicio de mes (00:00 Bogota)',
+        date: new Date('2026-06-01T05:00:00.000Z'),
+        total: 200000,
+        payments: [
+          { amount: 200000, method: 'CASH', date: '2026-06-01T05:00:00.000Z' },
+        ],
+      }),
+      userAId,
+      orgAId,
+    );
+    await service.create(
+      buildCreateDto(catCajaMenorId, {
+        description: 'Caja menor junio',
+        date: '2026-06-20',
+        total: 300000,
+        payments: [{ amount: 300000, method: 'CASH', date: '2026-06-20' }],
+      }),
+      userAId,
+      orgAId,
+    );
+    await service.create(
+      buildCreateDto(catArriendoId, {
+        description: 'Mayo 31 23:59 Bogota — fuera del mes',
+        date: new Date('2026-06-01T04:59:59.000Z'),
+        total: 999999,
+        payments: [
+          {
+            amount: 999999,
+            method: 'CASH',
+            date: '2026-06-01T04:59:59.000Z',
+          },
+        ],
+      }),
+      userAId,
+      orgAId,
+    );
+    await service.create(
+      buildCreateDto(catOrgBId, {
+        description: 'Gasto de la organización B',
+        date: '2026-06-18',
+        total: 777777,
+        payments: [{ amount: 777777, method: 'CASH', date: '2026-06-18' }],
+      }),
+      userBId,
+      orgBId,
+    );
+
+    const summary = await service.getMonthlySummary('2026-06', orgAId);
+
+    expect(summary.month).toBe('2026-06');
+    expect(summary.total.toString()).toBe('1000000');
+    expect(
+      summary.categories.map((row) => ({
+        categoryId: row.categoryId,
+        name: row.name,
+        total: row.total.toString(),
+      })),
+    ).toEqual([
+      { categoryId: catArriendoId, name: 'Arriendo INT', total: '700000' },
+      { categoryId: catCajaMenorId, name: 'Caja menor INT', total: '300000' },
+    ]);
+  });
+
+  it('duplicates an expense with today Bogota date, copied payments and derived status', async () => {
+    const created = await service.create(
+      buildCreateDto(catArriendoId, {
+        description: 'Original a duplicar',
+        date: '2026-08-10',
+        total: 500000,
+        payments: [
+          { amount: 300000, method: 'CASH', date: '2026-08-10' },
+          { amount: 200000, method: 'TRANSFER', date: '2026-08-11' },
+        ],
+      }),
+      userAId,
+      orgAId,
+    );
+    expect(created.status).toBe('PAID');
+
+    const duplicated = await service.duplicate(created.id, userAId, orgAId);
+
+    expect(duplicated.id).not.toBe(created.id);
+    expect(duplicated.categoryId).toBe(catArriendoId);
+    expect(duplicated.description).toBe('Original a duplicar');
+    expect(duplicated.total.toString()).toBe('500000');
+    expect(duplicated.status).toBe('PAID');
+    expect(duplicated.date.toISOString()).toBe(
+      new Date(formatDateInBogota(new Date())).toISOString(),
+    );
+    expect(duplicated.payments).toHaveLength(2);
+    expect(duplicated.payments.map((payment) => payment.method)).toEqual([
+      'CASH',
+      'TRANSFER',
+    ]);
+
+    const history = await service.getHistory(duplicated.id, orgAId);
+    expect(history.map((entry) => entry.action)).toEqual([
+      'EXPENSE_DUPLICATED',
+    ]);
+  });
+});

--- a/backend/src/expenses/expenses.service.int.spec.ts
+++ b/backend/src/expenses/expenses.service.int.spec.ts
@@ -24,7 +24,11 @@ describe('ExpensesService — Integration (Isolation + Payments + Summary)', () 
     overrides: Partial<{
       date: string | Date;
       total: number;
-      payments: { amount: number; method: 'CASH' | 'CARD' | 'TRANSFER'; date: string }[];
+      payments: {
+        amount: number;
+        method: 'CASH' | 'CARD' | 'TRANSFER';
+        date: string;
+      }[];
       description: string;
     }> = {},
   ) => ({
@@ -33,7 +37,11 @@ describe('ExpensesService — Integration (Isolation + Payments + Summary)', () 
     date: (overrides.date ?? '2026-08-15') as string,
     total: overrides.total ?? 500000,
     payments: overrides.payments ?? [
-      { amount: overrides.total ?? 500000, method: 'CASH' as const, date: '2026-08-15' },
+      {
+        amount: overrides.total ?? 500000,
+        method: 'CASH' as const,
+        date: '2026-08-15',
+      },
     ],
   });
 

--- a/backend/src/expenses/expenses.service.spec.ts
+++ b/backend/src/expenses/expenses.service.spec.ts
@@ -29,9 +29,11 @@ describe('ExpensesService', () => {
       findFirst: jest.fn(),
       findMany: jest.fn(),
       count: jest.fn(),
+      groupBy: jest.fn(),
     },
     expenseCategory: {
       findFirst: jest.fn(),
+      findMany: jest.fn(),
     },
     supplier: {
       findFirst: jest.fn(),
@@ -557,6 +559,81 @@ describe('ExpensesService', () => {
     it('throws BadRequestException when organizationId is missing', async () => {
       await expect(
         service.addPayment('exp-1', buildPaymentDto(), userId, undefined),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('getMonthlySummary', () => {
+    it('returns the month total and per-category breakdown sorted by total desc', async () => {
+      prismaMock.expense.groupBy.mockResolvedValue([
+        { categoryId: 'cat-2', _sum: { total: new Prisma.Decimal(500000) } },
+        { categoryId: 'cat-1', _sum: { total: new Prisma.Decimal(1000000) } },
+      ]);
+      prismaMock.expenseCategory.findMany.mockResolvedValue([
+        { id: 'cat-1', name: 'Arriendo' },
+        { id: 'cat-2', name: 'Caja menor' },
+      ]);
+
+      const result = await service.getMonthlySummary('2026-08', orgId);
+
+      expect(prismaMock.expense.groupBy).toHaveBeenCalledWith({
+        by: ['categoryId'],
+        where: {
+          organizationId: orgId,
+          active: true,
+          date: {
+            gte: new Date('2026-08-01T05:00:00.000Z'),
+            lte: new Date('2026-09-01T04:59:59.999Z'),
+          },
+        },
+        _sum: { total: true },
+      });
+      expect(prismaMock.expenseCategory.findMany).toHaveBeenCalledWith({
+        where: { id: { in: ['cat-2', 'cat-1'] } },
+        select: { id: true, name: true },
+      });
+      expect(result).toEqual({
+        month: '2026-08',
+        total: new Prisma.Decimal(1500000),
+        categories: [
+          {
+            categoryId: 'cat-1',
+            name: 'Arriendo',
+            total: new Prisma.Decimal(1000000),
+          },
+          {
+            categoryId: 'cat-2',
+            name: 'Caja menor',
+            total: new Prisma.Decimal(500000),
+          },
+        ],
+      });
+    });
+
+    it('returns zeros for a month without expenses', async () => {
+      prismaMock.expense.groupBy.mockResolvedValue([]);
+      prismaMock.expenseCategory.findMany.mockResolvedValue([]);
+
+      const result = await service.getMonthlySummary('2026-08', orgId);
+
+      expect(result).toEqual({
+        month: '2026-08',
+        total: new Prisma.Decimal(0),
+        categories: [],
+      });
+    });
+
+    it('rejects malformed month strings with 400', async () => {
+      await expect(
+        service.getMonthlySummary('2026-8', orgId),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(prismaMock.expense.groupBy).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when organizationId is missing', async () => {
+      await expect(
+        service.getMonthlySummary('2026-08', undefined),
       ).rejects.toThrow(BadRequestException);
     });
   });

--- a/backend/src/expenses/expenses.service.spec.ts
+++ b/backend/src/expenses/expenses.service.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
+import { formatDateInBogota } from '../common/utils/bogota-date';
 import {
   ExpensesService,
   deriveExpensePaymentStatus,
@@ -634,6 +635,124 @@ describe('ExpensesService', () => {
     it('throws BadRequestException when organizationId is missing', async () => {
       await expect(
         service.getMonthlySummary('2026-08', undefined),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('duplicate', () => {
+    const buildExisting = () => ({
+      id: 'exp-1',
+      organizationId: orgId,
+      active: true,
+      categoryId: 'cat-1',
+      supplierId: 'sup-1',
+      purchaseOrderId: 'po-1',
+      description: 'Arriendo agosto',
+      total: new Prisma.Decimal(500000),
+      status: 'PARTIAL',
+      payments: [
+        {
+          id: 'pay-1',
+          amount: new Prisma.Decimal(300000),
+          method: 'CASH',
+          date: new Date('2026-08-05T00:00:00.000Z'),
+        },
+        {
+          id: 'pay-2',
+          amount: new Prisma.Decimal(200000),
+          method: 'TRANSFER',
+          date: new Date('2026-08-10T00:00:00.000Z'),
+        },
+      ],
+    });
+
+    it('copies fields and payments into a new expense dated today in Bogota inside one transaction', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(buildExisting());
+      txMock.expense.create.mockResolvedValue({
+        id: 'exp-2',
+        status: 'PAID',
+      });
+
+      const result = await service.duplicate('exp-1', userId, orgId);
+
+      expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+      const createArgs = txMock.expense.create.mock.calls[0][0];
+      expect(createArgs.data).toMatchObject({
+        organizationId: orgId,
+        categoryId: 'cat-1',
+        supplierId: 'sup-1',
+        purchaseOrderId: 'po-1',
+        description: 'Arriendo agosto',
+        total: new Prisma.Decimal(500000),
+        status: 'PAID',
+        createdById: userId,
+        date: new Date(formatDateInBogota(new Date())),
+      });
+      expect(createArgs.data.payments.create).toEqual([
+        {
+          organizationId: orgId,
+          amount: new Prisma.Decimal(300000),
+          method: 'CASH',
+          date: new Date('2026-08-05T00:00:00.000Z'),
+        },
+        {
+          organizationId: orgId,
+          amount: new Prisma.Decimal(200000),
+          method: 'TRANSFER',
+          date: new Date('2026-08-10T00:00:00.000Z'),
+        },
+      ]);
+      expect(txMock.auditLog.create).toHaveBeenCalledTimes(1);
+      expect(txMock.auditLog.create.mock.calls[0][0].data).toMatchObject({
+        userId,
+        action: 'EXPENSE_DUPLICATED',
+        resource: 'Expense',
+        resourceId: 'exp-2',
+        organizationId: orgId,
+      });
+      expect(txMock.auditLog.create.mock.calls[0][0].data.metadata).toEqual(
+        expect.objectContaining({ originalId: 'exp-1' }),
+      );
+      expect(result).toEqual({ id: 'exp-2', status: 'PAID' });
+    });
+
+    it('derives the status from the copied payments sum', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(buildExisting());
+      txMock.expense.create.mockResolvedValue({
+        id: 'exp-2',
+        status: 'PAID',
+      });
+
+      const result = await service.duplicate('exp-1', userId, orgId);
+
+      expect(txMock.expense.create.mock.calls[0][0].data.status).toBe('PAID');
+      expect(result.status).toBe('PAID');
+    });
+
+    it('rejects duplicating an inactive expense with 400 and never opens a transaction', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue({
+        ...buildExisting(),
+        active: false,
+      });
+
+      await expect(service.duplicate('exp-1', userId, orgId)).rejects.toThrow(
+        'No se puede duplicar una salida eliminada',
+      );
+
+      expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException for unknown or cross-org ids', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(null);
+
+      await expect(service.duplicate('exp-x', userId, orgId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws BadRequestException when organizationId is missing', async () => {
+      await expect(
+        service.duplicate('exp-1', userId, undefined),
       ).rejects.toThrow(BadRequestException);
     });
   });

--- a/backend/src/expenses/expenses.service.spec.ts
+++ b/backend/src/expenses/expenses.service.spec.ts
@@ -42,6 +42,9 @@ describe('ExpensesService', () => {
     purchaseOrder: {
       findFirst: jest.fn(),
     },
+    auditLog: {
+      findMany: jest.fn(),
+    },
   };
 
   const buildValidCreateDto = () => ({
@@ -754,6 +757,52 @@ describe('ExpensesService', () => {
       await expect(
         service.duplicate('exp-1', userId, undefined),
       ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('getHistory', () => {
+    it('returns the org-scoped audit entries for the expense ordered ascending', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue({ id: 'exp-1' });
+      prismaMock.auditLog.findMany.mockResolvedValue([
+        { id: 'a-1', action: 'EXPENSE_CREATED' },
+        { id: 'a-2', action: 'EXPENSE_UPDATED' },
+      ]);
+
+      const result = await service.getHistory('exp-1', orgId);
+
+      expect(prismaMock.expense.findFirst).toHaveBeenCalledWith({
+        where: { id: 'exp-1', organizationId: orgId },
+        select: { id: true },
+      });
+      expect(prismaMock.auditLog.findMany).toHaveBeenCalledWith({
+        where: {
+          resource: 'Expense',
+          resourceId: 'exp-1',
+          organizationId: orgId,
+        },
+        orderBy: { createdAt: 'asc' },
+        include: { user: { select: { name: true, email: true } } },
+      });
+      expect(result).toEqual([
+        { id: 'a-1', action: 'EXPENSE_CREATED' },
+        { id: 'a-2', action: 'EXPENSE_UPDATED' },
+      ]);
+    });
+
+    it('throws NotFoundException for unknown or cross-org expense ids without reading the audit log', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(null);
+
+      await expect(service.getHistory('exp-x', orgId)).rejects.toThrow(
+        NotFoundException,
+      );
+
+      expect(prismaMock.auditLog.findMany).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when organizationId is missing', async () => {
+      await expect(service.getHistory('exp-1', undefined)).rejects.toThrow(
+        BadRequestException,
+      );
     });
   });
 

--- a/backend/src/expenses/expenses.service.spec.ts
+++ b/backend/src/expenses/expenses.service.spec.ts
@@ -643,9 +643,9 @@ describe('ExpensesService', () => {
     });
 
     it('rejects malformed month strings with 400', async () => {
-      await expect(
-        service.getMonthlySummary('2026-8', orgId),
-      ).rejects.toThrow(BadRequestException);
+      await expect(service.getMonthlySummary('2026-8', orgId)).rejects.toThrow(
+        BadRequestException,
+      );
 
       expect(prismaMock.expense.groupBy).not.toHaveBeenCalled();
     });

--- a/backend/src/expenses/expenses.service.spec.ts
+++ b/backend/src/expenses/expenses.service.spec.ts
@@ -57,12 +57,27 @@ describe('ExpensesService', () => {
     payments: [{ amount: 500000, method: 'CASH', date: '2026-08-15' }],
   });
 
+  const cloudinaryServiceMock = {
+    uploadImage: jest.fn(),
+    deleteImage: jest.fn(),
+  };
+
+  const buildReceiptFile = (): Express.Multer.File =>
+    ({
+      buffer: Buffer.from('fake-receipt'),
+      originalname: 'receipt.jpg',
+      mimetype: 'image/jpeg',
+    }) as unknown as Express.Multer.File;
+
   beforeEach(() => {
     jest.clearAllMocks();
     prismaMock.$transaction.mockImplementation(
       async (callback: (tx: typeof txMock) => unknown) => callback(txMock),
     );
-    service = new ExpensesService(prismaMock as never);
+    service = new ExpensesService(
+      prismaMock as never,
+      cloudinaryServiceMock as never,
+    );
   });
 
   describe('deriveExpensePaymentStatus', () => {
@@ -803,6 +818,128 @@ describe('ExpensesService', () => {
       await expect(service.getHistory('exp-1', undefined)).rejects.toThrow(
         BadRequestException,
       );
+    });
+  });
+
+  describe('uploadReceipt', () => {
+    it('uploads the file to the expense-receipts folder and persists the receipt URL with an audit entry in one transaction', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue({
+        id: 'exp-1',
+        createdById: userId,
+        receiptUrl: null,
+      });
+      cloudinaryServiceMock.uploadImage.mockResolvedValue(
+        'https://cloud.example/expense-receipts/r1.jpg',
+      );
+      txMock.expense.update.mockResolvedValue({
+        id: 'exp-1',
+        receiptUrl: 'https://cloud.example/expense-receipts/r1.jpg',
+      });
+
+      const result = await service.uploadReceipt(
+        'exp-1',
+        buildReceiptFile(),
+        userId,
+        orgId,
+      );
+
+      expect(cloudinaryServiceMock.uploadImage).toHaveBeenCalledWith(
+        buildReceiptFile(),
+        'expense-receipts',
+      );
+      expect(cloudinaryServiceMock.deleteImage).not.toHaveBeenCalled();
+      expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+      expect(txMock.expense.update).toHaveBeenCalledWith({
+        where: { id: 'exp-1' },
+        data: { receiptUrl: 'https://cloud.example/expense-receipts/r1.jpg' },
+        include: { category: true, supplier: true, payments: true },
+      });
+      expect(txMock.auditLog.create).toHaveBeenCalledTimes(1);
+      expect(txMock.auditLog.create.mock.calls[0][0].data).toMatchObject({
+        userId,
+        action: 'EXPENSE_RECEIPT_UPLOADED',
+        resource: 'Expense',
+        resourceId: 'exp-1',
+        organizationId: orgId,
+      });
+      expect(result).toEqual({
+        id: 'exp-1',
+        receiptUrl: 'https://cloud.example/expense-receipts/r1.jpg',
+      });
+    });
+
+    it('best-effort deletes the previous receipt when one exists', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue({
+        id: 'exp-1',
+        createdById: userId,
+        receiptUrl: 'https://cloud.example/expense-receipts/old.jpg',
+      });
+      cloudinaryServiceMock.uploadImage.mockResolvedValue(
+        'https://cloud.example/expense-receipts/new.jpg',
+      );
+      cloudinaryServiceMock.deleteImage.mockResolvedValue(undefined);
+      txMock.expense.update.mockResolvedValue({
+        id: 'exp-1',
+        receiptUrl: 'https://cloud.example/expense-receipts/new.jpg',
+      });
+
+      await service.uploadReceipt('exp-1', buildReceiptFile(), userId, orgId);
+
+      expect(cloudinaryServiceMock.deleteImage).toHaveBeenCalledWith(
+        'https://cloud.example/expense-receipts/old.jpg',
+      );
+    });
+
+    it('ignores a failed deletion of the previous receipt and still persists the new one', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue({
+        id: 'exp-1',
+        createdById: userId,
+        receiptUrl: 'https://cloud.example/expense-receipts/old.jpg',
+      });
+      cloudinaryServiceMock.uploadImage.mockResolvedValue(
+        'https://cloud.example/expense-receipts/new.jpg',
+      );
+      cloudinaryServiceMock.deleteImage.mockRejectedValue(
+        new Error('cloud unreachable'),
+      );
+      txMock.expense.update.mockResolvedValue({
+        id: 'exp-1',
+        receiptUrl: 'https://cloud.example/expense-receipts/new.jpg',
+      });
+
+      const result = await service.uploadReceipt(
+        'exp-1',
+        buildReceiptFile(),
+        userId,
+        orgId,
+      );
+
+      expect(txMock.expense.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: {
+            receiptUrl: 'https://cloud.example/expense-receipts/new.jpg',
+          },
+        }),
+      );
+      expect(result.receiptUrl).toBe(
+        'https://cloud.example/expense-receipts/new.jpg',
+      );
+    });
+
+    it('throws NotFoundException for unknown or cross-org expense ids without uploading', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.uploadReceipt('exp-x', buildReceiptFile(), userId, orgId),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(cloudinaryServiceMock.uploadImage).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when organizationId is missing', async () => {
+      await expect(
+        service.uploadReceipt('exp-1', buildReceiptFile(), userId, undefined),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/backend/src/expenses/expenses.service.spec.ts
+++ b/backend/src/expenses/expenses.service.spec.ts
@@ -2,7 +2,6 @@ import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import {
   ExpensesService,
-  buildMonthRange,
   deriveExpensePaymentStatus,
 } from './expenses.service';
 
@@ -86,20 +85,6 @@ describe('ExpensesService', () => {
           new Prisma.Decimal(500000.01),
         ),
       ).toBe('PAID');
-    });
-  });
-
-  describe('buildMonthRange', () => {
-    it('maps a YYYY-MM month to Bogota day boundaries', () => {
-      const { start, end } = buildMonthRange('2026-08');
-
-      expect(start.toISOString()).toBe('2026-08-01T05:00:00.000Z');
-      expect(end.toISOString()).toBe('2026-09-01T04:59:59.999Z');
-    });
-
-    it('rejects malformed month strings', () => {
-      expect(() => buildMonthRange('2026-8')).toThrow(BadRequestException);
-      expect(() => buildMonthRange('nope')).toThrow(BadRequestException);
     });
   });
 

--- a/backend/src/expenses/expenses.service.ts
+++ b/backend/src/expenses/expenses.service.ts
@@ -518,6 +518,25 @@ export class ExpensesService {
     });
   }
 
+  async getHistory(id: string, organizationId: string | undefined) {
+    const orgId = this.requireOrganizationId(organizationId);
+
+    const expense = await this.prisma.expense.findFirst({
+      where: { id, organizationId: orgId },
+      select: { id: true },
+    });
+
+    if (!expense) {
+      throw new NotFoundException('Salida no encontrada');
+    }
+
+    return this.prisma.auditLog.findMany({
+      where: { resource: 'Expense', resourceId: id, organizationId: orgId },
+      orderBy: { createdAt: 'asc' },
+      include: { user: { select: { name: true, email: true } } },
+    });
+  }
+
   async remove(id: string, userId: string, organizationId: string | undefined) {
     const orgId = this.requireOrganizationId(organizationId);
 

--- a/backend/src/expenses/expenses.service.ts
+++ b/backend/src/expenses/expenses.service.ts
@@ -212,6 +212,45 @@ export class ExpensesService {
     };
   }
 
+  async getMonthlySummary(month: string, organizationId: string | undefined) {
+    const orgId = this.requireOrganizationId(organizationId);
+    const { start, end } = parseBogotaMonthRange(month);
+
+    const grouped = await this.prisma.expense.groupBy({
+      by: ['categoryId'],
+      where: {
+        organizationId: orgId,
+        active: true,
+        date: { gte: start, lte: end },
+      },
+      _sum: { total: true },
+    });
+
+    const categories = await this.prisma.expenseCategory.findMany({
+      where: { id: { in: grouped.map((row) => row.categoryId) } },
+      select: { id: true, name: true },
+    });
+
+    const namesById = new Map(
+      categories.map((category) => [category.id, category.name]),
+    );
+
+    const rows = grouped
+      .map((row) => ({
+        categoryId: row.categoryId,
+        name: namesById.get(row.categoryId) ?? 'Sin categoría',
+        total: row._sum.total ?? new Prisma.Decimal(0),
+      }))
+      .sort((a, b) => b.total.comparedTo(a.total));
+
+    const total = rows.reduce(
+      (sum, row) => sum.add(row.total),
+      new Prisma.Decimal(0),
+    );
+
+    return { month, total, categories: rows };
+  }
+
   async findOne(id: string, organizationId: string | undefined) {
     const orgId = this.requireOrganizationId(organizationId);
 

--- a/backend/src/expenses/expenses.service.ts
+++ b/backend/src/expenses/expenses.service.ts
@@ -8,6 +8,7 @@ import {
   formatDateInBogota,
   parseBogotaMonthRange,
 } from '../common/utils/bogota-date';
+import { CloudinaryService } from '../cloudinary/cloudinary.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateExpenseDto } from './dto/create-expense.dto';
 import { CreateExpensePaymentDto } from './dto/create-expense-payment.dto';
@@ -23,7 +24,10 @@ export function deriveExpensePaymentStatus(
 
 @Injectable()
 export class ExpensesService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private cloudinaryService: CloudinaryService,
+  ) {}
 
   private requireOrganizationId(organizationId: string | undefined): string {
     if (!organizationId) {
@@ -534,6 +538,61 @@ export class ExpensesService {
       where: { resource: 'Expense', resourceId: id, organizationId: orgId },
       orderBy: { createdAt: 'asc' },
       include: { user: { select: { name: true, email: true } } },
+    });
+  }
+
+  async uploadReceipt(
+    id: string,
+    file: Express.Multer.File,
+    userId: string,
+    organizationId: string | undefined,
+  ) {
+    const orgId = this.requireOrganizationId(organizationId);
+
+    const existing = await this.prisma.expense.findFirst({
+      where: { id, organizationId: orgId },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Salida no encontrada');
+    }
+
+    const receiptUrl = await this.cloudinaryService.uploadImage(
+      file,
+      'expense-receipts',
+    );
+
+    if (existing.receiptUrl) {
+      try {
+        await this.cloudinaryService.deleteImage(existing.receiptUrl);
+      } catch (error) {
+        console.error('Error deleting old receipt:', error);
+      }
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.expense.update({
+        where: { id },
+        data: { receiptUrl },
+        include: { category: true, supplier: true, payments: true },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          userId,
+          action: 'EXPENSE_RECEIPT_UPLOADED',
+          resource: 'Expense',
+          resourceId: id,
+          organizationId: orgId,
+          metadata: {
+            summary: 'Comprobante adjuntado',
+            receiptUrl,
+            timestamp: new Date().toISOString(),
+          },
+        },
+      });
+
+      return updated;
     });
   }
 

--- a/backend/src/expenses/expenses.service.ts
+++ b/backend/src/expenses/expenses.service.ts
@@ -4,39 +4,18 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { ExpensePaymentStatus, Prisma } from '@prisma/client';
+import { parseBogotaMonthRange } from '../common/utils/bogota-date';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateExpenseDto } from './dto/create-expense.dto';
 import { CreateExpensePaymentDto } from './dto/create-expense-payment.dto';
 import { QueryExpensesDto } from './dto/query-expenses.dto';
 import { UpdateExpenseDto } from './dto/update-expense.dto';
 
-const MONTH_REGEX = /^\d{4}-\d{2}$/;
-const BOGOTA_OFFSET_UTC_HOURS = 5;
-
 export function deriveExpensePaymentStatus(
   total: Prisma.Decimal,
   paymentsSum: Prisma.Decimal,
 ): ExpensePaymentStatus {
   return paymentsSum.gte(total) ? 'PAID' : 'PARTIAL';
-}
-
-export function buildMonthRange(month: string): {
-  start: Date;
-  end: Date;
-} {
-  if (!MONTH_REGEX.test(month)) {
-    throw new BadRequestException('El formato del mes debe ser YYYY-MM');
-  }
-
-  const [year, monthIndex] = month.split('-').map(Number);
-  const start = new Date(
-    Date.UTC(year, monthIndex - 1, 1, BOGOTA_OFFSET_UTC_HOURS, 0, 0, 0),
-  );
-  const end = new Date(
-    Date.UTC(year, monthIndex, 1, BOGOTA_OFFSET_UTC_HOURS, 0, 0, 0) - 1,
-  );
-
-  return { start, end };
 }
 
 @Injectable()
@@ -193,7 +172,7 @@ export class ExpensesService {
     };
 
     if (query.month) {
-      const { start, end } = buildMonthRange(query.month);
+      const { start, end } = parseBogotaMonthRange(query.month);
       where.date = { gte: start, lte: end };
     }
     if (query.categoryId) {

--- a/backend/src/expenses/expenses.service.ts
+++ b/backend/src/expenses/expenses.service.ts
@@ -457,7 +457,9 @@ export class ExpensesService {
     }
 
     if (!existing.active) {
-      throw new BadRequestException('No se puede duplicar una salida eliminada');
+      throw new BadRequestException(
+        'No se puede duplicar una salida eliminada',
+      );
     }
 
     if (existing.payments.length === 0) {

--- a/backend/src/expenses/expenses.service.ts
+++ b/backend/src/expenses/expenses.service.ts
@@ -4,7 +4,10 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { ExpensePaymentStatus, Prisma } from '@prisma/client';
-import { parseBogotaMonthRange } from '../common/utils/bogota-date';
+import {
+  formatDateInBogota,
+  parseBogotaMonthRange,
+} from '../common/utils/bogota-date';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateExpenseDto } from './dto/create-expense.dto';
 import { CreateExpensePaymentDto } from './dto/create-expense-payment.dto';
@@ -430,6 +433,88 @@ export class ExpensesService {
       });
 
       return updated;
+    });
+  }
+
+  async duplicate(
+    id: string,
+    userId: string,
+    organizationId: string | undefined,
+  ) {
+    const orgId = this.requireOrganizationId(organizationId);
+
+    const existing = await this.prisma.expense.findFirst({
+      where: { id, organizationId: orgId },
+      include: { payments: true },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Salida no encontrada');
+    }
+
+    if (!existing.active) {
+      throw new BadRequestException('No se puede duplicar una salida eliminada');
+    }
+
+    if (existing.payments.length === 0) {
+      throw new BadRequestException(
+        'Cada salida debe registrarse con al menos un pago',
+      );
+    }
+
+    const paymentsSum = this.sumPayments(existing.payments);
+
+    if (paymentsSum.gt(existing.total)) {
+      throw new BadRequestException(
+        'La suma de los pagos no puede superar el total de la salida',
+      );
+    }
+
+    const status = deriveExpensePaymentStatus(existing.total, paymentsSum);
+    const today = new Date(formatDateInBogota(new Date()));
+
+    return this.prisma.$transaction(async (tx) => {
+      const duplicated = await tx.expense.create({
+        data: {
+          organizationId: orgId,
+          categoryId: existing.categoryId,
+          supplierId: existing.supplierId,
+          purchaseOrderId: existing.purchaseOrderId,
+          description: existing.description,
+          date: today,
+          total: existing.total,
+          status,
+          createdById: userId,
+          payments: {
+            create: existing.payments.map((payment) => ({
+              organizationId: orgId,
+              amount: payment.amount,
+              method: payment.method,
+              date: payment.date,
+            })),
+          },
+        },
+        include: { payments: true, category: true, supplier: true },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          userId,
+          action: 'EXPENSE_DUPLICATED',
+          resource: 'Expense',
+          resourceId: duplicated.id,
+          organizationId: orgId,
+          metadata: {
+            summary: 'Salida duplicada',
+            originalId: id,
+            total: existing.total.toString(),
+            status,
+            timestamp: new Date().toISOString(),
+          },
+        },
+      });
+
+      return duplicated;
     });
   }
 

--- a/backend/src/exports/dto/export.dto.ts
+++ b/backend/src/exports/dto/export.dto.ts
@@ -20,11 +20,11 @@ export class ExportQueryDto {
   format: ExportFormat;
 
   @ApiProperty({
-    enum: ['sales', 'products', 'customers', 'inventory'],
+    enum: ['sales', 'products', 'customers', 'inventory', 'expenses'],
     example: 'sales',
   })
-  @IsEnum(['sales', 'products', 'customers', 'inventory'])
-  type: 'sales' | 'products' | 'customers' | 'inventory';
+  @IsEnum(['sales', 'products', 'customers', 'inventory', 'expenses'])
+  type: 'sales' | 'products' | 'customers' | 'inventory' | 'expenses';
 
   @ApiPropertyOptional({ example: '2024-01-01' })
   @IsOptional()

--- a/backend/src/exports/exports.controller.spec.ts
+++ b/backend/src/exports/exports.controller.spec.ts
@@ -1,0 +1,51 @@
+import { type ExecutionContext } from '@nestjs/common';
+import { OrgRole } from '@prisma/client';
+import { ROLES_KEY } from '../common/decorators/roles.decorator';
+import type { RequestUser } from '../common/interfaces/request-user.interface';
+import { ExportsController } from './exports.controller';
+
+describe('ExportsController (expenses route)', () => {
+  const serviceMock = {
+    exportExpenses: jest.fn(),
+  };
+
+  const adminUser: RequestUser = {
+    userId: 'user-1',
+    email: 'admin@example.com',
+    organizationId: 'org-1',
+    role: OrgRole.ADMIN,
+    tokenVersion: 1,
+    isSuperAdmin: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('requires ADMIN on the expenses export handler', () => {
+    const controller = new ExportsController(serviceMock as never);
+
+    expect(Reflect.getMetadata(ROLES_KEY, controller.exportExpenses)).toEqual([
+      OrgRole.ADMIN,
+    ]);
+  });
+
+  it('delegates exportExpenses with organizationId from the token and the query body', async () => {
+    const controller = new ExportsController(serviceMock as never);
+    const res = {} as Response;
+
+    serviceMock.exportExpenses.mockResolvedValue(undefined);
+
+    await controller.exportExpenses(
+      adminUser,
+      { format: 'excel', type: 'expenses' },
+      res,
+    );
+
+    expect(serviceMock.exportExpenses).toHaveBeenCalledWith(
+      'org-1',
+      { format: 'excel', type: 'expenses' },
+      res,
+    );
+  });
+});

--- a/backend/src/exports/exports.controller.ts
+++ b/backend/src/exports/exports.controller.ts
@@ -101,4 +101,20 @@ export class ExportsController {
       res,
     );
   }
+
+  @Post('expenses')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Export expenses data' })
+  @ApiConsumes('application/json')
+  async exportExpenses(
+    @CurrentUser() user: RequestUser,
+    @Body() query: ExportQueryDto,
+    @Res() res: Response,
+  ) {
+    return this.exportsService.exportExpenses(
+      user.organizationId,
+      query,
+      res,
+    );
+  }
 }

--- a/backend/src/exports/exports.controller.ts
+++ b/backend/src/exports/exports.controller.ts
@@ -79,11 +79,7 @@ export class ExportsController {
     @Body() query: ExportQueryDto,
     @Res() res: Response,
   ) {
-    return this.exportsService.exportCustomers(
-      user.organizationId,
-      query,
-      res,
-    );
+    return this.exportsService.exportCustomers(user.organizationId, query, res);
   }
 
   @Post('inventory')
@@ -95,11 +91,7 @@ export class ExportsController {
     @Body() query: ExportQueryDto,
     @Res() res: Response,
   ) {
-    return this.exportsService.exportInventory(
-      user.organizationId,
-      query,
-      res,
-    );
+    return this.exportsService.exportInventory(user.organizationId, query, res);
   }
 
   @Post('expenses')
@@ -111,10 +103,6 @@ export class ExportsController {
     @Body() query: ExportQueryDto,
     @Res() res: Response,
   ) {
-    return this.exportsService.exportExpenses(
-      user.organizationId,
-      query,
-      res,
-    );
+    return this.exportsService.exportExpenses(user.organizationId, query, res);
   }
 }

--- a/backend/src/exports/exports.service.spec.ts
+++ b/backend/src/exports/exports.service.spec.ts
@@ -1,5 +1,11 @@
+import { Prisma } from '@prisma/client';
 import { ExportsService } from './exports.service';
 import { ExportQueryDto } from './dto/export.dto';
+import * as csv from '@fast-csv/format';
+
+jest.mock('@fast-csv/format', () => ({
+  write: jest.fn(() => ({ pipe: jest.fn() })),
+}));
 
 describe('ExportsService', () => {
   let service: ExportsService;
@@ -18,9 +24,21 @@ describe('ExportsService', () => {
     customer: {
       findMany: jest.fn(),
     },
+    expense: {
+      findMany: jest.fn(),
+    },
   };
 
   const ORG_ID = 'org-1';
+
+  const buildResMock = () => ({
+    setHeader: jest.fn(),
+    end: jest.fn(),
+    write: jest.fn(),
+    flushHeaders: jest.fn(),
+    pipe: jest.fn(),
+    send: jest.fn(),
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -144,6 +162,86 @@ describe('ExportsService', () => {
       expect.objectContaining({
         where: expect.objectContaining({ organizationId: ORG_ID }),
       }),
+    );
+  });
+
+  it('exportExpenses filters by organizationId, active and the expense date range', async () => {
+    prismaMock.expense.findMany.mockResolvedValue([]);
+    const expectedEnd = new Date('2026-08-31');
+    expectedEnd.setHours(23, 59, 59, 999);
+
+    await service.exportExpenses(
+      ORG_ID,
+      {
+        format: 'pdf',
+        type: 'expenses',
+        startDate: '2026-08-01',
+        endDate: '2026-08-31',
+      } as ExportQueryDto,
+      buildResMock(),
+    );
+
+    expect(prismaMock.expense.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          organizationId: ORG_ID,
+          active: true,
+          date: {
+            gte: new Date('2026-08-01'),
+            lte: expectedEnd,
+          },
+        },
+        orderBy: { date: 'desc' },
+        include: { category: { select: { name: true } } },
+      }),
+    );
+  });
+
+  it('exportExpenses writes CSV headers and rows with date, category, description, total and status', async () => {
+    const expenseDate = new Date('2026-08-15T00:00:00.000Z');
+    prismaMock.expense.findMany.mockResolvedValue([
+      {
+        date: expenseDate,
+        category: { name: 'Arriendo' },
+        description: 'Arriendo agosto',
+        total: new Prisma.Decimal(500000),
+        status: 'PAID',
+      },
+    ]);
+
+    await service.exportExpenses(
+      ORG_ID,
+      { format: 'csv', type: 'expenses' } as ExportQueryDto,
+      buildResMock(),
+    );
+
+    expect(csv.write).toHaveBeenCalledWith(
+      [
+        ['Date', 'Category', 'Description', 'Total', 'Status'],
+        [
+          expenseDate.toLocaleDateString(),
+          'Arriendo',
+          'Arriendo agosto',
+          '500000.00',
+          'PAID',
+        ],
+      ],
+      { headers: false },
+    );
+  });
+
+  it('exportExpenses exports an empty result with headers only', async () => {
+    prismaMock.expense.findMany.mockResolvedValue([]);
+
+    await service.exportExpenses(
+      ORG_ID,
+      { format: 'csv', type: 'expenses' } as ExportQueryDto,
+      buildResMock(),
+    );
+
+    expect(csv.write).toHaveBeenCalledWith(
+      [['Date', 'Category', 'Description', 'Total', 'Status']],
+      { headers: false },
     );
   });
 });

--- a/backend/src/exports/exports.service.ts
+++ b/backend/src/exports/exports.service.ts
@@ -17,7 +17,9 @@ export class ExportsService {
     const limit = query.limit ?? 20;
     const skip = (page - 1) * limit;
 
-    const where: Record<string, unknown> = { ...(organizationId ? { organizationId } : {}) };
+    const where: Record<string, unknown> = {
+      ...(organizationId ? { organizationId } : {}),
+    };
 
     if (query.productId) {
       where.productId = query.productId;
@@ -108,7 +110,10 @@ export class ExportsService {
     return this.exportData(expenses, 'expenses', query.format, response);
   }
 
-  private async getSalesData(organizationId: string | undefined, query: ExportQueryDto) {
+  private async getSalesData(
+    organizationId: string | undefined,
+    query: ExportQueryDto,
+  ) {
     const where: any = { ...(organizationId ? { organizationId } : {}) };
     if (query.startDate || query.endDate) {
       where.createdAt = {};
@@ -132,7 +137,10 @@ export class ExportsService {
     });
   }
 
-  private async getProductsData(organizationId: string | undefined, query: ExportQueryDto) {
+  private async getProductsData(
+    organizationId: string | undefined,
+    query: ExportQueryDto,
+  ) {
     return this.prisma.product.findMany({
       where: { ...(organizationId ? { organizationId } : {}), active: true },
       take: query.limit || undefined,

--- a/backend/src/exports/exports.service.ts
+++ b/backend/src/exports/exports.service.ts
@@ -99,6 +99,15 @@ export class ExportsService {
     return this.exportData(movements, 'inventory', query.format, response);
   }
 
+  async exportExpenses(
+    organizationId: string | undefined,
+    query: ExportQueryDto,
+    response: any,
+  ) {
+    const expenses = await this.getExpensesData(organizationId, query);
+    return this.exportData(expenses, 'expenses', query.format, response);
+  }
+
   private async getSalesData(organizationId: string | undefined, query: ExportQueryDto) {
     const where: any = { ...(organizationId ? { organizationId } : {}) };
     if (query.startDate || query.endDate) {
@@ -166,6 +175,32 @@ export class ExportsService {
         product: { select: { name: true, sku: true } },
         user: { select: { name: true } },
       },
+    });
+  }
+
+  private async getExpensesData(
+    organizationId: string | undefined,
+    query: ExportQueryDto,
+  ) {
+    const where: any = {
+      ...(organizationId ? { organizationId } : {}),
+      active: true,
+    };
+    if (query.startDate || query.endDate) {
+      where.date = {};
+      if (query.startDate) where.date.gte = new Date(query.startDate);
+      if (query.endDate) {
+        const end = new Date(query.endDate);
+        end.setHours(23, 59, 59, 999);
+        where.date.lte = end;
+      }
+    }
+
+    return this.prisma.expense.findMany({
+      where,
+      take: query.limit || undefined,
+      orderBy: { date: 'desc' },
+      include: { category: { select: { name: true } } },
     });
   }
 
@@ -309,6 +344,7 @@ export class ExportsService {
         'New Stock',
         'User',
       ],
+      expenses: ['Date', 'Category', 'Description', 'Total', 'Status'],
     };
     return headers[type] || [];
   }
@@ -350,6 +386,13 @@ export class ExportsService {
         item.newStock,
         item.user?.name || 'N/A',
       ],
+      expenses: (item) => [
+        new Date(item.date).toLocaleDateString(),
+        item.category?.name || 'N/A',
+        item.description || 'N/A',
+        Number(item.total).toFixed(2),
+        item.status,
+      ],
     };
     return getters[type](item);
   }
@@ -360,6 +403,7 @@ export class ExportsService {
       products: [50, 25, 25, 20, 20, 15, 15],
       customers: [35, 25, 25, 30, 25, 20],
       inventory: [25, 40, 25, 15, 20, 20, 25],
+      expenses: [25, 40, 40, 20, 20],
     };
     return widths[type] || [];
   }


### PR DESCRIPTION
Closes #12

## Chain Context

- Strategy: **Feature Branch Chain** (5 slices) — `chained-pr` contract
- Slice: **3 of 5 — aux endpoints + integration tests** 📍
- Base: `feat/expenses` (tracker, do not merge to main yet)
- Prior dependencies: slice 1 (merged via #9), slice 2 (merged via #11)
- Follow-up: slice 4 (frontend hooks/gating) → slice 5 (frontend UI)
- Out of scope in this slice: frontend

```
master
  └─ feat/expenses (tracker)
       ├─ feat/expenses-unit-1 (merged via #9)
       ├─ feat/expenses-unit-2 (merged via #11)
       └─ feat/expenses-unit-3 📍
```

## Summary

- `GET /expenses/summary/monthly?month=YYYY-MM` — month totals with America/Bogota boundaries, per category (static route registered before `:id` routes)
- `POST /expenses/:id/duplicate` — manual recurrence (today-Bogota date, derived status, inactive rejected)
- `GET /expenses/:id/history` — org-scoped audit log for the expense
- `POST /expenses/:id/upload` — receipt upload via Cloudinary (images + PDF), audit written
- `POST /exports/expenses` — export integrated into the existing exports module (Date/Category/Description/Total/Status)
- Refactor: month-range helper consolidated into `common/utils/bogota-date.ts` (`parseBogotaMonthRange`)
- Integration tests against the real database

## Changes

| File | Change |
|------|--------|
| `backend/src/expenses/expenses.controller.ts` | summary/duplicate/history/upload endpoints (ADMIN-only) |
| `backend/src/expenses/expenses.service.ts` | summary, duplicate, history, upload logic |
| `backend/src/common/utils/bogota-date.ts` | `parseBogotaMonthRange` consolidation |
| `backend/src/exports/*` | expenses export integration |
| `backend/src/expenses/expenses.service.int.spec.ts` | integration tests vs real DB |
| `backend/src/expenses/*.spec.ts` | updated/extended unit specs |

## Test Plan

- [x] Backend suite **405/405** (39 suites); `npm run build` exit 0
- [x] RED→GREEN per work unit (T11–T15)
- [x] Integration tests (real DB): cross-org isolation 404, payment flows, Bogota month-boundary summary, duplicate
- [x] Scoped ESLint 0 errors on new/changed files
- [ ] E2E (T16) — skipped: marked Optional in tasks

## Contributor Checklist

- [x] Issue linked (`Closes #12`)
- [x] Conventional commits, no `Co-Authored-By`
- [x] Tests kept with the work unit
- [x] N/A shellcheck (no shell scripts changed)
