### PR TITLE
feat(expenses): add frontend types, data hooks and ADMIN gating (4/5)

### DIFF
--- a/frontend/src/components/layout/DashboardLayout.test.tsx
+++ b/frontend/src/components/layout/DashboardLayout.test.tsx
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { DashboardLayout } from "./DashboardLayout";
+
+const replaceMock = vi.fn();
+const pushMock = vi.fn();
+const useAuthMock = vi.fn();
+let currentPathname = "/expenses";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: replaceMock, push: pushMock }),
+  usePathname: () => currentPathname,
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock("./Sidebar", () => ({
+  Sidebar: () => null,
+}));
+
+vi.mock("@/components/billing/PlanLimitBanner", () => ({
+  PlanLimitBanner: () => null,
+}));
+
+function setUser(role: string) {
+  useAuthMock.mockReturnValue({
+    isAuthenticated: true,
+    loading: false,
+    user: { id: "user-1", name: "Ana Perez", role, active: true },
+    organization: undefined,
+  });
+}
+
+describe("DashboardLayout route gating for /expenses", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentPathname = "/expenses";
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps ADMIN users on /expenses", () => {
+    setUser("ADMIN");
+
+    render(
+      <DashboardLayout>
+        <p>Salidas</p>
+      </DashboardLayout>
+    );
+
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects CASHIER users away from /expenses to /pos", () => {
+    setUser("CASHIER");
+
+    render(
+      <DashboardLayout>
+        <p>Salidas</p>
+      </DashboardLayout>
+    );
+
+    expect(replaceMock).toHaveBeenCalledWith("/pos");
+  });
+
+  it("redirects INVENTORY_USER users away from /expenses to /dashboard", () => {
+    setUser("INVENTORY_USER");
+
+    render(
+      <DashboardLayout>
+        <p>Salidas</p>
+      </DashboardLayout>
+    );
+
+    expect(replaceMock).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("does not redirect when the pathname is not gated", () => {
+    currentPathname = "/profile";
+    setUser("CASHIER");
+
+    render(
+      <DashboardLayout>
+        <p>Perfil</p>
+      </DashboardLayout>
+    );
+
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -16,6 +16,7 @@ const routeRoleMap: Array<{ prefix: string; roles: UserRole[] }> = [
   { prefix: "/suppliers", roles: ["ADMIN", "INVENTORY_USER"] },
   { prefix: "/purchase-orders", roles: ["ADMIN", "INVENTORY_USER"] },
   { prefix: "/sales", roles: ["ADMIN", "CASHIER"] },
+  { prefix: "/expenses", roles: ["ADMIN"] },
   { prefix: "/customers", roles: ["ADMIN", "CASHIER"] },
   { prefix: "/reports", roles: ["ADMIN"] },
   { prefix: "/users", roles: ["ADMIN"] },

--- a/frontend/src/components/layout/Sidebar.test.tsx
+++ b/frontend/src/components/layout/Sidebar.test.tsx
@@ -6,6 +6,7 @@ import { api } from "@/lib/api";
 
 const pushMock = vi.fn();
 const switchOrganizationMock = vi.fn();
+const useAuthMock = vi.fn();
 
 vi.mock("next/navigation", () => ({
   usePathname: () => "/dashboard",
@@ -32,17 +33,7 @@ vi.mock("@/contexts/ThemeContext", () => ({
 }));
 
 vi.mock("@/contexts/AuthContext", () => ({
-  useAuth: () => ({
-    user: {
-      id: "user-1",
-      name: "Ana Perez",
-      role: "ADMIN",
-      active: true,
-      organizationId: "org-a",
-    },
-    logout: vi.fn(),
-    switchOrganization: switchOrganizationMock,
-  }),
+  useAuth: () => useAuthMock(),
 }));
 
 vi.mock("@/lib/api", () => ({
@@ -80,6 +71,17 @@ const organizations = [
 describe("Sidebar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useAuthMock.mockReturnValue({
+      user: {
+        id: "user-1",
+        name: "Ana Perez",
+        role: "ADMIN",
+        active: true,
+        organizationId: "org-a",
+      },
+      logout: vi.fn(),
+      switchOrganization: switchOrganizationMock,
+    });
   });
 
   it("renders the organization switcher for multi-org users", async () => {
@@ -111,6 +113,75 @@ describe("Sidebar", () => {
 
     expect(
       screen.queryByLabelText(/Cambiar organizacion/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the Salidas nav item for ADMIN users", async () => {
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { organizations },
+    });
+
+    render(<Sidebar />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Org A")).toBeInTheDocument();
+    });
+
+    const link = screen.getByRole("link", { name: "Salidas" });
+    expect(link).toHaveAttribute("href", "/expenses");
+  });
+
+  it("hides the Salidas nav item for CASHIER users", async () => {
+    useAuthMock.mockReturnValue({
+      user: {
+        id: "user-2",
+        name: "Carlos Cajero",
+        role: "CASHIER",
+        active: true,
+        organizationId: "org-a",
+      },
+      logout: vi.fn(),
+      switchOrganization: switchOrganizationMock,
+    });
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { organizations: [organizations[0]] },
+    });
+
+    render(<Sidebar />, { wrapper });
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith("/auth/organizations");
+    });
+
+    expect(
+      screen.queryByRole("link", { name: "Salidas" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the Salidas nav item for INVENTORY_USER users", async () => {
+    useAuthMock.mockReturnValue({
+      user: {
+        id: "user-3",
+        name: "Inventario User",
+        role: "INVENTORY_USER",
+        active: true,
+        organizationId: "org-a",
+      },
+      logout: vi.fn(),
+      switchOrganization: switchOrganizationMock,
+    });
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { organizations: [organizations[0]] },
+    });
+
+    render(<Sidebar />, { wrapper });
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith("/auth/organizations");
+    });
+
+    expect(
+      screen.queryByRole("link", { name: "Salidas" })
     ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -26,6 +26,7 @@ import {
   Clock3,
   ClipboardList,
   Truck,
+  Wallet,
 } from "lucide-react";
 import { useTheme } from "@/contexts/ThemeContext";
 import { cn } from "@/lib/utils";
@@ -76,6 +77,12 @@ const navItems: NavItem[] = [
     href: "/sales",
     icon: <Receipt className="w-4 h-4" />,
     roles: ["ADMIN", "CASHIER"],
+  },
+  {
+    label: "Salidas",
+    href: "/expenses",
+    icon: <Wallet className="w-4 h-4" />,
+    roles: ["ADMIN"],
   },
   {
     label: "Clientes",

--- a/frontend/src/hooks/useExpenses.test.ts
+++ b/frontend/src/hooks/useExpenses.test.ts
@@ -27,6 +27,7 @@ import {
   useUpdateExpenseCategory,
   useUploadExpenseReceipt,
 } from "./useExpenses";
+import type { CreateExpensePayload, ExpensePaymentPayload } from "./useExpenses";
 
 vi.mock("@/lib/api", () => ({
   api: {
@@ -234,7 +235,7 @@ describe("useExpenses", () => {
         wrapper: wrapperWith(queryClient),
       });
 
-      const payload = {
+      const payload: CreateExpensePayload = {
         categoryId: "cat-1",
         description: "Arriendo agosto",
         date: "2026-08-01",
@@ -290,7 +291,11 @@ describe("useExpenses", () => {
         wrapper: wrapperWith(queryClient),
       });
 
-      const payload = { amount: 100000, method: "TRANSFER", date: "2026-08-10" };
+      const payload: ExpensePaymentPayload = {
+        amount: 100000,
+        method: "TRANSFER",
+        date: "2026-08-10",
+      };
       await result.current.mutateAsync({ id: "exp-1", data: payload });
 
       expect(apiMock.post).toHaveBeenCalledWith("/expenses/exp-1/payments", payload);

--- a/frontend/src/hooks/useExpenses.test.ts
+++ b/frontend/src/hooks/useExpenses.test.ts
@@ -1,0 +1,388 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+import { api } from "@/lib/api";
+import type {
+  Expense,
+  ExpenseAuditEntry,
+  ExpenseCategory,
+  ExpenseMonthlySummary,
+  ExpensePayment,
+  PaginatedResponse,
+} from "@/types";
+import {
+  useAddExpensePayment,
+  useCreateExpense,
+  useCreateExpenseCategory,
+  useDeleteExpense,
+  useDeleteExpenseCategory,
+  useDuplicateExpense,
+  useExpense,
+  useExpenseCategories,
+  useExpenseHistory,
+  useExpenses,
+  useExpenseSummary,
+  useUpdateExpense,
+  useUpdateExpenseCategory,
+  useUploadExpenseReceipt,
+} from "./useExpenses";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    upload: vi.fn(),
+  },
+}));
+
+type MockApi = {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  upload: ReturnType<typeof vi.fn>;
+};
+
+const apiMock = api as unknown as MockApi;
+
+function makeCategory(overrides: Partial<ExpenseCategory> = {}): ExpenseCategory {
+  return {
+    id: "cat-1",
+    organizationId: "org-a",
+    name: "Arriendo",
+    active: true,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makePayment(overrides: Partial<ExpensePayment> = {}): ExpensePayment {
+  return {
+    id: "pay-1",
+    expenseId: "exp-1",
+    organizationId: "org-a",
+    amount: 500000,
+    method: "CASH",
+    date: "2026-08-01T00:00:00.000Z",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeExpense(overrides: Partial<Expense> = {}): Expense {
+  return {
+    id: "exp-1",
+    organizationId: "org-a",
+    categoryId: "cat-1",
+    category: makeCategory(),
+    supplierId: null,
+    purchaseOrderId: null,
+    description: "Arriendo agosto",
+    date: "2026-08-01T00:00:00.000Z",
+    total: 500000,
+    status: "PAID",
+    receiptUrl: null,
+    active: true,
+    createdById: "user-1",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    payments: [makePayment()],
+    ...overrides,
+  };
+}
+
+function makePage(items: Expense[]): PaginatedResponse<Expense> {
+  return {
+    data: items,
+    meta: { total: items.length, page: 1, limit: 10, totalPages: 1 },
+  };
+}
+
+function makeSummary(): ExpenseMonthlySummary {
+  return {
+    month: "2026-08",
+    total: 500000,
+    categories: [{ categoryId: "cat-1", name: "Arriendo", total: 500000 }],
+  };
+}
+
+function makeAuditEntry(): ExpenseAuditEntry {
+  return {
+    id: "audit-1",
+    userId: "user-1",
+    action: "EXPENSE_CREATED",
+    resource: "Expense",
+    resourceId: "exp-1",
+    metadata: { summary: "Salida creada" },
+    createdAt: "2026-08-01T00:00:00.000Z",
+    organizationId: "org-a",
+    user: { name: "Ana Perez", email: "ana@example.com" },
+  };
+}
+
+function wrapperWith(queryClient: QueryClient) {
+  return function wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+describe("useExpenses", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("queries", () => {
+    it("fetches the paginated list with query params under the expenses key", async () => {
+      const params = { page: 1, limit: 10, month: "2026-08" };
+      const page = makePage([makeExpense()]);
+      apiMock.get.mockResolvedValue({ data: page });
+
+      const { result } = renderHook(() => useExpenses(params), {
+        wrapper: wrapperWith(makeQueryClient()),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(apiMock.get).toHaveBeenCalledWith("/expenses", params);
+      expect(result.current.data).toEqual(page);
+    });
+
+    it("fetches a single expense by id", async () => {
+      const expense = makeExpense();
+      apiMock.get.mockResolvedValue({ data: expense });
+
+      const { result } = renderHook(() => useExpense("exp-1"), {
+        wrapper: wrapperWith(makeQueryClient()),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(apiMock.get).toHaveBeenCalledWith("/expenses/exp-1");
+      expect(result.current.data).toEqual(expense);
+    });
+
+    it("does not fetch a single expense without an id", () => {
+      renderHook(() => useExpense(""), {
+        wrapper: wrapperWith(makeQueryClient()),
+      });
+
+      expect(apiMock.get).not.toHaveBeenCalled();
+    });
+
+    it("fetches the monthly summary for the requested month", async () => {
+      const summary = makeSummary();
+      apiMock.get.mockResolvedValue({ data: summary });
+
+      const { result } = renderHook(() => useExpenseSummary("2026-08"), {
+        wrapper: wrapperWith(makeQueryClient()),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(apiMock.get).toHaveBeenCalledWith("/expenses/summary/monthly", {
+        month: "2026-08",
+      });
+      expect(result.current.data).toEqual(summary);
+    });
+
+    it("fetches the audit history of an expense", async () => {
+      const entries = [makeAuditEntry()];
+      apiMock.get.mockResolvedValue({ data: entries });
+
+      const { result } = renderHook(() => useExpenseHistory("exp-1"), {
+        wrapper: wrapperWith(makeQueryClient()),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(apiMock.get).toHaveBeenCalledWith("/expenses/exp-1/history");
+      expect(result.current.data).toEqual(entries);
+    });
+
+    it("fetches the expense categories", async () => {
+      const categories = [makeCategory()];
+      apiMock.get.mockResolvedValue({ data: categories });
+
+      const { result } = renderHook(() => useExpenseCategories(), {
+        wrapper: wrapperWith(makeQueryClient()),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(apiMock.get).toHaveBeenCalledWith("/expense-categories");
+      expect(result.current.data).toEqual(categories);
+    });
+  });
+
+  describe("mutations", () => {
+    it("creates an expense and invalidates expense queries", async () => {
+      const queryClient = makeQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      const expense = makeExpense();
+      apiMock.post.mockResolvedValue({ data: expense });
+
+      const { result } = renderHook(() => useCreateExpense(), {
+        wrapper: wrapperWith(queryClient),
+      });
+
+      const payload = {
+        categoryId: "cat-1",
+        description: "Arriendo agosto",
+        date: "2026-08-01",
+        total: 500000,
+        payments: [
+          { amount: 500000, method: "CASH", date: "2026-08-01" },
+        ],
+      };
+
+      await result.current.mutateAsync(payload);
+
+      expect(apiMock.post).toHaveBeenCalledWith("/expenses", payload);
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["expenses"] });
+    });
+
+    it("updates an expense and invalidates expense queries", async () => {
+      const queryClient = makeQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      apiMock.patch.mockResolvedValue({ data: makeExpense() });
+
+      const { result } = renderHook(() => useUpdateExpense(), {
+        wrapper: wrapperWith(queryClient),
+      });
+
+      const payload = { description: "Arriendo septiembre" };
+      await result.current.mutateAsync({ id: "exp-1", data: payload });
+
+      expect(apiMock.patch).toHaveBeenCalledWith("/expenses/exp-1", payload);
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["expenses"] });
+    });
+
+    it("deletes an expense and invalidates expense queries", async () => {
+      const queryClient = makeQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      apiMock.delete.mockResolvedValue({ data: makeExpense() });
+
+      const { result } = renderHook(() => useDeleteExpense(), {
+        wrapper: wrapperWith(queryClient),
+      });
+
+      await result.current.mutateAsync("exp-1");
+
+      expect(apiMock.delete).toHaveBeenCalledWith("/expenses/exp-1");
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["expenses"] });
+    });
+
+    it("adds a payment and invalidates expense queries", async () => {
+      const queryClient = makeQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      apiMock.post.mockResolvedValue({ data: makeExpense() });
+
+      const { result } = renderHook(() => useAddExpensePayment(), {
+        wrapper: wrapperWith(queryClient),
+      });
+
+      const payload = { amount: 100000, method: "TRANSFER", date: "2026-08-10" };
+      await result.current.mutateAsync({ id: "exp-1", data: payload });
+
+      expect(apiMock.post).toHaveBeenCalledWith("/expenses/exp-1/payments", payload);
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["expenses"] });
+    });
+
+    it("duplicates an expense and invalidates expense queries", async () => {
+      const queryClient = makeQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      apiMock.post.mockResolvedValue({ data: makeExpense() });
+
+      const { result } = renderHook(() => useDuplicateExpense(), {
+        wrapper: wrapperWith(queryClient),
+      });
+
+      await result.current.mutateAsync("exp-1");
+
+      expect(apiMock.post).toHaveBeenCalledWith("/expenses/exp-1/duplicate");
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["expenses"] });
+    });
+
+    it("uploads a receipt via multipart and invalidates expense queries", async () => {
+      const queryClient = makeQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      apiMock.upload.mockResolvedValue({ data: makeExpense() });
+
+      const { result } = renderHook(() => useUploadExpenseReceipt(), {
+        wrapper: wrapperWith(queryClient),
+      });
+
+      const file = new File(["receipt"], "comprobante.jpg", {
+        type: "image/jpeg",
+      });
+      await result.current.mutateAsync({ id: "exp-1", file });
+
+      expect(apiMock.upload).toHaveBeenCalledWith("/expenses/exp-1/upload", file);
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["expenses"] });
+    });
+
+    it("creates a category and invalidates category queries", async () => {
+      const queryClient = makeQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      apiMock.post.mockResolvedValue({ data: makeCategory() });
+
+      const { result } = renderHook(() => useCreateExpenseCategory(), {
+        wrapper: wrapperWith(queryClient),
+      });
+
+      await result.current.mutateAsync({ name: "Impuestos" });
+
+      expect(apiMock.post).toHaveBeenCalledWith("/expense-categories", {
+        name: "Impuestos",
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["expense-categories"],
+      });
+    });
+
+    it("updates a category and invalidates category queries", async () => {
+      const queryClient = makeQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      apiMock.patch.mockResolvedValue({ data: makeCategory() });
+
+      const { result } = renderHook(() => useUpdateExpenseCategory(), {
+        wrapper: wrapperWith(queryClient),
+      });
+
+      await result.current.mutateAsync({ id: "cat-1", data: { name: "Seguros" } });
+
+      expect(apiMock.patch).toHaveBeenCalledWith("/expense-categories/cat-1", {
+        name: "Seguros",
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["expense-categories"],
+      });
+    });
+
+    it("deletes a category and invalidates category queries", async () => {
+      const queryClient = makeQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      apiMock.delete.mockResolvedValue({ data: makeCategory() });
+
+      const { result } = renderHook(() => useDeleteExpenseCategory(), {
+        wrapper: wrapperWith(queryClient),
+      });
+
+      await result.current.mutateAsync("cat-1");
+
+      expect(apiMock.delete).toHaveBeenCalledWith("/expense-categories/cat-1");
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["expense-categories"],
+      });
+    });
+  });
+});

--- a/frontend/src/hooks/useExpenses.ts
+++ b/frontend/src/hooks/useExpenses.ts
@@ -1,0 +1,202 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import type {
+  Expense,
+  ExpenseAuditEntry,
+  ExpenseCategory,
+  ExpenseMonthlySummary,
+  ExpenseQueryParams,
+  PaginatedResponse,
+} from "@/types";
+
+export interface ExpensePaymentPayload {
+  amount: number;
+  method: "CASH" | "CARD" | "TRANSFER";
+  date: string;
+}
+
+export interface CreateExpensePayload {
+  categoryId: string;
+  supplierId?: string;
+  purchaseOrderId?: string;
+  description?: string;
+  date: string;
+  total: number;
+  payments: ExpensePaymentPayload[];
+}
+
+export interface UpdateExpensePayload {
+  categoryId?: string;
+  supplierId?: string | null;
+  purchaseOrderId?: string | null;
+  description?: string | null;
+  date?: string;
+  total?: number;
+}
+
+export interface ExpenseCategoryPayload {
+  name: string;
+}
+
+export function useExpenses(params?: ExpenseQueryParams) {
+  return useQuery({
+    queryKey: ["expenses", params],
+    queryFn: () =>
+      api
+        .get<PaginatedResponse<Expense>>("/expenses", params)
+        .then((res) => res.data),
+  });
+}
+
+export function useExpense(id: string) {
+  return useQuery({
+    queryKey: ["expense", id],
+    queryFn: () => api.get<Expense>(`/expenses/${id}`).then((res) => res.data),
+    enabled: !!id,
+  });
+}
+
+export function useExpenseSummary(month: string) {
+  return useQuery({
+    queryKey: ["expenses", "summary", month],
+    queryFn: () =>
+      api
+        .get<ExpenseMonthlySummary>("/expenses/summary/monthly", { month })
+        .then((res) => res.data),
+    enabled: !!month,
+  });
+}
+
+export function useExpenseHistory(id: string) {
+  return useQuery({
+    queryKey: ["expenses", "history", id],
+    queryFn: () =>
+      api
+        .get<ExpenseAuditEntry[]>(`/expenses/${id}/history`)
+        .then((res) => res.data),
+    enabled: !!id,
+  });
+}
+
+export function useExpenseCategories() {
+  return useQuery({
+    queryKey: ["expense-categories"],
+    queryFn: () =>
+      api
+        .get<ExpenseCategory[]>("/expense-categories")
+        .then((res) => res.data),
+  });
+}
+
+export function useCreateExpense() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateExpensePayload) =>
+      api.post<Expense>("/expenses", data).then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+    },
+  });
+}
+
+export function useUpdateExpense() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateExpensePayload }) =>
+      api.patch<Expense>(`/expenses/${id}`, data).then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+    },
+  });
+}
+
+export function useDeleteExpense() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      api.delete<Expense>(`/expenses/${id}`).then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+    },
+  });
+}
+
+export function useAddExpensePayment() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      data,
+    }: {
+      id: string;
+      data: ExpensePaymentPayload;
+    }) =>
+      api.post<Expense>(`/expenses/${id}/payments`, data).then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+    },
+  });
+}
+
+export function useDuplicateExpense() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      api.post<Expense>(`/expenses/${id}/duplicate`).then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+    },
+  });
+}
+
+export function useUploadExpenseReceipt() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, file }: { id: string; file: File }) =>
+      api.upload<Expense>(`/expenses/${id}/upload`, file).then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+    },
+  });
+}
+
+export function useCreateExpenseCategory() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: ExpenseCategoryPayload) =>
+      api
+        .post<ExpenseCategory>("/expense-categories", data)
+        .then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["expense-categories"] });
+    },
+  });
+}
+
+export function useUpdateExpenseCategory() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: ExpenseCategoryPayload }) =>
+      api
+        .patch<ExpenseCategory>(`/expense-categories/${id}`, data)
+        .then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["expense-categories"] });
+    },
+  });
+}
+
+export function useDeleteExpenseCategory() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      api
+        .delete<ExpenseCategory>(`/expense-categories/${id}`)
+        .then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["expense-categories"] });
+    },
+  });
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -466,3 +466,77 @@ export interface BillingStatus {
   trialEndsAt: string | null;
   billingStatus: "PENDING" | "PAID" | "OVERDUE";
 }
+
+export type ExpenseStatus = "PARTIAL" | "PAID";
+
+export interface ExpensePayment {
+  id: string;
+  expenseId: string;
+  organizationId: string;
+  amount: number;
+  method: "CASH" | "CARD" | "TRANSFER";
+  date: string;
+  createdAt: string;
+}
+
+export interface ExpenseCategory {
+  id: string;
+  organizationId: string;
+  name: string;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Expense {
+  id: string;
+  organizationId: string;
+  categoryId: string;
+  category?: ExpenseCategory;
+  supplierId: string | null;
+  supplier?: Supplier | null;
+  purchaseOrderId: string | null;
+  purchaseOrder?: PurchaseOrder | null;
+  description: string | null;
+  date: string;
+  total: number;
+  status: ExpenseStatus;
+  receiptUrl: string | null;
+  active: boolean;
+  createdById: string;
+  createdAt: string;
+  updatedAt: string;
+  payments?: ExpensePayment[];
+}
+
+export interface ExpenseMonthlySummary {
+  month: string;
+  total: number;
+  categories: Array<{
+    categoryId: string;
+    name: string;
+    total: number;
+  }>;
+}
+
+export interface ExpenseAuditEntry {
+  id: string;
+  userId: string | null;
+  action: string;
+  resource: string;
+  resourceId: string | null;
+  metadata: unknown;
+  createdAt: string;
+  organizationId: string;
+  user?: { name: string; email: string } | null;
+}
+
+export type ExpenseQueryParams = {
+  page?: number;
+  limit?: number;
+  month?: string;
+  categoryId?: string;
+  supplierId?: string;
+  status?: ExpenseStatus;
+  search?: string;
+};


### PR DESCRIPTION
Closes #14

## Chain Context

- Strategy: **Feature Branch Chain** (5 slices) — `chained-pr` contract
- Slice: **4 of 5 — frontend hooks + gating** 📍
- Base: `feat/expenses` (tracker, do not merge to main yet)
- Prior dependencies: slice 1 (merged #9), slice 2 (merged #11), slice 3 (merged #13)
- Follow-up: slice 5 (frontend UI — page, forms, summary cards)
- Out of scope in this slice: the expenses page UI (slice 5)

```
master
  └─ feat/expenses (tracker)
       ├─ feat/expenses-unit-1 (merged #9)
       ├─ feat/expenses-unit-2 (merged #11)
       ├─ feat/expenses-unit-3 (merged #13)
       └─ feat/expenses-unit-4 📍
```

## Summary

- 7 expense-related types in `frontend/src/types/index.ts` matching the Units 1–3 backend shapes
- 14 TanStack Query hooks in `frontend/src/hooks/useExpenses.ts` (list with filters, detail, monthly summary, history, categories; create/update/delete/addPayment/duplicate/receipt-upload; category mutations) following the `useSuppliers` pattern (queryKeys + invalidations)
- "Salidas" sidebar entry + `/expenses` route in the DashboardLayout route-role map, **ADMIN-only on both sides** (mirrors backend)

## Changes

| File | Change |
|------|--------|
| `frontend/src/types/index.ts` | Expense-related types |
| `frontend/src/hooks/useExpenses.ts` | 14 data hooks |
| `frontend/src/hooks/useExpenses.test.ts` | Hook tests |
| `frontend/src/components/layout/Sidebar.tsx` | "Salidas" entry (after "Ventas") |
| `frontend/src/components/layout/DashboardLayout.tsx` | `/expenses` route in the role map |
| `frontend/src/components/layout/Sidebar.test.tsx` | Gating tests |
| `frontend/src/components/layout/DashboardLayout.test.tsx` | Redirect/gating tests |

## Test Plan

- [x] Frontend suite: **121 passed / 5 failed** — the 5 failures are the pre-existing baseline (pos scanner ×2, sales `cn` mock ×2, admin spinner ×1), verified unchanged
- [x] RED→GREEN: hooks T17 (15/15), gating T20 (9/9)
- [x] Scoped ESLint 0 problems on touched files
- [x] `tsc --noEmit` clean on touched files (2 pre-existing unrelated errors elsewhere)
- [ ] Backend untouched (405/405 baseline intact)

## Contributor Checklist

- [x] Issue linked (`Closes #14`)
- [x] Conventional commits, no `Co-Authored-By`
- [x] Tests kept with the work unit
- [x] N/A shellcheck (no shell scripts changed)
