### PR TITLE
feat(expenses): add Salidas UI - page, modals, summary and export (5/5)

### DIFF
--- a/frontend/src/app/expenses/expenses-page.evidence.test.tsx
+++ b/frontend/src/app/expenses/expenses-page.evidence.test.tsx
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+
+const { exportDataMock } = vi.hoisted(() => ({ exportDataMock: vi.fn() }));
+
+const useExpensesMock = vi.fn();
+const useExpenseSummaryMock = vi.fn();
+const useExpenseCategoriesMock = vi.fn();
+const useSuppliersMock = vi.fn();
+const deleteMutateAsyncMock = vi.fn();
+const duplicateMutateAsyncMock = vi.fn();
+const uploadReceiptMutateAsyncMock = vi.fn();
+const toastSuccessMock = vi.fn();
+const toastErrorMock = vi.fn();
+
+vi.mock("@/components/layout/DashboardLayout", () => ({
+  DashboardLayout: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/hooks/useExpenses", () => ({
+  useExpenses: (params?: unknown) => useExpensesMock(params),
+  useExpenseSummary: (month?: string) => useExpenseSummaryMock(month),
+  useExpenseCategories: () => useExpenseCategoriesMock(),
+  useDeleteExpense: () => ({ mutateAsync: deleteMutateAsyncMock }),
+  useDuplicateExpense: () => ({ mutateAsync: duplicateMutateAsyncMock }),
+  useUploadExpenseReceipt: () => ({ mutateAsync: uploadReceiptMutateAsyncMock }),
+}));
+
+vi.mock("@/hooks/useSuppliers", () => ({
+  useSuppliers: () => useSuppliersMock(),
+}));
+
+vi.mock("@/components/expenses/ExpenseFormModal", () => ({
+  ExpenseFormModal: () => <section>ExpenseFormModal</section>,
+}));
+
+vi.mock("@/components/expenses/AddPaymentModal", () => ({
+  AddPaymentModal: () => <section>AddPaymentModal</section>,
+}));
+
+vi.mock("@/components/expenses/HistoryModal", () => ({
+  HistoryModal: () => <section>HistoryModal</section>,
+}));
+
+vi.mock("@/contexts/ToastContext", () => ({
+  useToast: () => ({
+    success: toastSuccessMock,
+    error: toastErrorMock,
+    info: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      exportData: exportDataMock,
+    },
+  };
+});
+
+import ExpensesPage from "./page";
+
+const expenseFixture = {
+  id: "exp-1",
+  organizationId: "org-1",
+  categoryId: "cat-1",
+  category: {
+    id: "cat-1",
+    organizationId: "org-1",
+    name: "Arriendo",
+    active: true,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+  },
+  supplierId: null,
+  purchaseOrderId: null,
+  description: "Renta agosto",
+  date: "2026-08-01T00:00:00.000Z",
+  total: "500000",
+  status: "PARTIAL",
+  receiptUrl: null,
+  active: true,
+  createdById: "user-1",
+  createdAt: "2026-08-01T00:00:00.000Z",
+  updatedAt: "2026-08-01T00:00:00.000Z",
+  payments: [
+    {
+      id: "pay-1",
+      expenseId: "exp-1",
+      organizationId: "org-1",
+      amount: "300000",
+      method: "CASH",
+      date: "2026-08-01T00:00:00.000Z",
+      createdAt: "2026-08-01T00:00:00.000Z",
+    },
+  ],
+};
+
+describe("Expenses page evidence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    exportDataMock.mockResolvedValue(undefined);
+    deleteMutateAsyncMock.mockResolvedValue({} as never);
+    duplicateMutateAsyncMock.mockResolvedValue({} as never);
+    uploadReceiptMutateAsyncMock.mockResolvedValue({} as never);
+
+    useExpenseSummaryMock.mockReturnValue({
+      data: {
+        month: "2026-08",
+        total: "800000",
+        categories: [
+          { categoryId: "cat-1", name: "Arriendo", total: "500000" },
+          { categoryId: "cat-2", name: "Caja menor", total: "300000" },
+        ],
+      },
+      isLoading: false,
+    });
+
+    useExpensesMock.mockReturnValue({
+      data: {
+        data: [expenseFixture],
+        meta: { total: 1, page: 1, limit: 15, totalPages: 1 },
+      },
+      isLoading: false,
+    });
+
+    useExpenseCategoriesMock.mockReturnValue({
+      data: [
+        {
+          id: "cat-1",
+          organizationId: "org-1",
+          name: "Arriendo",
+          active: true,
+          createdAt: "2026-08-01T00:00:00.000Z",
+          updatedAt: "2026-08-01T00:00:00.000Z",
+        },
+      ],
+      isLoading: false,
+    });
+
+    useSuppliersMock.mockReturnValue({ data: { data: [] }, isLoading: false });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the month total and per-category summary cards (EXP-8)", () => {
+    render(<ExpensesPage />);
+
+    expect(screen.getByText("Total del mes")).toBeTruthy();
+    expect(screen.getByText(/800\.000/)).toBeTruthy();
+    expect(screen.getAllByText("Arriendo").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Caja menor")).toBeTruthy();
+    expect(useExpenseSummaryMock).toHaveBeenCalledWith("2026-08");
+  });
+
+  it("renders the expense list with status badge and COP totals", () => {
+    render(<ExpensesPage />);
+
+    expect(screen.getByText("Renta agosto")).toBeTruthy();
+    expect(screen.getAllByText("Parcial").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/500\.000/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("applies the month filter to the list query", () => {
+    render(<ExpensesPage />);
+
+    expect(useExpensesMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ month: "2026-08" }),
+    );
+
+    fireEvent.change(screen.getByLabelText("Mes"), {
+      target: { value: "2026-07" },
+    });
+
+    expect(useExpensesMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ month: "2026-07", page: 1 }),
+    );
+  });
+
+  it("exports the filtered list through the exports endpoint (EXP-9)", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpensesPage />);
+
+    await user.click(screen.getByRole("button", { name: /Exportar/i }));
+
+    expect(exportDataMock).toHaveBeenCalledWith(
+      "/exports/expenses",
+      expect.objectContaining({ type: "expenses" }),
+    );
+    expect(toastSuccessMock).toHaveBeenCalled();
+  });
+
+  it("opens the create form modal", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpensesPage />);
+
+    await user.click(screen.getByRole("button", { name: /Nuevo gasto/i }));
+
+    expect(screen.getByText("ExpenseFormModal")).toBeTruthy();
+  });
+
+  it("opens the add payment modal from the row actions", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpensesPage />);
+
+    await user.click(screen.getByRole("button", { name: "Agregar pago" }));
+
+    expect(screen.getByText("AddPaymentModal")).toBeTruthy();
+  });
+
+  it("opens the history modal from the row actions", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpensesPage />);
+
+    await user.click(screen.getByRole("button", { name: "Ver historial" }));
+
+    expect(screen.getByText("HistoryModal")).toBeTruthy();
+  });
+
+  it("deletes an expense after confirmation (EXP-5)", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpensesPage />);
+
+    await user.click(screen.getByRole("button", { name: "Eliminar gasto" }));
+    expect(screen.getByText("Eliminar gasto")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Sí, eliminar" }));
+
+    expect(deleteMutateAsyncMock).toHaveBeenCalledWith("exp-1");
+    expect(toastSuccessMock).toHaveBeenCalledWith("Gasto eliminado");
+  });
+
+  it("duplicates an expense after confirmation (EXP-10)", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpensesPage />);
+
+    await user.click(screen.getByRole("button", { name: "Duplicar gasto" }));
+    expect(screen.getByText("Duplicar gasto")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Sí, duplicar" }));
+
+    expect(duplicateMutateAsyncMock).toHaveBeenCalledWith("exp-1");
+    expect(toastSuccessMock).toHaveBeenCalledWith("Gasto duplicado");
+  });
+
+  it("uploads a receipt from the row actions", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpensesPage />);
+
+    const file = new File(["receipt"], "recibo.png", { type: "image/png" });
+    const input = screen.getByLabelText("Subir comprobante");
+    await user.upload(input, file);
+
+    expect(uploadReceiptMutateAsyncMock).toHaveBeenCalledWith({
+      id: "exp-1",
+      file,
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith("Comprobante subido");
+  });
+});

--- a/frontend/src/app/expenses/page.tsx
+++ b/frontend/src/app/expenses/page.tsx
@@ -1,0 +1,532 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { DashboardLayout } from "@/components/layout/DashboardLayout";
+import { useSuppliers } from "@/hooks/useSuppliers";
+import {
+  useDeleteExpense,
+  useDuplicateExpense,
+  useExpenseCategories,
+  useExpenses,
+  useExpenseSummary,
+  useUploadExpenseReceipt,
+} from "@/hooks/useExpenses";
+import { useToast } from "@/contexts/ToastContext";
+import { api, getApiErrorMessage } from "@/lib/api";
+import { formatCurrency, formatDate, getBogotaDateInputValue } from "@/lib/utils";
+import { Button } from "@/components/ui/Button";
+import { Pagination } from "@/components/ui/Pagination";
+import { FilterBar } from "@/components/ui/FilterBar";
+import { Table, TableHeader, TableRow, TableCell } from "@/components/ui/Table";
+import { LoadingState } from "@/components/ui/LoadingState";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { ExpenseStatusBadge } from "@/components/expenses/ExpenseStatusBadge";
+import { ExpenseSummaryCards } from "@/components/expenses/ExpenseSummaryCards";
+import { ExpenseFormModal } from "@/components/expenses/ExpenseFormModal";
+import { AddPaymentModal } from "@/components/expenses/AddPaymentModal";
+import { HistoryModal } from "@/components/expenses/HistoryModal";
+import {
+  Copy,
+  History,
+  Pencil,
+  Plus,
+  Trash2,
+  Upload,
+  Wallet,
+  Download,
+} from "lucide-react";
+import { chipStyles } from "@/lib/chipStyles";
+import type { Expense, ExpenseStatus } from "@/types";
+
+const STATUS_OPTIONS: Array<{ value: "" | ExpenseStatus; label: string }> = [
+  { value: "", label: "Todos los estados" },
+  { value: "PARTIAL", label: "Parcial" },
+  { value: "PAID", label: "Pagado" },
+];
+
+export default function ExpensesPage() {
+  const toast = useToast();
+  const [month, setMonth] = useState(() =>
+    getBogotaDateInputValue().slice(0, 7),
+  );
+  const [categoryId, setCategoryId] = useState("");
+  const [supplierId, setSupplierId] = useState("");
+  const [status, setStatus] = useState<"" | ExpenseStatus>("");
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
+  const [exportFormat, setExportFormat] = useState<"excel" | "csv">("excel");
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
+  const [paymentExpense, setPaymentExpense] = useState<Expense | null>(null);
+  const [historyExpense, setHistoryExpense] = useState<Expense | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Expense | null>(null);
+  const [duplicateTarget, setDuplicateTarget] = useState<Expense | null>(null);
+
+  const { data: summary } = useExpenseSummary(month);
+  const { data: categoriesData } = useExpenseCategories();
+  const { data: suppliersData } = useSuppliers({ limit: 200, status: "active" });
+  const { data, isLoading } = useExpenses({
+    page,
+    limit: 15,
+    month,
+    categoryId: categoryId || undefined,
+    supplierId: supplierId || undefined,
+    status: status || undefined,
+    search: search.trim() || undefined,
+  });
+
+  const deleteExpense = useDeleteExpense();
+  const duplicateExpense = useDuplicateExpense();
+  const uploadReceipt = useUploadExpenseReceipt();
+
+  const expenses = data?.data ?? [];
+  const meta = data?.meta;
+  const categories = categoriesData ?? [];
+  const suppliers = suppliersData?.data ?? [];
+
+  const hasFilters = !!categoryId || !!supplierId || !!status || !!search;
+
+  const clearFilters = () => {
+    setPage(1);
+    setCategoryId("");
+    setSupplierId("");
+    setStatus("");
+    setSearch("");
+  };
+
+  const exportRange = useMemo(() => {
+    const [year, monthNumber] = month.split("-").map(Number);
+    if (!year || !monthNumber) {
+      return {};
+    }
+    const lastDay = new Date(Date.UTC(year, monthNumber, 0)).getUTCDate();
+    return {
+      startDate: `${month}-01`,
+      endDate: `${month}-${String(lastDay).padStart(2, "0")}`,
+    };
+  }, [month]);
+
+  const handleExport = async () => {
+    try {
+      await api.exportData("/exports/expenses", {
+        format: exportFormat,
+        type: "expenses",
+        ...exportRange,
+      });
+      toast.success("Exportación generada correctamente");
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "Error al exportar gastos"));
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteExpense.mutateAsync(deleteTarget.id);
+      toast.success("Gasto eliminado");
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "No se pudo eliminar el gasto"));
+    }
+  };
+
+  const handleDuplicate = async () => {
+    if (!duplicateTarget) return;
+    try {
+      await duplicateExpense.mutateAsync(duplicateTarget.id);
+      toast.success("Gasto duplicado");
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "No se pudo duplicar el gasto"));
+    }
+  };
+
+  const handleReceiptUpload = async (expense: Expense, file: File) => {
+    try {
+      await uploadReceipt.mutateAsync({ id: expense.id, file });
+      toast.success("Comprobante subido");
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "No se pudo subir el comprobante"));
+    }
+  };
+
+  const openCreate = () => {
+    setEditingExpense(null);
+    setFormOpen(true);
+  };
+
+  const openEdit = (expense: Expense) => {
+    setEditingExpense(expense);
+    setFormOpen(true);
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-5 lg:space-y-7">
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-3 mb-1">
+              <div className="w-1 h-7 rounded-full bg-primary shrink-0" />
+              <h1 className="text-2xl lg:text-3xl font-bold text-foreground">
+                Salidas
+              </h1>
+              {meta && (
+                <span
+                  className={`hidden sm:inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold ${chipStyles.primary}`}
+                >
+                  {meta.total} registros
+                </span>
+              )}
+            </div>
+            <p className="text-sm text-muted-foreground ml-4">
+              Registra los gastos y pagos de tu negocio
+            </p>
+          </div>
+          <div className="flex items-center gap-2 w-full sm:w-auto">
+            <select
+              aria-label="Formato de exportación"
+              value={exportFormat}
+              onChange={(e) =>
+                setExportFormat(e.target.value as "excel" | "csv")
+              }
+              className="h-8 px-2.5 rounded-lg text-xs font-semibold bg-muted/40 border border-border/60 text-foreground focus:outline-none focus:border-primary/50"
+            >
+              <option value="excel">Excel</option>
+              <option value="csv">CSV</option>
+            </select>
+            <Button
+              variant="secondary"
+              size="sm"
+              type="button"
+              onClick={handleExport}
+              className="shrink-0"
+            >
+              <Download className="w-3.5 h-3.5" /> Exportar
+            </Button>
+            <Button type="button" onClick={openCreate} className="shrink-0">
+              <Plus className="w-4 h-4" /> Nuevo gasto
+            </Button>
+          </div>
+        </div>
+
+        <ExpenseSummaryCards month={month} summary={summary} />
+
+        <FilterBar
+          searchValue={search}
+          onSearchChange={(value) => {
+            setPage(1);
+            setSearch(value);
+          }}
+          searchPlaceholder="Buscar por descripción..."
+          filterControls={
+            <>
+              <input
+                type="month"
+                aria-label="Mes"
+                value={month}
+                onChange={(e) => {
+                  setPage(1);
+                  setMonth(e.target.value);
+                }}
+                className="h-8 px-2 rounded-lg text-xs font-semibold bg-muted/40 border border-border/60 text-foreground focus:outline-none focus:border-primary/50"
+              />
+              <select
+                value={categoryId}
+                onChange={(e) => {
+                  setPage(1);
+                  setCategoryId(e.target.value);
+                }}
+                className="h-8 px-2.5 rounded-lg text-xs font-semibold bg-muted/40 border border-border/60 text-foreground focus:outline-none focus:border-primary/50 max-w-[180px]"
+              >
+                <option value="">Todas las categorías</option>
+                {categories.map((category) => (
+                  <option key={category.id} value={category.id}>
+                    {category.name}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={supplierId}
+                onChange={(e) => {
+                  setPage(1);
+                  setSupplierId(e.target.value);
+                }}
+                className="h-8 px-2.5 rounded-lg text-xs font-semibold bg-muted/40 border border-border/60 text-foreground focus:outline-none focus:border-primary/50 max-w-[180px]"
+              >
+                <option value="">Todos los proveedores</option>
+                {suppliers.map((supplier) => (
+                  <option key={supplier.id} value={supplier.id}>
+                    {supplier.name}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={status}
+                onChange={(e) => {
+                  setPage(1);
+                  setStatus(e.target.value as "" | ExpenseStatus);
+                }}
+                className="h-8 px-2.5 rounded-lg text-xs font-semibold bg-muted/40 border border-border/60 text-foreground focus:outline-none focus:border-primary/50"
+              >
+                {STATUS_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              {hasFilters && (
+                <button
+                  onClick={clearFilters}
+                  className="flex items-center gap-1.5 h-8 px-2.5 rounded-lg text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted/60 border border-border/60 transition-colors"
+                >
+                  Limpiar
+                </button>
+              )}
+            </>
+          }
+        />
+
+        {isLoading ? (
+          <LoadingState
+            icon={<Wallet className="w-4 h-4 text-primary/50" />}
+            message="Cargando salidas..."
+          />
+        ) : (
+          <>
+            <div className="rounded-3xl border border-accent/30 bg-accent/10 overflow-hidden">
+              <div className="overflow-x-auto">
+                <Table variant="accent" className="min-w-[860px]">
+                  <TableHeader>
+                    <TableRow>
+                      <TableCell
+                        as="th"
+                        className="text-left text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+                      >
+                        Fecha
+                      </TableCell>
+                      <TableCell
+                        as="th"
+                        className="text-left text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+                      >
+                        Categoría
+                      </TableCell>
+                      <TableCell
+                        as="th"
+                        className="text-left text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+                      >
+                        Descripción
+                      </TableCell>
+                      <TableCell
+                        as="th"
+                        className="text-left text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+                      >
+                        Proveedor
+                      </TableCell>
+                      <TableCell
+                        as="th"
+                        className="text-left text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+                      >
+                        Estado
+                      </TableCell>
+                      <TableCell
+                        as="th"
+                        className="text-right text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+                      >
+                        Total
+                      </TableCell>
+                      <TableCell
+                        as="th"
+                        className="text-right text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+                      >
+                        Acciones
+                      </TableCell>
+                    </TableRow>
+                  </TableHeader>
+                  <tbody>
+                    {expenses.length === 0 ? (
+                      <tr>
+                        <td colSpan={7} className="text-center py-14">
+                          <EmptyState
+                            icon={
+                              <Wallet className="w-6 h-6 text-muted-foreground/30" />
+                            }
+                            title="No hay salidas registradas"
+                          />
+                        </td>
+                      </tr>
+                    ) : (
+                      expenses.map((expense) => (
+                        <TableRow key={expense.id}>
+                          <TableCell className="text-muted-foreground whitespace-nowrap font-mono">
+                            {formatDate(expense.date)}
+                          </TableCell>
+                          <TableCell>
+                            <span className="text-xs font-semibold text-foreground">
+                              {expense.category?.name ?? "—"}
+                            </span>
+                          </TableCell>
+                          <TableCell className="max-w-[220px] truncate">
+                            <span className="text-xs text-muted-foreground">
+                              {expense.description ?? "—"}
+                            </span>
+                          </TableCell>
+                          <TableCell className="max-w-[180px] truncate">
+                            <span className="text-xs font-semibold text-foreground">
+                              {expense.supplier?.name ?? "—"}
+                            </span>
+                          </TableCell>
+                          <TableCell>
+                            <ExpenseStatusBadge status={expense.status} />
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <span className="stat-number text-sm font-bold text-foreground">
+                              {formatCurrency(Number(expense.total))}
+                            </span>
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <div className="flex items-center justify-end gap-1">
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                type="button"
+                                aria-label="Agregar pago"
+                                title="Agregar pago"
+                                disabled={expense.status === "PAID"}
+                                onClick={() => setPaymentExpense(expense)}
+                                className="p-1.5 h-7 w-7"
+                              >
+                                <Wallet className="w-3.5 h-3.5" />
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                type="button"
+                                aria-label="Ver historial"
+                                title="Ver historial"
+                                onClick={() => setHistoryExpense(expense)}
+                                className="p-1.5 h-7 w-7"
+                              >
+                                <History className="w-3.5 h-3.5" />
+                              </Button>
+                              <label
+                                className="inline-flex items-center justify-center p-1.5 h-7 w-7 rounded-lg cursor-pointer text-muted-foreground hover:text-foreground hover:bg-muted"
+                                title="Subir comprobante"
+                              >
+                                <input
+                                  type="file"
+                                  accept="image/*"
+                                  aria-label="Subir comprobante"
+                                  className="hidden"
+                                  onChange={(e) => {
+                                    const file = e.target.files?.[0];
+                                    if (file) {
+                                      handleReceiptUpload(expense, file);
+                                    }
+                                    e.target.value = "";
+                                  }}
+                                />
+                                <Upload className="w-3.5 h-3.5" />
+                              </label>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                type="button"
+                                aria-label="Duplicar gasto"
+                                title="Duplicar gasto"
+                                onClick={() => setDuplicateTarget(expense)}
+                                className="p-1.5 h-7 w-7"
+                              >
+                                <Copy className="w-3.5 h-3.5" />
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                type="button"
+                                aria-label="Editar gasto"
+                                title="Editar gasto"
+                                onClick={() => openEdit(expense)}
+                                className="p-1.5 h-7 w-7"
+                              >
+                                <Pencil className="w-3.5 h-3.5" />
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                type="button"
+                                aria-label="Eliminar gasto"
+                                title="Eliminar gasto"
+                                onClick={() => setDeleteTarget(expense)}
+                                className="p-1.5 h-7 w-7 hover:text-red-500"
+                              >
+                                <Trash2 className="w-3.5 h-3.5" />
+                              </Button>
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      ))
+                    )}
+                  </tbody>
+                </Table>
+              </div>
+            </div>
+
+            {meta && meta.totalPages > 1 && (
+              <Pagination
+                currentPage={page}
+                totalPages={meta.totalPages}
+                onPageChange={setPage}
+                totalItems={meta.total}
+                itemLabel="salida"
+              />
+            )}
+          </>
+        )}
+      </div>
+
+      {formOpen && (
+        <ExpenseFormModal
+          isOpen
+          expense={editingExpense}
+          onClose={() => {
+            setFormOpen(false);
+            setEditingExpense(null);
+          }}
+        />
+      )}
+
+      {paymentExpense && (
+        <AddPaymentModal
+          isOpen
+          expense={paymentExpense}
+          onClose={() => setPaymentExpense(null)}
+        />
+      )}
+
+      {historyExpense && (
+        <HistoryModal
+          isOpen
+          expense={historyExpense}
+          onClose={() => setHistoryExpense(null)}
+        />
+      )}
+
+      <ConfirmDialog
+        isOpen={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleDelete}
+        title="Eliminar gasto"
+        message="El gasto se ocultará de los listados y el resumen del mes. Esta acción no se puede deshacer."
+        confirmText="Sí, eliminar"
+      />
+
+      <ConfirmDialog
+        isOpen={!!duplicateTarget}
+        onClose={() => setDuplicateTarget(null)}
+        onConfirm={handleDuplicate}
+        title="Duplicar gasto"
+        message="Se creará una copia del gasto con la fecha de hoy y sus pagos."
+        confirmText="Sí, duplicar"
+      />
+    </DashboardLayout>
+  );
+}

--- a/frontend/src/components/expenses/AddPaymentModal.tsx
+++ b/frontend/src/components/expenses/AddPaymentModal.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState } from "react";
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/Button";
+import { Select } from "@/components/ui/Select";
+import { useAddExpensePayment } from "@/hooks/useExpenses";
+import { useToast } from "@/contexts/ToastContext";
+import { getApiErrorMessage } from "@/lib/api";
+import { formatCurrency, getBogotaDateInputValue } from "@/lib/utils";
+import type { Expense, ExpensePayment } from "@/types";
+
+interface Props {
+  expense: Expense;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const PAYMENT_METHOD_OPTIONS = [
+  { value: "CASH", label: "Efectivo" },
+  { value: "CARD", label: "Tarjeta" },
+  { value: "TRANSFER", label: "Transferencia" },
+];
+
+export function AddPaymentModal({ expense, isOpen, onClose }: Props) {
+  const toast = useToast();
+  const addPayment = useAddExpensePayment();
+
+  const [amount, setAmount] = useState("");
+  const [method, setMethod] = useState<ExpensePayment["method"]>("CASH");
+  const [date, setDate] = useState(getBogotaDateInputValue());
+
+  const paidSum = (expense.payments ?? []).reduce(
+    (acc, p) => acc + (Number(p.amount) || 0),
+    0,
+  );
+  const remaining = Number(expense.total) - paidSum;
+
+  const numericAmount = Number(amount) || 0;
+  const error =
+    numericAmount <= 0
+      ? "Ingresa un valor válido"
+      : numericAmount > remaining
+        ? "El pago supera el saldo pendiente"
+        : null;
+
+  const handleSubmit = async () => {
+    if (error) return;
+    try {
+      await addPayment.mutateAsync({
+        id: expense.id,
+        data: { amount: numericAmount, method, date },
+      });
+      toast.success("Pago registrado");
+      onClose();
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, "No se pudo registrar el pago"));
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Agregar pago"
+      size="sm"
+    >
+      <div className="space-y-4">
+        <div className="rounded-lg border border-border/60 bg-muted/30 px-4 py-3 flex items-center justify-between">
+          <span className="text-xs font-semibold text-muted-foreground">
+            Saldo pendiente
+          </span>
+          <span className="text-sm font-bold text-foreground stat-number">
+            {formatCurrency(remaining)}
+          </span>
+        </div>
+
+        <div>
+          <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Valor
+          </label>
+          <input
+            type="number"
+            min={0}
+            step="0.01"
+            placeholder="Valor del pago"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm focus:outline-none focus:border-primary/50"
+          />
+        </div>
+
+        <Select
+          label="Método de pago"
+          value={method}
+          onChange={(e) =>
+            setMethod(e.target.value as ExpensePayment["method"])
+          }
+          options={PAYMENT_METHOD_OPTIONS}
+        />
+
+        <div>
+          <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Fecha
+          </label>
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm focus:outline-none focus:border-primary/50"
+          />
+        </div>
+
+        {error && (
+          <p className="text-xs font-medium text-red-500">{error}</p>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!!error}
+            loading={addPayment.isPending}
+          >
+            Registrar pago
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/expenses/ExpenseFormModal.tsx
+++ b/frontend/src/components/expenses/ExpenseFormModal.tsx
@@ -1,0 +1,432 @@
+"use client";
+
+import { useId, useState } from "react";
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/Button";
+import { Select } from "@/components/ui/Select";
+import { ImageUpload } from "@/components/ui/ImageUpload";
+import {
+  useCreateExpense,
+  useExpenseCategories,
+  useUpdateExpense,
+  useUploadExpenseReceipt,
+} from "@/hooks/useExpenses";
+import { useSuppliers } from "@/hooks/useSuppliers";
+import { usePurchaseOrders } from "@/hooks/usePurchaseOrders";
+import { useToast } from "@/contexts/ToastContext";
+import { getApiErrorMessage } from "@/lib/api";
+import { formatCurrency, getBogotaDateInputValue } from "@/lib/utils";
+import { Plus, Trash2 } from "lucide-react";
+import type { Expense, ExpensePayment } from "@/types";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  expense?: Expense | null;
+}
+
+interface PaymentRow {
+  tempId: string;
+  amount: string;
+  method: ExpensePayment["method"];
+  date: string;
+}
+
+const PAYMENT_METHOD_OPTIONS = [
+  { value: "CASH", label: "Efectivo" },
+  { value: "CARD", label: "Tarjeta" },
+  { value: "TRANSFER", label: "Transferencia" },
+];
+
+function genId() {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+function newRow(): PaymentRow {
+  return {
+    tempId: genId(),
+    amount: "",
+    method: "CASH",
+    date: getBogotaDateInputValue(),
+  };
+}
+
+export function ExpenseFormModal({ isOpen, onClose, expense }: Props) {
+  const toast = useToast();
+  const uid = useId();
+  const createExpense = useCreateExpense();
+  const updateExpense = useUpdateExpense();
+  const uploadReceipt = useUploadExpenseReceipt();
+
+  const { data: categoriesData } = useExpenseCategories();
+  const { data: suppliersData } = useSuppliers({ limit: 200, status: "active" });
+  const { data: ordersData } = usePurchaseOrders({ limit: 200 });
+
+  const categories = categoriesData ?? [];
+  const suppliers = suppliersData?.data ?? [];
+  const orders = ordersData?.data ?? [];
+
+  const [categoryId, setCategoryId] = useState(expense?.categoryId ?? "");
+  const [supplierId, setSupplierId] = useState(expense?.supplierId ?? "");
+  const [purchaseOrderId, setPurchaseOrderId] = useState(
+    expense?.purchaseOrderId ?? "",
+  );
+  const [description, setDescription] = useState(expense?.description ?? "");
+  const [date, setDate] = useState(
+    expense ? expense.date.slice(0, 10) : getBogotaDateInputValue(),
+  );
+  const [total, setTotal] = useState(expense ? String(expense.total) : "");
+  const [rows, setRows] = useState<PaymentRow[]>(() =>
+    expense ? [] : [newRow()],
+  );
+  const [pendingReceiptFile, setPendingReceiptFile] = useState<File | null>(
+    null,
+  );
+
+  const numericTotal = Number(total) || 0;
+  const paymentsSum = rows.reduce(
+    (acc, row) => acc + (Number(row.amount) || 0),
+    0,
+  );
+  const hasValidPayment = rows.some((row) => (Number(row.amount) || 0) > 0);
+  const existingPaymentsSum = expense
+    ? (expense.payments ?? []).reduce(
+        (acc, payment) => acc + (Number(payment.amount) || 0),
+        0,
+      )
+    : 0;
+
+  const error = !categoryId
+    ? "Selecciona una categoría"
+    : !date
+      ? "Selecciona una fecha"
+      : numericTotal <= 0
+        ? "Ingresa un total válido"
+        : expense
+          ? numericTotal < existingPaymentsSum
+            ? "El nuevo total no puede ser menor a los pagos registrados"
+            : null
+          : !hasValidPayment
+            ? "Agrega al menos un pago válido"
+            : paymentsSum > numericTotal
+              ? "El total de pagos supera el total del gasto"
+              : null;
+
+  const handleSubmit = async () => {
+    if (error) return;
+    try {
+      if (expense) {
+        await updateExpense.mutateAsync({
+          id: expense.id,
+          data: {
+            categoryId,
+            supplierId: supplierId || null,
+            purchaseOrderId: purchaseOrderId || null,
+            description: description.trim() || null,
+            date,
+            total: numericTotal,
+          },
+        });
+        toast.success("Gasto actualizado");
+      } else {
+        const created = await createExpense.mutateAsync({
+          categoryId,
+          supplierId: supplierId || undefined,
+          purchaseOrderId: purchaseOrderId || undefined,
+          description: description.trim() || undefined,
+          date,
+          total: numericTotal,
+          payments: rows
+            .filter((row) => (Number(row.amount) || 0) > 0)
+            .map((row) => ({
+              amount: Number(row.amount),
+              method: row.method,
+              date: row.date,
+            })),
+        });
+        if (pendingReceiptFile) {
+          try {
+            await uploadReceipt.mutateAsync({
+              id: created.id,
+              file: pendingReceiptFile,
+            });
+          } catch (err) {
+            toast.error(
+              getApiErrorMessage(
+                err,
+                "El gasto se creó pero no se pudo subir el comprobante",
+              ),
+            );
+          }
+        }
+        toast.success("Gasto registrado");
+      }
+      onClose();
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, "No se pudo guardar el gasto"));
+    }
+  };
+
+  const updateRow = (tempId: string, patch: Partial<PaymentRow>) => {
+    setRows((prev) =>
+      prev.map((row) => (row.tempId === tempId ? { ...row, ...patch } : row)),
+    );
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={expense ? "Editar gasto" : "Nuevo gasto"}
+      size="lg"
+    >
+      <div className="space-y-5">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <Select
+            label="Categoría"
+            value={categoryId}
+            onChange={(e) => setCategoryId(e.target.value)}
+            options={[
+              { value: "", label: "Selecciona una categoría" },
+              ...categories
+                .filter((category) => category.active)
+                .map((category) => ({
+                  value: category.id,
+                  label: category.name,
+                })),
+            ]}
+          />
+
+          <Select
+            label="Proveedor"
+            value={supplierId}
+            onChange={(e) => setSupplierId(e.target.value)}
+            options={[
+              { value: "", label: "Sin proveedor" },
+              ...suppliers.map((supplier) => ({
+                value: supplier.id,
+                label: supplier.name,
+              })),
+            ]}
+          />
+
+          <Select
+            label="Orden de compra"
+            value={purchaseOrderId}
+            onChange={(e) => setPurchaseOrderId(e.target.value)}
+            options={[
+              { value: "", label: "Sin orden de compra" },
+              ...orders.map((order) => ({
+                value: order.id,
+                label: `OC-${order.orderNumber}`,
+              })),
+            ]}
+          />
+
+          <div>
+            <label
+              htmlFor={`${uid}-date`}
+              className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            >
+              Fecha
+            </label>
+            <input
+              id={`${uid}-date`}
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              className="w-full rounded-lg border border-border bg-card px-3 py-2.5 text-sm focus:outline-none focus:border-primary/50"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor={`${uid}-total`}
+              className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            >
+              Total (COP)
+            </label>
+            <input
+              id={`${uid}-total`}
+              type="number"
+              min={0}
+              step="0.01"
+              placeholder="Total del gasto"
+              value={total}
+              onChange={(e) => setTotal(e.target.value)}
+              className="w-full rounded-lg border border-border bg-card px-3 py-2.5 text-sm focus:outline-none focus:border-primary/50"
+            />
+          </div>
+
+          <div className="sm:col-span-2">
+            <label
+              htmlFor={`${uid}-description`}
+              className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            >
+              Descripción
+            </label>
+            <textarea
+              id={`${uid}-description`}
+              rows={2}
+              placeholder="Descripción (opcional)"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm focus:outline-none focus:border-primary/50 resize-none"
+            />
+          </div>
+        </div>
+
+        {!expense && (
+          <div className="rounded-xl border border-border/60 overflow-hidden">
+            <div className="flex items-center justify-between px-4 py-2.5 border-b border-border/60 bg-muted/30">
+              <span className="text-xs font-semibold text-foreground">
+                Pagos
+              </span>
+              <Button
+                size="sm"
+                type="button"
+                variant="secondary"
+                onClick={() => setRows((prev) => [...prev, newRow()])}
+              >
+                <Plus className="w-3.5 h-3.5" /> Agregar pago
+              </Button>
+            </div>
+            <div className="space-y-3 p-4">
+              {rows.map((row, index) => (
+                <div key={row.tempId} className="flex flex-wrap gap-2 items-end">
+                  <div className="min-w-[120px] flex-1">
+                    <label
+                      htmlFor={`${uid}-amount-${row.tempId}`}
+                      className="mb-1 block text-[11px] font-semibold uppercase tracking-wide text-muted-foreground"
+                    >
+                      Valor
+                    </label>
+                    <input
+                      id={`${uid}-amount-${row.tempId}`}
+                      type="number"
+                      min={0}
+                      step="0.01"
+                      placeholder="Valor del pago"
+                      value={row.amount}
+                      onChange={(e) =>
+                        updateRow(row.tempId, { amount: e.target.value })
+                      }
+                      className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm focus:outline-none focus:border-primary/50"
+                    />
+                  </div>
+                  <div>
+                    <label
+                      htmlFor={`${uid}-method-${row.tempId}`}
+                      className="mb-1 block text-[11px] font-semibold uppercase tracking-wide text-muted-foreground"
+                    >
+                      Método
+                    </label>
+                    <select
+                      id={`${uid}-method-${row.tempId}`}
+                      aria-label={`Método de pago ${index + 1}`}
+                      value={row.method}
+                      onChange={(e) =>
+                        updateRow(row.tempId, {
+                          method: e.target.value as ExpensePayment["method"],
+                        })
+                      }
+                      className="rounded-lg border border-border bg-card px-3 py-2 text-sm focus:outline-none focus:border-primary/50"
+                    >
+                      {PAYMENT_METHOD_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label
+                      htmlFor={`${uid}-paydate-${row.tempId}`}
+                      className="mb-1 block text-[11px] font-semibold uppercase tracking-wide text-muted-foreground"
+                    >
+                      Fecha pago
+                    </label>
+                    <input
+                      id={`${uid}-paydate-${row.tempId}`}
+                      type="date"
+                      aria-label="Fecha del pago"
+                      value={row.date}
+                      onChange={(e) =>
+                        updateRow(row.tempId, { date: e.target.value })
+                      }
+                      className="rounded-lg border border-border bg-card px-3 py-2 text-sm focus:outline-none focus:border-primary/50"
+                    />
+                  </div>
+                  <button
+                    type="button"
+                    aria-label="Eliminar pago"
+                    onClick={() =>
+                      setRows((prev) =>
+                        prev.filter((r) => r.tempId !== row.tempId),
+                      )
+                    }
+                    disabled={rows.length === 1}
+                    className="p-2 rounded-lg text-muted-foreground hover:text-rose-500 hover:bg-rose-500/10 disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </div>
+              ))}
+              <p className="text-xs text-muted-foreground">
+                Total de pagos:{" "}
+                <span className="font-bold text-foreground stat-number">
+                  {formatCurrency(paymentsSum)}
+                </span>
+              </p>
+            </div>
+          </div>
+        )}
+
+        <div>
+          <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Comprobante
+          </p>
+          {expense ? (
+            <ImageUpload
+              value={expense.receiptUrl ?? undefined}
+              onChange={() => {}}
+              onUpload={async (file) => {
+                const updated = await uploadReceipt.mutateAsync({
+                  id: expense.id,
+                  file,
+                });
+                return updated.receiptUrl ?? "";
+              }}
+            />
+          ) : (
+            <ImageUpload
+              onChange={() => {}}
+              onUpload={(file) => {
+                setPendingReceiptFile(file);
+                return Promise.resolve(URL.createObjectURL(file));
+              }}
+            />
+          )}
+        </div>
+
+        {error && (
+          <p className="text-xs font-medium text-red-500">{error}</p>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2 border-t border-border/60">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!!error}
+            loading={createExpense.isPending || updateExpense.isPending}
+          >
+            {expense ? "Guardar cambios" : "Registrar gasto"}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/expenses/ExpenseStatusBadge.tsx
+++ b/frontend/src/components/expenses/ExpenseStatusBadge.tsx
@@ -1,0 +1,12 @@
+import { Badge } from "@/components/ui/Badge";
+import type { ExpenseStatus } from "@/types";
+
+export function ExpenseStatusBadge({ status }: { status: ExpenseStatus }) {
+  const isPaid = status === "PAID";
+
+  return (
+    <Badge variant={isPaid ? "success" : "warning"}>
+      {isPaid ? "Pagado" : "Parcial"}
+    </Badge>
+  );
+}

--- a/frontend/src/components/expenses/ExpenseSummaryCards.tsx
+++ b/frontend/src/components/expenses/ExpenseSummaryCards.tsx
@@ -1,0 +1,43 @@
+import { Card } from "@/components/ui/Card";
+import { formatCurrency } from "@/lib/utils";
+import { Wallet } from "lucide-react";
+import type { ExpenseMonthlySummary } from "@/types";
+
+interface Props {
+  month?: string;
+  summary?: ExpenseMonthlySummary;
+}
+
+export function ExpenseSummaryCards({ month, summary }: Props) {
+  return (
+    <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      <Card className="p-5 border-primary/25 bg-primary/5">
+        <div className="flex items-center justify-between">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Total del mes
+          </p>
+          <Wallet className="w-4 h-4 text-primary" />
+        </div>
+        <p className="mt-2 text-2xl font-bold text-foreground stat-number">
+          {formatCurrency(Number(summary?.total ?? 0))}
+        </p>
+        {month && (
+          <p className="mt-1 text-xs text-muted-foreground font-mono">
+            {month}
+          </p>
+        )}
+      </Card>
+
+      {(summary?.categories ?? []).map((category) => (
+        <Card key={category.categoryId} className="p-5">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground truncate">
+            {category.name}
+          </p>
+          <p className="mt-2 text-2xl font-bold text-foreground stat-number">
+            {formatCurrency(Number(category.total ?? 0))}
+          </p>
+        </Card>
+      ))}
+    </section>
+  );
+}

--- a/frontend/src/components/expenses/HistoryModal.tsx
+++ b/frontend/src/components/expenses/HistoryModal.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Modal } from "@/components/ui/Modal";
+import { useExpenseHistory } from "@/hooks/useExpenses";
+import { formatDateTime } from "@/lib/utils";
+import { History } from "lucide-react";
+import type { Expense } from "@/types";
+
+interface Props {
+  expense: Expense;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const ACTION_LABELS: Record<string, string> = {
+  EXPENSE_CREATED: "Gasto creado",
+  EXPENSE_UPDATED: "Gasto actualizado",
+  EXPENSE_PAYMENT_ADDED: "Pago agregado",
+  EXPENSE_DUPLICATED: "Gasto duplicado",
+  EXPENSE_RECEIPT_UPLOADED: "Comprobante subido",
+  EXPENSE_DELETED: "Gasto eliminado",
+};
+
+export function HistoryModal({ expense, isOpen, onClose }: Props) {
+  const { data: entries = [], isLoading } = useExpenseHistory(expense.id);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Historial del gasto"
+      size="md"
+    >
+      {isLoading ? (
+        <div className="flex flex-col items-center justify-center py-10 gap-3">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+          <p className="text-xs text-muted-foreground">Cargando historial...</p>
+        </div>
+      ) : entries.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-10 gap-2">
+          <History className="w-6 h-6 text-muted-foreground/30" />
+          <p className="text-xs text-muted-foreground">
+            Sin movimientos registrados
+          </p>
+        </div>
+      ) : (
+        <ol className="space-y-4">
+          {entries.map((entry) => (
+            <li
+              key={entry.id}
+              className="flex items-start gap-3 rounded-lg border border-border/60 bg-muted/20 px-4 py-3"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold text-foreground">
+                  {ACTION_LABELS[entry.action] ?? entry.action}
+                </p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  {entry.user?.name ?? "—"}
+                </p>
+              </div>
+              <span className="text-xs text-muted-foreground font-mono whitespace-nowrap">
+                {formatDateTime(entry.createdAt)}
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </Modal>
+  );
+}

--- a/frontend/src/components/expenses/add-payment-modal.test.tsx
+++ b/frontend/src/components/expenses/add-payment-modal.test.tsx
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import type { Expense } from "@/types";
+
+const addPaymentMutateAsyncMock = vi.fn();
+const toastSuccessMock = vi.fn();
+const toastErrorMock = vi.fn();
+
+vi.mock("@/components/ui/Modal", () => ({
+  Modal: ({
+    isOpen,
+    title,
+    children,
+  }: {
+    isOpen: boolean;
+    title?: string;
+    children: ReactNode;
+  }) =>
+    isOpen ? (
+      <section>
+        {title ? <h2>{title}</h2> : null}
+        {children}
+      </section>
+    ) : null,
+}));
+
+vi.mock("@/components/ui/Button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/hooks/useExpenses", () => ({
+  useAddExpensePayment: () => ({
+    mutateAsync: addPaymentMutateAsyncMock,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/contexts/ToastContext", () => ({
+  useToast: () => ({
+    success: toastSuccessMock,
+    error: toastErrorMock,
+    info: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {},
+  getApiErrorMessage: () => "Overpayment",
+}));
+
+import { AddPaymentModal } from "./AddPaymentModal";
+
+function makeExpense(): Expense {
+  return {
+    id: "exp-1",
+    organizationId: "org-1",
+    categoryId: "cat-1",
+    supplierId: null,
+    purchaseOrderId: null,
+    description: "Renta agosto",
+    date: "2026-08-01T00:00:00.000Z",
+    total: "500000",
+    status: "PARTIAL",
+    receiptUrl: null,
+    active: true,
+    createdById: "user-1",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    payments: [
+      {
+        id: "pay-1",
+        expenseId: "exp-1",
+        organizationId: "org-1",
+        amount: "300000",
+        method: "CASH",
+        date: "2026-08-01T00:00:00.000Z",
+        createdAt: "2026-08-01T00:00:00.000Z",
+      },
+    ],
+    // Decimal fields arrive as strings at runtime (backend Decimal serialization)
+  } as unknown as Expense;
+}
+
+describe("AddPaymentModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    addPaymentMutateAsyncMock.mockResolvedValue({} as never);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows the remaining balance and submits a valid payment", async () => {
+    const user = userEvent.setup();
+
+    render(<AddPaymentModal expense={makeExpense()} isOpen onClose={vi.fn()} />);
+
+    expect(screen.getByText(/Saldo pendiente/)).toBeTruthy();
+
+    fireEvent.change(screen.getByPlaceholderText("Valor del pago"), {
+      target: { value: "100000" },
+    });
+    await user.click(screen.getByRole("button", { name: /Registrar pago/i }));
+
+    expect(addPaymentMutateAsyncMock).toHaveBeenCalledWith({
+      id: "exp-1",
+      data: {
+        amount: 100000,
+        method: "CASH",
+        date: expect.any(String),
+      },
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith("Pago registrado");
+  });
+
+  it("surfaces an overpayment error before calling the API (EXP-2)", async () => {
+    const user = userEvent.setup();
+
+    render(<AddPaymentModal expense={makeExpense()} isOpen onClose={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Valor del pago"), {
+      target: { value: "300000" },
+    });
+    await user.click(screen.getByRole("button", { name: /Registrar pago/i }));
+
+    expect(
+      screen.getByText("El pago supera el saldo pendiente"),
+    ).toBeInTheDocument();
+    expect(addPaymentMutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a server overpayment rejection through the error toast", async () => {
+    const user = userEvent.setup();
+    addPaymentMutateAsyncMock.mockRejectedValueOnce(new Error("boom"));
+
+    render(<AddPaymentModal expense={makeExpense()} isOpen onClose={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Valor del pago"), {
+      target: { value: "50000" },
+    });
+    await user.click(screen.getByRole("button", { name: /Registrar pago/i }));
+
+    expect(toastErrorMock).toHaveBeenCalledWith("Overpayment");
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/expenses/expense-form-modal.test.tsx
+++ b/frontend/src/components/expenses/expense-form-modal.test.tsx
@@ -1,0 +1,289 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import type { Expense } from "@/types";
+
+const createMutateAsyncMock = vi.fn();
+const updateMutateAsyncMock = vi.fn();
+const uploadReceiptMutateAsyncMock = vi.fn();
+const toastSuccessMock = vi.fn();
+const toastErrorMock = vi.fn();
+
+vi.mock("@/components/ui/Modal", () => ({
+  Modal: ({
+    isOpen,
+    title,
+    children,
+  }: {
+    isOpen: boolean;
+    title?: string;
+    children: ReactNode;
+  }) =>
+    isOpen ? (
+      <section>
+        {title ? <h2>{title}</h2> : null}
+        {children}
+      </section>
+    ) : null,
+}));
+
+vi.mock("@/components/ui/Button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/ImageUpload", () => ({
+  ImageUpload: () => <div>ImageUpload</div>,
+}));
+
+vi.mock("@/hooks/useExpenses", () => ({
+  useExpenseCategories: () => ({
+    data: [
+      {
+        id: "cat-1",
+        organizationId: "org-1",
+        name: "Arriendo",
+        active: true,
+        createdAt: "2026-08-01T00:00:00.000Z",
+        updatedAt: "2026-08-01T00:00:00.000Z",
+      },
+      {
+        id: "cat-2",
+        organizationId: "org-1",
+        name: "Caja menor",
+        active: true,
+        createdAt: "2026-08-01T00:00:00.000Z",
+        updatedAt: "2026-08-01T00:00:00.000Z",
+      },
+    ],
+    isLoading: false,
+  }),
+  useCreateExpense: () => ({
+    mutateAsync: createMutateAsyncMock,
+    isPending: false,
+  }),
+  useUpdateExpense: () => ({
+    mutateAsync: updateMutateAsyncMock,
+    isPending: false,
+  }),
+  useUploadExpenseReceipt: () => ({
+    mutateAsync: uploadReceiptMutateAsyncMock,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/hooks/useSuppliers", () => ({
+  useSuppliers: () => ({ data: { data: [] }, isLoading: false }),
+}));
+
+vi.mock("@/hooks/usePurchaseOrders", () => ({
+  usePurchaseOrders: () => ({ data: { data: [] }, isLoading: false }),
+}));
+
+vi.mock("@/contexts/ToastContext", () => ({
+  useToast: () => ({
+    success: toastSuccessMock,
+    error: toastErrorMock,
+    info: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {},
+  getApiErrorMessage: () => "Error de red",
+}));
+
+import { ExpenseFormModal } from "./ExpenseFormModal";
+
+function makeExpense(): Expense {
+  return {
+    id: "exp-1",
+    organizationId: "org-1",
+    categoryId: "cat-1",
+    category: {
+      id: "cat-1",
+      organizationId: "org-1",
+      name: "Arriendo",
+      active: true,
+      createdAt: "2026-08-01T00:00:00.000Z",
+      updatedAt: "2026-08-01T00:00:00.000Z",
+    },
+    supplierId: null,
+    purchaseOrderId: null,
+    description: "Renta agosto",
+    date: "2026-08-01T00:00:00.000Z",
+    total: "500000",
+    status: "PARTIAL",
+    receiptUrl: null,
+    active: true,
+    createdById: "user-1",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    payments: [
+      {
+        id: "pay-1",
+        expenseId: "exp-1",
+        organizationId: "org-1",
+        amount: "300000",
+        method: "CASH",
+        date: "2026-08-01T00:00:00.000Z",
+        createdAt: "2026-08-01T00:00:00.000Z",
+      },
+    ],
+    // Decimal fields arrive as strings at runtime (backend Decimal serialization)
+  } as unknown as Expense;
+}
+
+describe("ExpenseFormModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createMutateAsyncMock.mockResolvedValue({ id: "exp-1" } as never);
+    updateMutateAsyncMock.mockResolvedValue({} as never);
+    uploadReceiptMutateAsyncMock.mockResolvedValue({} as never);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("submits a create payload with the inline first payment", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpenseFormModal isOpen onClose={vi.fn()} />);
+
+    await user.selectOptions(screen.getByLabelText("Categoría"), "cat-1");
+    fireEvent.change(screen.getByLabelText("Fecha"), {
+      target: { value: "2026-08-10" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Total del gasto"), {
+      target: { value: "500000" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Valor del pago"), {
+      target: { value: "500000" },
+    });
+    await user.click(screen.getByRole("button", { name: /Registrar gasto/i }));
+
+    expect(createMutateAsyncMock).toHaveBeenCalledTimes(1);
+    expect(createMutateAsyncMock).toHaveBeenCalledWith({
+      categoryId: "cat-1",
+      supplierId: undefined,
+      purchaseOrderId: undefined,
+      description: undefined,
+      date: "2026-08-10",
+      total: 500000,
+      payments: [
+        { amount: 500000, method: "CASH", date: expect.any(String) },
+      ],
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith("Gasto registrado");
+  });
+
+  it("blocks submission when there is no valid payment (EXP-1)", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpenseFormModal isOpen onClose={vi.fn()} />);
+
+    await user.selectOptions(screen.getByLabelText("Categoría"), "cat-1");
+    fireEvent.change(screen.getByLabelText("Fecha"), {
+      target: { value: "2026-08-10" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Total del gasto"), {
+      target: { value: "500000" },
+    });
+    await user.click(screen.getByRole("button", { name: /Registrar gasto/i }));
+
+    expect(
+      screen.getByText("Agrega al menos un pago válido"),
+    ).toBeInTheDocument();
+    expect(createMutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks submission when payments exceed the total (EXP-2 overpayment guard)", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpenseFormModal isOpen onClose={vi.fn()} />);
+
+    await user.selectOptions(screen.getByLabelText("Categoría"), "cat-1");
+    fireEvent.change(screen.getByLabelText("Fecha"), {
+      target: { value: "2026-08-10" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Total del gasto"), {
+      target: { value: "100" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Valor del pago"), {
+      target: { value: "200" },
+    });
+    await user.click(screen.getByRole("button", { name: /Registrar gasto/i }));
+
+    expect(
+      screen.getByText("El total de pagos supera el total del gasto"),
+    ).toBeInTheDocument();
+    expect(createMutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it("boots edit mode from the expense snapshot and submits an update", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ExpenseFormModal
+        isOpen
+        expense={makeExpense()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByDisplayValue("Renta agosto")).toBeTruthy();
+
+    fireEvent.change(screen.getByPlaceholderText("Descripción (opcional)"), {
+      target: { value: "Renta septiembre" },
+    });
+    await user.click(screen.getByRole("button", { name: /Guardar cambios/i }));
+
+    expect(updateMutateAsyncMock).toHaveBeenCalledWith({
+      id: "exp-1",
+      data: {
+        categoryId: "cat-1",
+        supplierId: null,
+        purchaseOrderId: null,
+        description: "Renta septiembre",
+        date: "2026-08-01",
+        total: 500000,
+      },
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith("Gasto actualizado");
+  });
+
+  it("blocks an edit whose new total is below the sum of payments (EXP-5)", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ExpenseFormModal
+        isOpen
+        expense={makeExpense()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Total del gasto"), {
+      target: { value: "200000" },
+    });
+    await user.click(screen.getByRole("button", { name: /Guardar cambios/i }));
+
+    expect(
+      screen.getByText("El nuevo total no puede ser menor a los pagos registrados"),
+    ).toBeInTheDocument();
+    expect(updateMutateAsyncMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/expenses/expense-status-badge.test.tsx
+++ b/frontend/src/components/expenses/expense-status-badge.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ExpenseStatusBadge } from "./ExpenseStatusBadge";
+
+describe("ExpenseStatusBadge", () => {
+  it("renders Pagado for PAID", () => {
+    render(<ExpenseStatusBadge status="PAID" />);
+
+    expect(screen.getByText("Pagado")).toBeInTheDocument();
+  });
+
+  it("renders Parcial for PARTIAL", () => {
+    render(<ExpenseStatusBadge status="PARTIAL" />);
+
+    expect(screen.getByText("Parcial")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/expenses/history-modal.test.tsx
+++ b/frontend/src/components/expenses/history-modal.test.tsx
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { Expense, ExpenseAuditEntry } from "@/types";
+
+const useExpenseHistoryMock = vi.fn();
+
+vi.mock("@/components/ui/Modal", () => ({
+  Modal: ({
+    isOpen,
+    title,
+    children,
+  }: {
+    isOpen: boolean;
+    title?: string;
+    children: ReactNode;
+  }) =>
+    isOpen ? (
+      <section>
+        {title ? <h2>{title}</h2> : null}
+        {children}
+      </section>
+    ) : null,
+}));
+
+vi.mock("@/hooks/useExpenses", () => ({
+  useExpenseHistory: (id: string) => useExpenseHistoryMock(id),
+}));
+
+import { HistoryModal } from "./HistoryModal";
+
+const expense = {
+  id: "exp-1",
+  organizationId: "org-1",
+  categoryId: "cat-1",
+  supplierId: null,
+  purchaseOrderId: null,
+  description: "Renta agosto",
+  date: "2026-08-01T00:00:00.000Z",
+  total: "500000",
+  status: "PARTIAL",
+  receiptUrl: null,
+  active: true,
+  createdById: "user-1",
+  createdAt: "2026-08-01T00:00:00.000Z",
+  updatedAt: "2026-08-01T00:00:00.000Z",
+  // Decimal fields arrive as strings at runtime (backend Decimal serialization)
+} as unknown as Expense;
+
+const entries: ExpenseAuditEntry[] = [
+  {
+    id: "a-1",
+    userId: "user-1",
+    action: "EXPENSE_CREATED",
+    resource: "Expense",
+    resourceId: "exp-1",
+    metadata: {},
+    createdAt: "2026-08-01T10:00:00.000Z",
+    organizationId: "org-1",
+    user: { name: "Ana Admin", email: "ana@example.com" },
+  },
+  {
+    id: "a-2",
+    userId: "user-1",
+    action: "EXPENSE_PAYMENT_ADDED",
+    resource: "Expense",
+    resourceId: "exp-1",
+    metadata: {},
+    createdAt: "2026-08-02T10:00:00.000Z",
+    organizationId: "org-1",
+    user: { name: "Ana Admin", email: "ana@example.com" },
+  },
+];
+
+describe("HistoryModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useExpenseHistoryMock.mockReturnValue({
+      data: entries,
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("lists human-readable audit entries with user and date", () => {
+    render(<HistoryModal expense={expense} isOpen onClose={vi.fn()} />);
+
+    expect(useExpenseHistoryMock).toHaveBeenCalledWith("exp-1");
+    expect(screen.getByText("Gasto creado")).toBeInTheDocument();
+    expect(screen.getByText("Pago agregado")).toBeInTheDocument();
+    expect(screen.getAllByText("Ana Admin").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("shows a loading message while history is pending", () => {
+    useExpenseHistoryMock.mockReturnValue({ data: undefined, isLoading: true });
+
+    render(<HistoryModal expense={expense} isOpen onClose={vi.fn()} />);
+
+    expect(screen.getByText(/Cargando historial/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #16

## Chain Context

- Strategy: **Feature Branch Chain** (5 slices) — `chained-pr` contract
- Slice: **5 of 5 (FINAL) — frontend UI** 📍
- Base: `feat/expenses` (tracker, do not merge to main yet)
- Prior dependencies: slice 1 (#9), slice 2 (#11), slice 3 (#13), slice 4 (#15) — all merged
- Follow-up: after this merges, the tracker `feat/expenses` gets its final PR to main
- Out of scope: none — this closes the module

```
master
  └─ feat/expenses (tracker)
       ├─ feat/expenses-unit-1 (merged #9)
       ├─ feat/expenses-unit-2 (merged #11)
       ├─ feat/expenses-unit-3 (merged #13)
       ├─ feat/expenses-unit-4 (merged #15)
       └─ feat/expenses-unit-5 📍
```

## Summary

- `frontend/src/app/expenses/page.tsx`: Salidas page — monthly summary cards (total + per category), expense list with filters (month, category, supplier, status, search), pagination, export Excel/CSV, and full row actions (create, edit, delete, add payment, duplicate, history, receipt upload) with ConfirmDialogs
- `ExpenseFormModal`: create/edit with inline first payment, overpayment guard, deferred receipt upload (create mode)
- `AddPaymentModal`: client-side overpayment guard + server 400 surfaced as toast
- `HistoryModal`: audit history per expense
- `ExpenseSummaryCards` + `ExpenseStatusBadge`
- Built on existing UI primitives (`Modal`, `Input`, `Select`, `Button`, `Card`, `Badge`, `ConfirmDialog`, `ImageUpload`) and `cn()`, with `formatCurrency`/`formatDate` (es-CO) and `getApiErrorMessage`

## Changes

| File | Change |
|------|--------|
| `frontend/src/app/expenses/page.tsx` | Salidas page |
| `frontend/src/components/expenses/ExpenseFormModal.tsx` | Create/edit form modal |
| `frontend/src/components/expenses/AddPaymentModal.tsx` | Add-payment modal |
| `frontend/src/components/expenses/HistoryModal.tsx` | History modal |
| `frontend/src/components/expenses/ExpenseSummaryCards.tsx` | Month summary cards |
| `frontend/src/components/expenses/ExpenseStatusBadge.tsx` | Status badge |
| `frontend/src/app/expenses/expenses-page.evidence.test.tsx` | Page evidence tests |
| `frontend/src/components/expenses/*.test.tsx` | Component tests |

## Test Plan

- [x] Frontend suite: **143 passed / 5 failed** — the 5 failures are the pre-existing baseline (pos scanner ×2, sales `cn` mock ×2, admin spinner ×1), verified unchanged
- [x] RED→GREEN: 5 new suites (12/12 components, 22/22 page)
- [x] Scoped ESLint clean on new files; `tsc` clean for new files
- [x] Backend untouched (405/405 baseline intact)

## Contributor Checklist

- [x] Issue linked (`Closes #16`)
- [x] Conventional commits, no `Co-Authored-By`
- [x] Tests kept with the work unit
- [x] N/A shellcheck (no shell scripts changed)
