### PR TITLE
feat(expenses): Salidas module - final integration (tracker to master)

### DIFF
--- a/backend/prisma/migrations/20260815000000_add_expenses/migration.sql
+++ b/backend/prisma/migrations/20260815000000_add_expenses/migration.sql
@@ -1,0 +1,94 @@
+-- CreateEnum
+CREATE TYPE "ExpensePaymentStatus" AS ENUM ('PARTIAL', 'PAID');
+
+-- CreateTable
+CREATE TABLE "ExpenseCategory" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ExpenseCategory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Expense" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "categoryId" TEXT NOT NULL,
+    "supplierId" TEXT,
+    "purchaseOrderId" TEXT,
+    "description" TEXT,
+    "date" TIMESTAMP(3) NOT NULL,
+    "total" DECIMAL(12,2) NOT NULL,
+    "status" "ExpensePaymentStatus" NOT NULL,
+    "receiptUrl" TEXT,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Expense_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ExpensePayment" (
+    "id" TEXT NOT NULL,
+    "expenseId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "amount" DECIMAL(12,2) NOT NULL,
+    "method" "PaymentMethod" NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ExpensePayment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ExpenseCategory_organizationId_name_key" ON "ExpenseCategory"("organizationId", "name");
+
+-- CreateIndex
+CREATE INDEX "ExpenseCategory_organizationId_active_idx" ON "ExpenseCategory"("organizationId", "active");
+
+-- CreateIndex
+CREATE INDEX "Expense_organizationId_date_idx" ON "Expense"("organizationId", "date");
+
+-- CreateIndex
+CREATE INDEX "Expense_organizationId_categoryId_idx" ON "Expense"("organizationId", "categoryId");
+
+-- CreateIndex
+CREATE INDEX "ExpensePayment_organizationId_expenseId_idx" ON "ExpensePayment"("organizationId", "expenseId");
+
+-- AddForeignKey
+ALTER TABLE "ExpenseCategory" ADD CONSTRAINT "ExpenseCategory_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Expense" ADD CONSTRAINT "Expense_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Expense" ADD CONSTRAINT "Expense_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "ExpenseCategory"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Expense" ADD CONSTRAINT "Expense_supplierId_fkey" FOREIGN KEY ("supplierId") REFERENCES "Supplier"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Expense" ADD CONSTRAINT "Expense_purchaseOrderId_fkey" FOREIGN KEY ("purchaseOrderId") REFERENCES "PurchaseOrder"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Expense" ADD CONSTRAINT "Expense_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ExpensePayment" ADD CONSTRAINT "ExpensePayment_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ExpensePayment" ADD CONSTRAINT "ExpensePayment_expenseId_fkey" FOREIGN KEY ("expenseId") REFERENCES "Expense"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Data backfill: five default expense categories (Spanish) for every existing organization
+INSERT INTO "ExpenseCategory" ("id", "organizationId", "name", "active", "createdAt", "updatedAt")
+SELECT gen_random_uuid(), o."id", n."name", TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM "Organization" AS o
+CROSS JOIN (
+    VALUES ('Arriendo'), ('Pago mensual'), ('Seguridad'), ('Salida de empleados'), ('Caja menor')
+) AS n("name");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -28,6 +28,9 @@ model Organization {
   cashRegisters      CashRegister[]
   categories         Category[]
   customers          Customer[]
+  expenseCategories  ExpenseCategory[]
+  expensePayments    ExpensePayment[]
+  expenses           Expense[]
   inventoryMovements InventoryMovement[]
   sequences          OrganizationSequence[]
   users              OrganizationUser[]
@@ -56,6 +59,7 @@ model User {
   tokenVersion       Int                 @default(0)
   isSuperAdmin       Boolean             @default(false)
   auditLogs          AuditLog[]
+  expensesCreated    Expense[]           @relation("ExpenseCreatedBy")
   inventoryMovements InventoryMovement[]
   organizationUsers  OrganizationUser[]
   purchaseOrders     PurchaseOrder[]
@@ -329,6 +333,7 @@ model Supplier {
   createdAt      DateTime        @default(now())
   updatedAt      DateTime        @updatedAt
   organizationId String
+  expenses       Expense[]
   preferredBy    Product[]       @relation("PreferredSupplier")
   purchaseOrders PurchaseOrder[]
   organization   Organization    @relation(fields: [organizationId], references: [id], onDelete: Cascade)
@@ -358,6 +363,7 @@ model PurchaseOrder {
   createdBy      User                @relation(fields: [createdById], references: [id])
   organization   Organization        @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   supplier       Supplier            @relation(fields: [supplierId], references: [id])
+  expenses       Expense[]
   items          PurchaseOrderItem[]
 
   @@unique([organizationId, orderNumber])
@@ -418,6 +424,60 @@ model PaymentRecord {
   @@index([organizationId, date])
 }
 
+model ExpenseCategory {
+  id             String       @id @default(uuid())
+  organizationId String
+  name           String
+  active         Boolean      @default(true)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  expenses       Expense[]
+
+  @@unique([organizationId, name])
+  @@index([organizationId, active])
+}
+
+model Expense {
+  id              String              @id @default(uuid())
+  organizationId  String
+  categoryId      String
+  supplierId      String?
+  purchaseOrderId String?
+  description     String?
+  date            DateTime
+  total           Decimal             @db.Decimal(12, 2)
+  status          ExpensePaymentStatus
+  receiptUrl      String?
+  active          Boolean             @default(true)
+  createdById     String
+  createdAt       DateTime            @default(now())
+  updatedAt       DateTime            @updatedAt
+  organization    Organization        @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  category        ExpenseCategory     @relation(fields: [categoryId], references: [id])
+  supplier        Supplier?           @relation(fields: [supplierId], references: [id], onDelete: SetNull)
+  purchaseOrder   PurchaseOrder?      @relation(fields: [purchaseOrderId], references: [id], onDelete: SetNull)
+  createdBy       User                @relation("ExpenseCreatedBy", fields: [createdById], references: [id])
+  payments        ExpensePayment[]
+
+  @@index([organizationId, date])
+  @@index([organizationId, categoryId])
+}
+
+model ExpensePayment {
+  id             String        @id @default(uuid())
+  expenseId      String
+  organizationId String
+  amount         Decimal       @db.Decimal(12, 2)
+  method         PaymentMethod
+  date           DateTime
+  createdAt      DateTime      @default(now())
+  organization   Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  expense        Expense       @relation(fields: [expenseId], references: [id], onDelete: Cascade)
+
+  @@index([organizationId, expenseId])
+}
+
 enum OrgStatus {
   TRIAL
   ACTIVE
@@ -464,6 +524,11 @@ enum PaymentMethod {
   CASH
   CARD
   TRANSFER
+}
+
+enum ExpensePaymentStatus {
+  PARTIAL
+  PAID
 }
 
 enum PaymentRecordStatus {

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,6 +1,7 @@
 import { PrismaClient, Prisma, OrgRole, PlanType, OrgStatus, BillingStatus } from '@prisma/client';
 import * as bcrypt from 'bcryptjs';
 import { faker } from '@faker-js/faker';
+import { DEFAULT_EXPENSE_CATEGORY_NAMES } from '../src/expenses/default-expense-categories';
 
 const prisma = new PrismaClient();
 
@@ -345,6 +346,19 @@ async function createDemoSales(
   });
 }
 
+async function createDemoExpenseCategories(orgId: string): Promise<number> {
+  const result = await prisma.expenseCategory.createMany({
+    data: DEFAULT_EXPENSE_CATEGORY_NAMES.map((name) => ({
+      name,
+      organizationId: orgId,
+    })),
+    skipDuplicates: true,
+  });
+
+  console.log(`  🏷️  ${result.count} categorías de salidas creadas`);
+  return result.count;
+}
+
 async function seedDemoOrganization(
   name: string,
   slug: string,
@@ -362,6 +376,9 @@ async function seedDemoOrganization(
   // Categorías
   const categoryCount = plan === PlanType.PRO ? 10 : 5;
   const categoryIds = await createDemoCategories(orgId, categoryCount);
+
+  // Categorías de salidas
+  await createDemoExpenseCategories(orgId);
 
   // Productos
   const productCount = plan === PlanType.PRO ? 30 : 20;

--- a/backend/src/admin/admin.service.spec.ts
+++ b/backend/src/admin/admin.service.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { AdminService } from './admin.service';
 import { OrgRole, OrgStatus, PlanType } from '@prisma/client';
+import { DEFAULT_EXPENSE_CATEGORY_NAMES } from '../expenses/default-expense-categories';
 
 describe('AdminService', () => {
   let service: AdminService;
@@ -47,6 +48,9 @@ describe('AdminService', () => {
     cashRegister: {
       create: jest.fn(),
       findMany: jest.fn(),
+    },
+    expenseCategory: {
+      createMany: jest.fn(),
     },
     refreshToken: {
       updateMany: jest.fn(),
@@ -175,6 +179,39 @@ describe('AdminService', () => {
       expect(prismaMock.cashRegister.create).toHaveBeenCalled();
       expect(result.tempPassword).toBeUndefined();
       expect(result.message).toContain('Existing user assigned');
+    });
+
+    it('seeds the five default expense categories inside the creation transaction', async () => {
+      prismaMock.organization.findFirst.mockResolvedValue(null);
+      prismaMock.organization.create.mockResolvedValue({
+        id: 'org-1',
+        name: 'Test Org',
+        slug: 'test-org',
+        plan: PlanType.BASIC,
+        status: OrgStatus.TRIAL,
+      });
+      prismaMock.organizationSequence.createMany.mockResolvedValue({
+        count: 2,
+      });
+      prismaMock.cashRegister.create.mockResolvedValue({
+        id: 'cr-1',
+        organizationId: 'org-1',
+        name: 'Caja Principal',
+        isDefault: true,
+      });
+      prismaMock.expenseCategory.createMany.mockResolvedValue({ count: 5 });
+
+      await service.createOrganization({
+        name: 'Test Org',
+        slug: 'test-org',
+      });
+
+      expect(prismaMock.expenseCategory.createMany).toHaveBeenCalledWith({
+        data: DEFAULT_EXPENSE_CATEGORY_NAMES.map((name) => ({
+          name,
+          organizationId: 'org-1',
+        })),
+      });
     });
 
     it('fails if slug already exists', async () => {

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -15,6 +15,7 @@ import { UpdateOrganizationPlanDto } from './dto/update-organization-plan.dto';
 import { OrgRole, OrgStatus, PlanType, Prisma } from '@prisma/client';
 import { PlanLimitService } from '../plan-limits/plan-limits.service';
 import { PLAN_LIMITS, LimitType } from '../plan-limits/plan-limits.constants';
+import { DEFAULT_EXPENSE_CATEGORY_NAMES } from '../expenses/default-expense-categories';
 
 @Injectable()
 export class AdminService {
@@ -103,6 +104,13 @@ export class AdminService {
           name: 'Caja Principal',
           isDefault: true,
         },
+      });
+
+      await tx.expenseCategory.createMany({
+        data: DEFAULT_EXPENSE_CATEGORY_NAMES.map((name) => ({
+          name,
+          organizationId: organization.id,
+        })),
       });
 
       return {

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -27,6 +27,7 @@ import { OrganizationStatusGuard } from './common/guards/organization-status.gua
 import { CashRegistersModule } from './cash-registers/cash-registers.module';
 import { BillingModule } from './billing/billing.module';
 import { ExpenseCategoriesModule } from './expenses/expense-categories.module';
+import { ExpensesModule } from './expenses/expenses.module';
 
 @Module({
   imports: [
@@ -61,6 +62,7 @@ import { ExpenseCategoriesModule } from './expenses/expense-categories.module';
     CashRegistersModule,
     BillingModule,
     ExpenseCategoriesModule,
+    ExpensesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -26,6 +26,7 @@ import { PlanLimitsModule } from './plan-limits/plan-limits.module';
 import { OrganizationStatusGuard } from './common/guards/organization-status.guard';
 import { CashRegistersModule } from './cash-registers/cash-registers.module';
 import { BillingModule } from './billing/billing.module';
+import { ExpenseCategoriesModule } from './expenses/expense-categories.module';
 
 @Module({
   imports: [
@@ -59,6 +60,7 @@ import { BillingModule } from './billing/billing.module';
     PlanLimitsModule,
     CashRegistersModule,
     BillingModule,
+    ExpenseCategoriesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/common/utils/bogota-date.spec.ts
+++ b/backend/src/common/utils/bogota-date.spec.ts
@@ -1,0 +1,39 @@
+import { BadRequestException } from '@nestjs/common';
+import { parseBogotaMonthRange } from './bogota-date';
+
+describe('parseBogotaMonthRange', () => {
+  it('maps a YYYY-MM month to Bogota day boundaries', () => {
+    const { start, end } = parseBogotaMonthRange('2026-08');
+
+    expect(start.toISOString()).toBe('2026-08-01T05:00:00.000Z');
+    expect(end.toISOString()).toBe('2026-09-01T04:59:59.999Z');
+  });
+
+  it('handles the December to January year rollover', () => {
+    const { start, end } = parseBogotaMonthRange('2026-12');
+
+    expect(start.toISOString()).toBe('2026-12-01T05:00:00.000Z');
+    expect(end.toISOString()).toBe('2027-01-01T04:59:59.999Z');
+  });
+
+  it('treats 2026-08-01T05:00Z (midnight in Bogota) as the month start boundary', () => {
+    const { start, end } = parseBogotaMonthRange('2026-08');
+
+    expect(new Date('2026-08-01T05:00:00.000Z').getTime()).toBe(
+      start.getTime(),
+    );
+    expect(new Date('2026-08-01T04:59:59.999Z').getTime()).toBeLessThan(
+      start.getTime(),
+    );
+    expect(new Date('2026-09-01T04:59:59.999Z').getTime()).toBe(end.getTime());
+  });
+
+  it('rejects malformed month strings', () => {
+    expect(() => parseBogotaMonthRange('2026-8')).toThrow(BadRequestException);
+    expect(() => parseBogotaMonthRange('nope')).toThrow(BadRequestException);
+    expect(() => parseBogotaMonthRange('')).toThrow(BadRequestException);
+    expect(() => parseBogotaMonthRange(undefined as never)).toThrow(
+      BadRequestException,
+    );
+  });
+});

--- a/backend/src/common/utils/bogota-date.ts
+++ b/backend/src/common/utils/bogota-date.ts
@@ -1,4 +1,7 @@
+import { BadRequestException } from '@nestjs/common';
+
 const DATE_ONLY_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+const MONTH_ONLY_REGEX = /^\d{4}-\d{2}$/;
 const BOGOTA_OFFSET_UTC_HOURS = 5;
 
 const bogotaDateFormatter = new Intl.DateTimeFormat('en-CA', {
@@ -67,4 +70,23 @@ export function formatDateInBogota(date: Date): string {
   }
 
   return `${year}-${month}-${day}`;
+}
+
+export function parseBogotaMonthRange(month: string): {
+  start: Date;
+  end: Date;
+} {
+  if (!MONTH_ONLY_REGEX.test(month ?? '')) {
+    throw new BadRequestException('El formato del mes debe ser YYYY-MM');
+  }
+
+  const [year, monthIndex] = month.split('-').map(Number);
+  const start = new Date(
+    Date.UTC(year, monthIndex - 1, 1, BOGOTA_OFFSET_UTC_HOURS, 0, 0, 0),
+  );
+  const end = new Date(
+    Date.UTC(year, monthIndex, 1, BOGOTA_OFFSET_UTC_HOURS, 0, 0, 0) - 1,
+  );
+
+  return { start, end };
 }

--- a/backend/src/expenses/default-expense-categories.ts
+++ b/backend/src/expenses/default-expense-categories.ts
@@ -1,0 +1,7 @@
+export const DEFAULT_EXPENSE_CATEGORY_NAMES = [
+  'Arriendo',
+  'Pago mensual',
+  'Seguridad',
+  'Salida de empleados',
+  'Caja menor',
+] as const;

--- a/backend/src/expenses/dto/create-expense-category.dto.ts
+++ b/backend/src/expenses/dto/create-expense-category.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class CreateExpenseCategoryDto {
+  @ApiProperty({ example: 'Servicios públicos' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+}

--- a/backend/src/expenses/dto/create-expense-payment.dto.ts
+++ b/backend/src/expenses/dto/create-expense-payment.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PaymentMethod } from '@prisma/client';
+import { IsDateString, IsEnum, IsNumber, Min } from 'class-validator';
+
+export class CreateExpensePaymentDto {
+  @ApiProperty({ example: 500000, minimum: 0.01 })
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0.01)
+  amount: number;
+
+  @ApiProperty({ enum: PaymentMethod, example: PaymentMethod.CASH })
+  @IsEnum(PaymentMethod)
+  method: PaymentMethod;
+
+  @ApiProperty({ example: '2026-08-15' })
+  @IsDateString()
+  date: string;
+}

--- a/backend/src/expenses/dto/create-expense.dto.ts
+++ b/backend/src/expenses/dto/create-expense.dto.ts
@@ -1,0 +1,53 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsDateString,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { CreateExpensePaymentDto } from './create-expense-payment.dto';
+
+export class CreateExpenseDto {
+  @ApiProperty({ example: 'uuid-category-id' })
+  @IsUUID()
+  categoryId: string;
+
+  @ApiPropertyOptional({ example: 'uuid-supplier-id' })
+  @IsOptional()
+  @IsUUID()
+  supplierId?: string;
+
+  @ApiPropertyOptional({ example: 'uuid-purchase-order-id' })
+  @IsOptional()
+  @IsUUID()
+  purchaseOrderId?: string;
+
+  @ApiPropertyOptional({ example: 'Arriendo agosto' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+
+  @ApiProperty({ example: '2026-08-15' })
+  @IsDateString()
+  date: string;
+
+  @ApiProperty({ example: 500000, minimum: 0.01 })
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0.01)
+  total: number;
+
+  @ApiProperty({ type: [CreateExpensePaymentDto] })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => CreateExpensePaymentDto)
+  payments: CreateExpensePaymentDto[];
+}

--- a/backend/src/expenses/dto/query-expenses.dto.ts
+++ b/backend/src/expenses/dto/query-expenses.dto.ts
@@ -1,0 +1,55 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ExpensePaymentStatus } from '@prisma/client';
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Matches,
+  Min,
+} from 'class-validator';
+
+export class QueryExpensesDto {
+  @ApiPropertyOptional({ example: 1, default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({ example: 10, default: 10 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number;
+
+  @ApiPropertyOptional({ example: '2026-08', pattern: '^\\d{4}-\\d{2}$' })
+  @IsOptional()
+  @Matches(/^\d{4}-\d{2}$/, {
+    message: 'El formato del mes debe ser YYYY-MM',
+  })
+  month?: string;
+
+  @ApiPropertyOptional({ example: 'uuid-category-id' })
+  @IsOptional()
+  @IsUUID()
+  categoryId?: string;
+
+  @ApiPropertyOptional({ example: 'uuid-supplier-id' })
+  @IsOptional()
+  @IsUUID()
+  supplierId?: string;
+
+  @ApiPropertyOptional({ enum: ExpensePaymentStatus })
+  @IsOptional()
+  @IsEnum(ExpensePaymentStatus)
+  status?: ExpensePaymentStatus;
+
+  @ApiPropertyOptional({ example: 'arriendo' })
+  @IsOptional()
+  @IsString()
+  search?: string;
+}

--- a/backend/src/expenses/dto/query-month.dto.ts
+++ b/backend/src/expenses/dto/query-month.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Matches } from 'class-validator';
+
+export class QueryMonthDto {
+  @ApiProperty({ example: '2026-08', pattern: '^\\d{4}-\\d{2}$' })
+  @Matches(/^\d{4}-\d{2}$/, {
+    message: 'El formato del mes debe ser YYYY-MM',
+  })
+  month: string;
+}

--- a/backend/src/expenses/dto/update-expense-category.dto.ts
+++ b/backend/src/expenses/dto/update-expense-category.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateExpenseCategoryDto {
+  @ApiProperty({ required: false, example: 'Servicios públicos' })
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  name?: string;
+}

--- a/backend/src/expenses/dto/update-expense.dto.spec.ts
+++ b/backend/src/expenses/dto/update-expense.dto.spec.ts
@@ -1,0 +1,35 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UpdateExpenseDto } from './update-expense.dto';
+
+describe('UpdateExpenseDto', () => {
+  it('allows null to clear supplierId, purchaseOrderId and description', async () => {
+    const dto = plainToInstance(UpdateExpenseDto, {
+      supplierId: null,
+      purchaseOrderId: null,
+      description: null,
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toEqual([]);
+  });
+
+  it('rejects a non-UUID supplierId', async () => {
+    const dto = plainToInstance(UpdateExpenseDto, { supplierId: 'no-uuid' });
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a non-UUID purchaseOrderId', async () => {
+    const dto = plainToInstance(UpdateExpenseDto, {
+      purchaseOrderId: 'no-uuid',
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/backend/src/expenses/dto/update-expense.dto.ts
+++ b/backend/src/expenses/dto/update-expense.dto.ts
@@ -25,11 +25,11 @@ export class UpdateExpenseDto {
   @IsUUID()
   purchaseOrderId?: string | null;
 
-  @ApiPropertyOptional({ example: 'Arriendo agosto' })
+  @ApiPropertyOptional({ example: 'Arriendo agosto', nullable: true })
   @IsOptional()
   @IsString()
   @MaxLength(500)
-  description?: string;
+  description?: string | null;
 
   @ApiPropertyOptional({ example: '2026-08-15' })
   @IsOptional()

--- a/backend/src/expenses/dto/update-expense.dto.ts
+++ b/backend/src/expenses/dto/update-expense.dto.ts
@@ -1,0 +1,44 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsDateString,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  Min,
+} from 'class-validator';
+
+export class UpdateExpenseDto {
+  @ApiPropertyOptional({ example: 'uuid-category-id' })
+  @IsOptional()
+  @IsUUID()
+  categoryId?: string;
+
+  @ApiPropertyOptional({ example: 'uuid-supplier-id', nullable: true })
+  @IsOptional()
+  @IsUUID()
+  supplierId?: string | null;
+
+  @ApiPropertyOptional({ example: 'uuid-purchase-order-id', nullable: true })
+  @IsOptional()
+  @IsUUID()
+  purchaseOrderId?: string | null;
+
+  @ApiPropertyOptional({ example: 'Arriendo agosto' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+
+  @ApiPropertyOptional({ example: '2026-08-15' })
+  @IsOptional()
+  @IsDateString()
+  date?: string;
+
+  @ApiPropertyOptional({ example: 500000, minimum: 0.01 })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0.01)
+  total?: number;
+}

--- a/backend/src/expenses/expense-categories.controller.spec.ts
+++ b/backend/src/expenses/expense-categories.controller.spec.ts
@@ -1,0 +1,103 @@
+import { ForbiddenException, type ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { OrgRole } from '@prisma/client';
+import { ROLES_KEY } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { ExpenseCategoriesController } from './expense-categories.controller';
+import type { RequestUser } from '../common/interfaces/request-user.interface';
+
+describe('ExpenseCategoriesController', () => {
+  const serviceMock = {
+    findAll: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  const adminUser: RequestUser = {
+    userId: 'user-1',
+    email: 'admin@example.com',
+    organizationId: 'org-1',
+    role: OrgRole.ADMIN,
+    tokenVersion: 1,
+    isSuperAdmin: false,
+  };
+
+  const createContext = (
+    handler: (...args: unknown[]) => unknown,
+    role: OrgRole,
+  ): ExecutionContext =>
+    ({
+      getHandler: () => handler,
+      getClass: () => ExpenseCategoriesController,
+      switchToHttp: () => ({
+        getRequest: () => ({ user: { role } }),
+      }),
+    }) as unknown as ExecutionContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('requires ADMIN on every handler', () => {
+    const controller = new ExpenseCategoriesController(serviceMock as never);
+    const handlers = [
+      controller.findAll,
+      controller.create,
+      controller.update,
+      controller.remove,
+    ];
+
+    for (const handler of handlers) {
+      expect(Reflect.getMetadata(ROLES_KEY, handler)).toEqual([OrgRole.ADMIN]);
+    }
+  });
+
+  it('allows OWNER through RolesGuard because OWNER inherits ADMIN', () => {
+    const controller = new ExpenseCategoriesController(serviceMock as never);
+    const guard = new RolesGuard(new Reflector());
+
+    expect(
+      guard.canActivate(createContext(controller.findAll, OrgRole.OWNER)),
+    ).toBe(true);
+  });
+
+  it('denies CASHIER access through RolesGuard', () => {
+    const controller = new ExpenseCategoriesController(serviceMock as never);
+    const guard = new RolesGuard(new Reflector());
+
+    expect(() =>
+      guard.canActivate(createContext(controller.findAll, OrgRole.CASHIER)),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('delegates list/create/update/remove with organizationId from token only', async () => {
+    const controller = new ExpenseCategoriesController(serviceMock as never);
+    const body = { name: 'Servicios' };
+    const category = {
+      id: 'c1',
+      name: 'Servicios',
+      organizationId: 'org-1',
+    };
+
+    serviceMock.findAll.mockResolvedValue([category]);
+    serviceMock.create.mockResolvedValue(category);
+    serviceMock.update.mockResolvedValue(category);
+    serviceMock.remove.mockResolvedValue({ ...category, active: false });
+
+    await expect(controller.findAll(adminUser)).resolves.toEqual([category]);
+    await expect(controller.create(body, adminUser)).resolves.toEqual(category);
+    await expect(controller.update('c1', body, adminUser)).resolves.toEqual(
+      category,
+    );
+    await expect(controller.remove('c1', adminUser)).resolves.toEqual({
+      ...category,
+      active: false,
+    });
+
+    expect(serviceMock.findAll).toHaveBeenCalledWith('org-1');
+    expect(serviceMock.create).toHaveBeenCalledWith(body, 'org-1');
+    expect(serviceMock.update).toHaveBeenCalledWith('c1', body, 'org-1');
+    expect(serviceMock.remove).toHaveBeenCalledWith('c1', 'org-1');
+  });
+});

--- a/backend/src/expenses/expense-categories.controller.ts
+++ b/backend/src/expenses/expense-categories.controller.ts
@@ -1,0 +1,71 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { OrgRole } from '@prisma/client';
+import { JwtAuthGuard } from '../auth/jwt.strategy';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { Roles } from '../common/decorators/roles.decorator';
+import { OrganizationRequiredGuard } from '../common/guards/organization-required.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
+import type { RequestUser } from '../common/interfaces/request-user.interface';
+import { ExpenseCategoriesService } from './expense-categories.service';
+import { CreateExpenseCategoryDto } from './dto/create-expense-category.dto';
+import { UpdateExpenseCategoryDto } from './dto/update-expense-category.dto';
+
+@ApiTags('Expense Categories')
+@Controller('expense-categories')
+@UseGuards(JwtAuthGuard, RolesGuard, OrganizationRequiredGuard)
+@UseInterceptors(AdminOrganizationInterceptor)
+@ApiBearerAuth()
+export class ExpenseCategoriesController {
+  constructor(
+    private readonly expenseCategoriesService: ExpenseCategoriesService,
+  ) {}
+
+  @Get()
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Listar categorías de salidas de la organización' })
+  findAll(@CurrentUser() user: RequestUser) {
+    return this.expenseCategoriesService.findAll(user.organizationId);
+  }
+
+  @Post()
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Crear una categoría de salidas' })
+  create(
+    @Body() dto: CreateExpenseCategoryDto,
+    @CurrentUser() user: RequestUser,
+  ) {
+    return this.expenseCategoriesService.create(dto, user.organizationId);
+  }
+
+  @Patch(':id')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Actualizar una categoría de salidas' })
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdateExpenseCategoryDto,
+    @CurrentUser() user: RequestUser,
+  ) {
+    return this.expenseCategoriesService.update(id, dto, user.organizationId);
+  }
+
+  @Delete(':id')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({
+    summary: 'Desactivar una categoría de salidas (borrado lógico)',
+  })
+  remove(@Param('id') id: string, @CurrentUser() user: RequestUser) {
+    return this.expenseCategoriesService.remove(id, user.organizationId);
+  }
+}

--- a/backend/src/expenses/expense-categories.module.ts
+++ b/backend/src/expenses/expense-categories.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { OrganizationRequiredGuard } from '../common/guards/organization-required.guard';
+import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
+import { ExpenseCategoriesController } from './expense-categories.controller';
+import { ExpenseCategoriesService } from './expense-categories.service';
+
+@Module({
+  controllers: [ExpenseCategoriesController],
+  providers: [
+    ExpenseCategoriesService,
+    OrganizationRequiredGuard,
+    AdminOrganizationInterceptor,
+  ],
+  exports: [ExpenseCategoriesService],
+})
+export class ExpenseCategoriesModule {}

--- a/backend/src/expenses/expense-categories.service.spec.ts
+++ b/backend/src/expenses/expense-categories.service.spec.ts
@@ -1,0 +1,216 @@
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  DEFAULT_EXPENSE_CATEGORY_NAMES,
+  ExpenseCategoriesService,
+} from './expense-categories.service';
+
+describe('ExpenseCategoriesService', () => {
+  let service: ExpenseCategoriesService;
+  const orgId = 'org-1';
+
+  const prismaMock = {
+    expenseCategory: {
+      count: jest.fn(),
+      createMany: jest.fn(),
+      create: jest.fn(),
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ExpenseCategoriesService(prismaMock as never);
+  });
+
+  describe('ensureDefaultCategories', () => {
+    it('seeds the five Spanish defaults when the org has zero categories', async () => {
+      prismaMock.expenseCategory.count.mockResolvedValue(0);
+      prismaMock.expenseCategory.createMany.mockResolvedValue({ count: 5 });
+
+      const result = await service.ensureDefaultCategories(orgId);
+
+      expect(prismaMock.expenseCategory.count).toHaveBeenCalledWith({
+        where: { organizationId: orgId },
+      });
+      expect(prismaMock.expenseCategory.createMany).toHaveBeenCalledWith({
+        data: DEFAULT_EXPENSE_CATEGORY_NAMES.map((name) => ({
+          name,
+          organizationId: orgId,
+        })),
+        skipDuplicates: true,
+      });
+      expect(result).toBe(5);
+    });
+
+    it('is idempotent: does nothing when the org already has categories', async () => {
+      prismaMock.expenseCategory.count.mockResolvedValue(3);
+
+      const result = await service.ensureDefaultCategories(orgId);
+
+      expect(prismaMock.expenseCategory.createMany).not.toHaveBeenCalled();
+      expect(result).toBe(0);
+    });
+  });
+
+  describe('findAll', () => {
+    it('ensures defaults lazily and lists org-scoped active categories', async () => {
+      prismaMock.expenseCategory.count.mockResolvedValue(5);
+      prismaMock.expenseCategory.findMany.mockResolvedValue([
+        { id: 'c1', name: 'Arriendo', active: true, organizationId: orgId },
+      ]);
+
+      const result = await service.findAll(orgId);
+
+      expect(prismaMock.expenseCategory.count).toHaveBeenCalledWith({
+        where: { organizationId: orgId },
+      });
+      expect(prismaMock.expenseCategory.findMany).toHaveBeenCalledWith({
+        where: { organizationId: orgId, active: true },
+        orderBy: { name: 'asc' },
+      });
+      expect(result).toHaveLength(1);
+    });
+
+    it('throws BadRequestException when organizationId is missing', async () => {
+      await expect(service.findAll(undefined)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('create', () => {
+    it('creates a category scoped to the organization', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue(null);
+      prismaMock.expenseCategory.create.mockResolvedValue({
+        id: 'c1',
+        name: 'Servicios',
+        organizationId: orgId,
+        active: true,
+      });
+
+      const result = await service.create({ name: 'Servicios' }, orgId);
+
+      expect(prismaMock.expenseCategory.findFirst).toHaveBeenCalledWith({
+        where: { name: 'Servicios', organizationId: orgId },
+      });
+      expect(prismaMock.expenseCategory.create).toHaveBeenCalledWith({
+        data: { name: 'Servicios', organizationId: orgId },
+      });
+      expect(result.name).toBe('Servicios');
+    });
+
+    it('rejects duplicate names within the same organization (409)', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue({ id: 'c1' });
+
+      await expect(service.create({ name: 'Arriendo' }, orgId)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('allows the same name in another organization', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue(null);
+      prismaMock.expenseCategory.create.mockResolvedValue({
+        id: 'c2',
+        name: 'Arriendo',
+        organizationId: 'org-2',
+      });
+
+      const result = await service.create({ name: 'Arriendo' }, 'org-2');
+
+      expect(prismaMock.expenseCategory.findFirst).toHaveBeenCalledWith({
+        where: { name: 'Arriendo', organizationId: 'org-2' },
+      });
+      expect(result.organizationId).toBe('org-2');
+    });
+
+    it('throws BadRequestException when organizationId is missing', async () => {
+      await expect(service.create({ name: 'X' }, undefined)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('updates a category within the organization', async () => {
+      prismaMock.expenseCategory.findFirst
+        .mockResolvedValueOnce({
+          id: 'c1',
+          name: 'Arriendo',
+          organizationId: orgId,
+        })
+        .mockResolvedValueOnce(null);
+      prismaMock.expenseCategory.update.mockResolvedValue({
+        id: 'c1',
+        name: 'Arriendo Nómina',
+        active: true,
+      });
+
+      const result = await service.update(
+        'c1',
+        { name: 'Arriendo Nómina' },
+        orgId,
+      );
+
+      expect(prismaMock.expenseCategory.update).toHaveBeenCalledWith({
+        where: { id: 'c1' },
+        data: { name: 'Arriendo Nómina' },
+      });
+      expect(result.name).toBe('Arriendo Nómina');
+    });
+
+    it('throws NotFoundException when category is not in the organization', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.update('nope', { name: 'X' }, orgId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects renaming to a duplicate name within the org (409)', async () => {
+      prismaMock.expenseCategory.findFirst
+        .mockResolvedValueOnce({ id: 'c1' })
+        .mockResolvedValueOnce({ id: 'c2' });
+
+      await expect(
+        service.update('c1', { name: 'Seguridad' }, orgId),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('remove', () => {
+    it('soft-deletes the category, keeping expense references intact', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue({
+        id: 'c1',
+        active: true,
+      });
+      prismaMock.expenseCategory.update.mockResolvedValue({
+        id: 'c1',
+        active: false,
+      });
+
+      const result = await service.remove('c1', orgId);
+
+      expect(prismaMock.expenseCategory.update).toHaveBeenCalledWith({
+        where: { id: 'c1' },
+        data: { active: false },
+      });
+      expect(prismaMock.expenseCategory.delete).not.toHaveBeenCalled();
+      expect(result.active).toBe(false);
+    });
+
+    it('throws NotFoundException when category is not in the organization', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue(null);
+
+      await expect(service.remove('nope', orgId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/backend/src/expenses/expense-categories.service.ts
+++ b/backend/src/expenses/expense-categories.service.ts
@@ -1,0 +1,135 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateExpenseCategoryDto } from './dto/create-expense-category.dto';
+import { UpdateExpenseCategoryDto } from './dto/update-expense-category.dto';
+import { DEFAULT_EXPENSE_CATEGORY_NAMES } from './default-expense-categories';
+
+export { DEFAULT_EXPENSE_CATEGORY_NAMES };
+
+@Injectable()
+export class ExpenseCategoriesService {
+  constructor(private prisma: PrismaService) {}
+
+  async ensureDefaultCategories(organizationId: string): Promise<number> {
+    const count = await this.prisma.expenseCategory.count({
+      where: { organizationId },
+    });
+
+    if (count > 0) {
+      return 0;
+    }
+
+    const result = await this.prisma.expenseCategory.createMany({
+      data: DEFAULT_EXPENSE_CATEGORY_NAMES.map((name) => ({
+        name,
+        organizationId,
+      })),
+      skipDuplicates: true,
+    });
+
+    return result.count;
+  }
+
+  async findAll(organizationId: string | undefined) {
+    if (!organizationId) {
+      throw new BadRequestException(
+        'Organization ID is required for this operation',
+      );
+    }
+
+    await this.ensureDefaultCategories(organizationId);
+
+    return this.prisma.expenseCategory.findMany({
+      where: { organizationId, active: true },
+      orderBy: { name: 'asc' },
+    });
+  }
+
+  async create(
+    dto: CreateExpenseCategoryDto,
+    organizationId: string | undefined,
+  ) {
+    if (!organizationId) {
+      throw new BadRequestException(
+        'Organization ID is required for this operation',
+      );
+    }
+
+    const existing = await this.prisma.expenseCategory.findFirst({
+      where: { name: dto.name, organizationId },
+    });
+
+    if (existing) {
+      throw new ConflictException(
+        'Ya existe una categoría de salidas con ese nombre',
+      );
+    }
+
+    return this.prisma.expenseCategory.create({
+      data: { name: dto.name, organizationId },
+    });
+  }
+
+  async update(
+    id: string,
+    dto: UpdateExpenseCategoryDto,
+    organizationId: string | undefined,
+  ) {
+    if (!organizationId) {
+      throw new BadRequestException(
+        'Organization ID is required for this operation',
+      );
+    }
+
+    const category = await this.prisma.expenseCategory.findFirst({
+      where: { id, organizationId },
+    });
+
+    if (!category) {
+      throw new NotFoundException('Categoría de salidas no encontrada');
+    }
+
+    if (dto.name) {
+      const existing = await this.prisma.expenseCategory.findFirst({
+        where: { name: dto.name, organizationId },
+      });
+
+      if (existing && existing.id !== id) {
+        throw new ConflictException(
+          'Ya existe una categoría de salidas con ese nombre',
+        );
+      }
+    }
+
+    return this.prisma.expenseCategory.update({
+      where: { id },
+      data: dto,
+    });
+  }
+
+  async remove(id: string, organizationId: string | undefined) {
+    if (!organizationId) {
+      throw new BadRequestException(
+        'Organization ID is required for this operation',
+      );
+    }
+
+    const category = await this.prisma.expenseCategory.findFirst({
+      where: { id, organizationId },
+    });
+
+    if (!category) {
+      throw new NotFoundException('Categoría de salidas no encontrada');
+    }
+
+    return this.prisma.expenseCategory.update({
+      where: { id },
+      data: { active: false },
+    });
+  }
+}

--- a/backend/src/expenses/expenses.controller.spec.ts
+++ b/backend/src/expenses/expenses.controller.spec.ts
@@ -14,6 +14,7 @@ describe('ExpensesController', () => {
     update: jest.fn(),
     remove: jest.fn(),
     addPayment: jest.fn(),
+    getMonthlySummary: jest.fn(),
   };
 
   const adminUser: RequestUser = {
@@ -46,6 +47,7 @@ describe('ExpensesController', () => {
     const handlers = [
       controller.create,
       controller.findAll,
+      controller.getMonthlySummary,
       controller.findOne,
       controller.update,
       controller.remove,
@@ -112,6 +114,26 @@ describe('ExpensesController', () => {
       'org-1',
     );
     expect(serviceMock.remove).toHaveBeenCalledWith('exp-1', 'user-1', 'org-1');
+  });
+
+  it('delegates getMonthlySummary with month and organizationId from the token only', async () => {
+    const controller = new ExpensesController(serviceMock as never);
+    const summary = {
+      month: '2026-08',
+      total: 0,
+      categories: [],
+    };
+
+    serviceMock.getMonthlySummary.mockResolvedValue(summary);
+
+    await expect(
+      controller.getMonthlySummary({ month: '2026-08' }, adminUser),
+    ).resolves.toEqual(summary);
+
+    expect(serviceMock.getMonthlySummary).toHaveBeenCalledWith(
+      '2026-08',
+      'org-1',
+    );
   });
 
   it('delegates addPayment with expense id, payment body, userId and organizationId from the token only', async () => {

--- a/backend/src/expenses/expenses.controller.spec.ts
+++ b/backend/src/expenses/expenses.controller.spec.ts
@@ -1,0 +1,114 @@
+import { ForbiddenException, type ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { OrgRole } from '@prisma/client';
+import { ROLES_KEY } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import type { RequestUser } from '../common/interfaces/request-user.interface';
+import { ExpensesController } from './expenses.controller';
+
+describe('ExpensesController', () => {
+  const serviceMock = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  const adminUser: RequestUser = {
+    userId: 'user-1',
+    email: 'admin@example.com',
+    organizationId: 'org-1',
+    role: OrgRole.ADMIN,
+    tokenVersion: 1,
+    isSuperAdmin: false,
+  };
+
+  const createContext = (
+    handler: (...args: unknown[]) => unknown,
+    role: OrgRole,
+  ): ExecutionContext =>
+    ({
+      getHandler: () => handler,
+      getClass: () => ExpensesController,
+      switchToHttp: () => ({
+        getRequest: () => ({ user: { role } }),
+      }),
+    }) as unknown as ExecutionContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('requires ADMIN on every handler', () => {
+    const controller = new ExpensesController(serviceMock as never);
+    const handlers = [
+      controller.create,
+      controller.findAll,
+      controller.findOne,
+      controller.update,
+      controller.remove,
+    ];
+
+    for (const handler of handlers) {
+      expect(Reflect.getMetadata(ROLES_KEY, handler)).toEqual([OrgRole.ADMIN]);
+    }
+  });
+
+  it('allows OWNER through RolesGuard because OWNER inherits ADMIN', () => {
+    const controller = new ExpensesController(serviceMock as never);
+    const guard = new RolesGuard(new Reflector());
+
+    expect(
+      guard.canActivate(createContext(controller.findAll, OrgRole.OWNER)),
+    ).toBe(true);
+  });
+
+  it('denies CASHIER access through RolesGuard', () => {
+    const controller = new ExpensesController(serviceMock as never);
+    const guard = new RolesGuard(new Reflector());
+
+    expect(() =>
+      guard.canActivate(createContext(controller.findAll, OrgRole.CASHIER)),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('delegates CRUD with organizationId and userId from the token only', async () => {
+    const controller = new ExpensesController(serviceMock as never);
+    const body = { categoryId: 'cat-1', date: '2026-08-15', total: 500 };
+    const expense = { id: 'exp-1', organizationId: 'org-1' };
+
+    serviceMock.create.mockResolvedValue(expense);
+    serviceMock.findAll.mockResolvedValue({ data: [expense], meta: {} });
+    serviceMock.findOne.mockResolvedValue(expense);
+    serviceMock.update.mockResolvedValue(expense);
+    serviceMock.remove.mockResolvedValue({ ...expense, active: false });
+
+    await expect(controller.create(body, adminUser)).resolves.toEqual(expense);
+    await expect(controller.findAll({}, adminUser)).resolves.toEqual({
+      data: [expense],
+      meta: {},
+    });
+    await expect(controller.findOne('exp-1', adminUser)).resolves.toEqual(
+      expense,
+    );
+    await expect(controller.update('exp-1', body, adminUser)).resolves.toEqual(
+      expense,
+    );
+    await expect(controller.remove('exp-1', adminUser)).resolves.toEqual({
+      ...expense,
+      active: false,
+    });
+
+    expect(serviceMock.create).toHaveBeenCalledWith(body, 'user-1', 'org-1');
+    expect(serviceMock.findAll).toHaveBeenCalledWith({}, 'org-1');
+    expect(serviceMock.findOne).toHaveBeenCalledWith('exp-1', 'org-1');
+    expect(serviceMock.update).toHaveBeenCalledWith(
+      'exp-1',
+      body,
+      'user-1',
+      'org-1',
+    );
+    expect(serviceMock.remove).toHaveBeenCalledWith('exp-1', 'user-1', 'org-1');
+  });
+});

--- a/backend/src/expenses/expenses.controller.spec.ts
+++ b/backend/src/expenses/expenses.controller.spec.ts
@@ -16,6 +16,7 @@ describe('ExpensesController', () => {
     addPayment: jest.fn(),
     getMonthlySummary: jest.fn(),
     duplicate: jest.fn(),
+    getHistory: jest.fn(),
   };
 
   const adminUser: RequestUser = {
@@ -54,6 +55,7 @@ describe('ExpensesController', () => {
       controller.remove,
       controller.addPayment,
       controller.duplicate,
+      controller.getHistory,
     ];
 
     for (const handler of handlers) {
@@ -153,6 +155,19 @@ describe('ExpensesController', () => {
       'user-1',
       'org-1',
     );
+  });
+
+  it('delegates getHistory with expense id and organizationId from the token only', async () => {
+    const controller = new ExpensesController(serviceMock as never);
+    const entries = [{ id: 'a-1', action: 'EXPENSE_CREATED' }];
+
+    serviceMock.getHistory.mockResolvedValue(entries);
+
+    await expect(controller.getHistory('exp-1', adminUser)).resolves.toEqual(
+      entries,
+    );
+
+    expect(serviceMock.getHistory).toHaveBeenCalledWith('exp-1', 'org-1');
   });
 
   it('delegates addPayment with expense id, payment body, userId and organizationId from the token only', async () => {

--- a/backend/src/expenses/expenses.controller.spec.ts
+++ b/backend/src/expenses/expenses.controller.spec.ts
@@ -15,6 +15,7 @@ describe('ExpensesController', () => {
     remove: jest.fn(),
     addPayment: jest.fn(),
     getMonthlySummary: jest.fn(),
+    duplicate: jest.fn(),
   };
 
   const adminUser: RequestUser = {
@@ -52,6 +53,7 @@ describe('ExpensesController', () => {
       controller.update,
       controller.remove,
       controller.addPayment,
+      controller.duplicate,
     ];
 
     for (const handler of handlers) {
@@ -132,6 +134,23 @@ describe('ExpensesController', () => {
 
     expect(serviceMock.getMonthlySummary).toHaveBeenCalledWith(
       '2026-08',
+      'org-1',
+    );
+  });
+
+  it('delegates duplicate with expense id, userId and organizationId from the token only', async () => {
+    const controller = new ExpensesController(serviceMock as never);
+    const duplicated = { id: 'exp-2', organizationId: 'org-1', status: 'PAID' };
+
+    serviceMock.duplicate.mockResolvedValue(duplicated);
+
+    await expect(controller.duplicate('exp-1', adminUser)).resolves.toEqual(
+      duplicated,
+    );
+
+    expect(serviceMock.duplicate).toHaveBeenCalledWith(
+      'exp-1',
+      'user-1',
       'org-1',
     );
   });

--- a/backend/src/expenses/expenses.controller.spec.ts
+++ b/backend/src/expenses/expenses.controller.spec.ts
@@ -13,6 +13,7 @@ describe('ExpensesController', () => {
     findOne: jest.fn(),
     update: jest.fn(),
     remove: jest.fn(),
+    addPayment: jest.fn(),
   };
 
   const adminUser: RequestUser = {
@@ -48,6 +49,7 @@ describe('ExpensesController', () => {
       controller.findOne,
       controller.update,
       controller.remove,
+      controller.addPayment,
     ];
 
     for (const handler of handlers) {
@@ -110,5 +112,24 @@ describe('ExpensesController', () => {
       'org-1',
     );
     expect(serviceMock.remove).toHaveBeenCalledWith('exp-1', 'user-1', 'org-1');
+  });
+
+  it('delegates addPayment with expense id, payment body, userId and organizationId from the token only', async () => {
+    const controller = new ExpensesController(serviceMock as never);
+    const payment = { amount: 100000, method: 'CASH', date: '2026-08-20' };
+    const expense = { id: 'exp-1', organizationId: 'org-1', status: 'PAID' };
+
+    serviceMock.addPayment.mockResolvedValue(expense);
+
+    await expect(
+      controller.addPayment('exp-1', payment, adminUser),
+    ).resolves.toEqual(expense);
+
+    expect(serviceMock.addPayment).toHaveBeenCalledWith(
+      'exp-1',
+      payment,
+      'user-1',
+      'org-1',
+    );
   });
 });

--- a/backend/src/expenses/expenses.controller.spec.ts
+++ b/backend/src/expenses/expenses.controller.spec.ts
@@ -17,6 +17,7 @@ describe('ExpensesController', () => {
     getMonthlySummary: jest.fn(),
     duplicate: jest.fn(),
     getHistory: jest.fn(),
+    uploadReceipt: jest.fn(),
   };
 
   const adminUser: RequestUser = {
@@ -56,6 +57,7 @@ describe('ExpensesController', () => {
       controller.addPayment,
       controller.duplicate,
       controller.getHistory,
+      controller.uploadReceipt,
     ];
 
     for (const handler of handlers) {
@@ -168,6 +170,28 @@ describe('ExpensesController', () => {
     );
 
     expect(serviceMock.getHistory).toHaveBeenCalledWith('exp-1', 'org-1');
+  });
+
+  it('delegates uploadReceipt with expense id, file, userId and organizationId from the token only', async () => {
+    const controller = new ExpensesController(serviceMock as never);
+    const file = {
+      buffer: Buffer.from('fake'),
+      originalname: 'receipt.jpg',
+    } as unknown as Express.Multer.File;
+    const updated = { id: 'exp-1', receiptUrl: 'https://cloud.example/r1.jpg' };
+
+    serviceMock.uploadReceipt.mockResolvedValue(updated);
+
+    await expect(
+      controller.uploadReceipt('exp-1', adminUser, file),
+    ).resolves.toEqual(updated);
+
+    expect(serviceMock.uploadReceipt).toHaveBeenCalledWith(
+      'exp-1',
+      file,
+      'user-1',
+      'org-1',
+    );
   });
 
   it('delegates addPayment with expense id, payment body, userId and organizationId from the token only', async () => {

--- a/backend/src/expenses/expenses.controller.ts
+++ b/backend/src/expenses/expenses.controller.ts
@@ -121,11 +121,7 @@ export class ExpensesController {
   @Roles(OrgRole.ADMIN)
   @ApiOperation({ summary: 'Duplicar una salida (recurrencia manual)' })
   duplicate(@Param('id') id: string, @CurrentUser() user: RequestUser) {
-    return this.expensesService.duplicate(
-      id,
-      user.userId,
-      user.organizationId,
-    );
+    return this.expensesService.duplicate(id, user.userId, user.organizationId);
   }
 
   @Post(':id/upload')

--- a/backend/src/expenses/expenses.controller.ts
+++ b/backend/src/expenses/expenses.controller.ts
@@ -100,6 +100,17 @@ export class ExpensesController {
     );
   }
 
+  @Post(':id/duplicate')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Duplicar una salida (recurrencia manual)' })
+  duplicate(@Param('id') id: string, @CurrentUser() user: RequestUser) {
+    return this.expensesService.duplicate(
+      id,
+      user.userId,
+      user.organizationId,
+    );
+  }
+
   @Delete(':id')
   @Roles(OrgRole.ADMIN)
   @ApiOperation({ summary: 'Desactivar una salida (borrado lógico)' })

--- a/backend/src/expenses/expenses.controller.ts
+++ b/backend/src/expenses/expenses.controller.ts
@@ -3,14 +3,24 @@ import {
   Controller,
   Delete,
   Get,
+  HttpStatus,
   Param,
+  ParseFilePipeBuilder,
   Patch,
   Post,
   Query,
+  UploadedFile,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { FileInterceptor } from '@nestjs/platform-express';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { OrgRole } from '@prisma/client';
 import { JwtAuthGuard } from '../auth/jwt.strategy';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
@@ -113,6 +123,43 @@ export class ExpensesController {
   duplicate(@Param('id') id: string, @CurrentUser() user: RequestUser) {
     return this.expensesService.duplicate(
       id,
+      user.userId,
+      user.organizationId,
+    );
+  }
+
+  @Post(':id/upload')
+  @Roles(OrgRole.ADMIN)
+  @UseInterceptors(FileInterceptor('image'))
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        image: {
+          type: 'string',
+          format: 'binary',
+        },
+      },
+    },
+  })
+  @ApiOperation({ summary: 'Adjuntar comprobante a una salida' })
+  uploadReceipt(
+    @Param('id') id: string,
+    @CurrentUser() user: RequestUser,
+    @UploadedFile(
+      new ParseFilePipeBuilder()
+        .addFileTypeValidator({ fileType: /(jpg|jpeg|png|gif|webp|pdf)$/ })
+        .addMaxSizeValidator({ maxSize: 5 * 1024 * 1024 })
+        .build({
+          errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+        }),
+    )
+    file: Express.Multer.File,
+  ) {
+    return this.expensesService.uploadReceipt(
+      id,
+      file,
       user.userId,
       user.organizationId,
     );

--- a/backend/src/expenses/expenses.controller.ts
+++ b/backend/src/expenses/expenses.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { OrgRole } from '@prisma/client';
+import { JwtAuthGuard } from '../auth/jwt.strategy';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { Roles } from '../common/decorators/roles.decorator';
+import { OrganizationRequiredGuard } from '../common/guards/organization-required.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
+import type { RequestUser } from '../common/interfaces/request-user.interface';
+import { CreateExpenseDto } from './dto/create-expense.dto';
+import { QueryExpensesDto } from './dto/query-expenses.dto';
+import { UpdateExpenseDto } from './dto/update-expense.dto';
+import { ExpensesService } from './expenses.service';
+
+@ApiTags('Expenses')
+@Controller('expenses')
+@UseGuards(JwtAuthGuard, RolesGuard, OrganizationRequiredGuard)
+@UseInterceptors(AdminOrganizationInterceptor)
+@ApiBearerAuth()
+export class ExpensesController {
+  constructor(private readonly expensesService: ExpensesService) {}
+
+  @Post()
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Crear una salida con su primer pago' })
+  create(@Body() dto: CreateExpenseDto, @CurrentUser() user: RequestUser) {
+    return this.expensesService.create(dto, user.userId, user.organizationId);
+  }
+
+  @Get()
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Listar salidas de la organización' })
+  findAll(@Query() query: QueryExpensesDto, @CurrentUser() user: RequestUser) {
+    return this.expensesService.findAll(query, user.organizationId);
+  }
+
+  @Get(':id')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Obtener una salida por ID' })
+  findOne(@Param('id') id: string, @CurrentUser() user: RequestUser) {
+    return this.expensesService.findOne(id, user.organizationId);
+  }
+
+  @Patch(':id')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Actualizar una salida' })
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdateExpenseDto,
+    @CurrentUser() user: RequestUser,
+  ) {
+    return this.expensesService.update(
+      id,
+      dto,
+      user.userId,
+      user.organizationId,
+    );
+  }
+
+  @Delete(':id')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Desactivar una salida (borrado lógico)' })
+  remove(@Param('id') id: string, @CurrentUser() user: RequestUser) {
+    return this.expensesService.remove(id, user.userId, user.organizationId);
+  }
+}

--- a/backend/src/expenses/expenses.controller.ts
+++ b/backend/src/expenses/expenses.controller.ts
@@ -68,6 +68,13 @@ export class ExpensesController {
     return this.expensesService.findOne(id, user.organizationId);
   }
 
+  @Get(':id/history')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Ver historial de cambios de una salida' })
+  getHistory(@Param('id') id: string, @CurrentUser() user: RequestUser) {
+    return this.expensesService.getHistory(id, user.organizationId);
+  }
+
   @Patch(':id')
   @Roles(OrgRole.ADMIN)
   @ApiOperation({ summary: 'Actualizar una salida' })

--- a/backend/src/expenses/expenses.controller.ts
+++ b/backend/src/expenses/expenses.controller.ts
@@ -22,6 +22,7 @@ import type { RequestUser } from '../common/interfaces/request-user.interface';
 import { CreateExpenseDto } from './dto/create-expense.dto';
 import { CreateExpensePaymentDto } from './dto/create-expense-payment.dto';
 import { QueryExpensesDto } from './dto/query-expenses.dto';
+import { QueryMonthDto } from './dto/query-month.dto';
 import { UpdateExpenseDto } from './dto/update-expense.dto';
 import { ExpensesService } from './expenses.service';
 
@@ -45,6 +46,19 @@ export class ExpensesController {
   @ApiOperation({ summary: 'Listar salidas de la organización' })
   findAll(@Query() query: QueryExpensesDto, @CurrentUser() user: RequestUser) {
     return this.expensesService.findAll(query, user.organizationId);
+  }
+
+  @Get('summary/monthly')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Resumen mensual de salidas por categoría' })
+  getMonthlySummary(
+    @Query() query: QueryMonthDto,
+    @CurrentUser() user: RequestUser,
+  ) {
+    return this.expensesService.getMonthlySummary(
+      query.month,
+      user.organizationId,
+    );
   }
 
   @Get(':id')

--- a/backend/src/expenses/expenses.controller.ts
+++ b/backend/src/expenses/expenses.controller.ts
@@ -20,6 +20,7 @@ import { RolesGuard } from '../common/guards/roles.guard';
 import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
 import type { RequestUser } from '../common/interfaces/request-user.interface';
 import { CreateExpenseDto } from './dto/create-expense.dto';
+import { CreateExpensePaymentDto } from './dto/create-expense-payment.dto';
 import { QueryExpensesDto } from './dto/query-expenses.dto';
 import { UpdateExpenseDto } from './dto/update-expense.dto';
 import { ExpensesService } from './expenses.service';
@@ -62,6 +63,22 @@ export class ExpensesController {
     @CurrentUser() user: RequestUser,
   ) {
     return this.expensesService.update(
+      id,
+      dto,
+      user.userId,
+      user.organizationId,
+    );
+  }
+
+  @Post(':id/payments')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Registrar un pago adicional a una salida' })
+  addPayment(
+    @Param('id') id: string,
+    @Body() dto: CreateExpensePaymentDto,
+    @CurrentUser() user: RequestUser,
+  ) {
+    return this.expensesService.addPayment(
       id,
       dto,
       user.userId,

--- a/backend/src/expenses/expenses.module.ts
+++ b/backend/src/expenses/expenses.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { OrganizationRequiredGuard } from '../common/guards/organization-required.guard';
+import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
+import { ExpensesController } from './expenses.controller';
+import { ExpensesService } from './expenses.service';
+
+@Module({
+  controllers: [ExpensesController],
+  providers: [
+    ExpensesService,
+    OrganizationRequiredGuard,
+    AdminOrganizationInterceptor,
+  ],
+  exports: [ExpensesService],
+})
+export class ExpensesModule {}

--- a/backend/src/expenses/expenses.module.ts
+++ b/backend/src/expenses/expenses.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
+import { CloudinaryModule } from '../cloudinary/cloudinary.module';
 import { OrganizationRequiredGuard } from '../common/guards/organization-required.guard';
 import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
 import { ExpensesController } from './expenses.controller';
 import { ExpensesService } from './expenses.service';
 
 @Module({
+  imports: [CloudinaryModule],
   controllers: [ExpensesController],
   providers: [
     ExpensesService,

--- a/backend/src/expenses/expenses.service.int.spec.ts
+++ b/backend/src/expenses/expenses.service.int.spec.ts
@@ -1,0 +1,301 @@
+import { PrismaClient, Prisma, PlanType } from '@prisma/client';
+import { formatDateInBogota } from '../common/utils/bogota-date';
+import { ExpensesService } from './expenses.service';
+
+const prisma = new PrismaClient();
+
+const cloudinaryServiceMock = {
+  uploadImage: jest.fn(),
+  deleteImage: jest.fn(),
+};
+
+describe('ExpensesService — Integration (Isolation + Payments + Summary)', () => {
+  let service: ExpensesService;
+  let orgAId: string;
+  let orgBId: string;
+  let userAId: string;
+  let userBId: string;
+  let catArriendoId: string;
+  let catCajaMenorId: string;
+  let catOrgBId: string;
+
+  const buildCreateDto = (
+    categoryId: string,
+    overrides: Partial<{
+      date: string | Date;
+      total: number;
+      payments: { amount: number; method: 'CASH' | 'CARD' | 'TRANSFER'; date: string }[];
+      description: string;
+    }> = {},
+  ) => ({
+    categoryId,
+    description: overrides.description ?? 'Gasto de integración',
+    date: (overrides.date ?? '2026-08-15') as string,
+    total: overrides.total ?? 500000,
+    payments: overrides.payments ?? [
+      { amount: overrides.total ?? 500000, method: 'CASH' as const, date: '2026-08-15' },
+    ],
+  });
+
+  beforeAll(async () => {
+    service = new ExpensesService(
+      prisma as never,
+      cloudinaryServiceMock as never,
+    );
+
+    const [orgA, orgB] = await Promise.all([
+      prisma.organization.create({
+        data: {
+          name: 'Expenses INT Org A',
+          slug: 'expenses-int-a-' + Date.now(),
+          plan: PlanType.BASIC,
+          active: true,
+        },
+      }),
+      prisma.organization.create({
+        data: {
+          name: 'Expenses INT Org B',
+          slug: 'expenses-int-b-' + Date.now(),
+          plan: PlanType.BASIC,
+          active: true,
+        },
+      }),
+    ]);
+    orgAId = orgA.id;
+    orgBId = orgB.id;
+
+    const [userA, userB] = await Promise.all([
+      prisma.user.create({
+        data: {
+          email: 'expenses-int-user-a@example.com',
+          password: 'hash',
+          name: 'Test User A',
+          tokenVersion: 0,
+        },
+      }),
+      prisma.user.create({
+        data: {
+          email: 'expenses-int-user-b@example.com',
+          password: 'hash',
+          name: 'Test User B',
+          tokenVersion: 0,
+        },
+      }),
+    ]);
+    userAId = userA.id;
+    userBId = userB.id;
+
+    const [catArriendo, catCajaMenor, catOrgB] = await Promise.all([
+      prisma.expenseCategory.create({
+        data: { name: 'Arriendo INT', organizationId: orgAId },
+      }),
+      prisma.expenseCategory.create({
+        data: { name: 'Caja menor INT', organizationId: orgAId },
+      }),
+      prisma.expenseCategory.create({
+        data: { name: 'Categoría org B', organizationId: orgBId },
+      }),
+    ]);
+    catArriendoId = catArriendo.id;
+    catCajaMenorId = catCajaMenor.id;
+    catOrgBId = catOrgB.id;
+  });
+
+  afterAll(async () => {
+    await prisma.expensePayment.deleteMany({
+      where: { organizationId: { in: [orgAId, orgBId] } },
+    });
+    await prisma.auditLog.deleteMany({
+      where: { organizationId: { in: [orgAId, orgBId] } },
+    });
+    await prisma.expense.deleteMany({
+      where: { organizationId: { in: [orgAId, orgBId] } },
+    });
+    await prisma.expenseCategory.deleteMany({
+      where: { organizationId: { in: [orgAId, orgBId] } },
+    });
+    await prisma.user.deleteMany({
+      where: { id: { in: [userAId, userBId] } },
+    });
+    await prisma.organization.deleteMany({
+      where: { id: { in: [orgAId, orgBId] } },
+    });
+    await prisma.$disconnect();
+  });
+
+  it('isolates organizations: cross-org reads 404 and lists never leak', async () => {
+    const created = await service.create(
+      buildCreateDto(catArriendoId),
+      userAId,
+      orgAId,
+    );
+
+    await expect(service.findOne(created.id, orgBId)).rejects.toThrow(
+      'Salida no encontrada',
+    );
+    await expect(service.getHistory(created.id, orgBId)).rejects.toThrow(
+      'Salida no encontrada',
+    );
+    await expect(
+      service.duplicate(created.id, userBId, orgBId),
+    ).rejects.toThrow('Salida no encontrada');
+
+    const listB = await service.findAll({}, orgBId);
+    expect(listB.data).toHaveLength(0);
+    expect(listB.meta.total).toBe(0);
+
+    const summaryB = await service.getMonthlySummary('2026-08', orgBId);
+    expect(summaryB.total.toString()).toBe('0');
+  });
+
+  it('supports the partial to paid payment flow and rejects overpayment', async () => {
+    const created = await service.create(
+      buildCreateDto(catArriendoId, {
+        total: 500000,
+        payments: [{ amount: 200000, method: 'TRANSFER', date: '2026-08-15' }],
+      }),
+      userAId,
+      orgAId,
+    );
+    expect(created.status).toBe('PARTIAL');
+
+    const paid = await service.addPayment(
+      created.id,
+      { amount: 300000, method: 'CASH', date: '2026-08-16' },
+      userAId,
+      orgAId,
+    );
+    expect(paid.status).toBe('PAID');
+
+    await expect(
+      service.addPayment(
+        created.id,
+        { amount: 1, method: 'CASH', date: '2026-08-17' },
+        userAId,
+        orgAId,
+      ),
+    ).rejects.toThrow(
+      'La suma de los pagos no puede superar el total de la salida',
+    );
+
+    const history = await service.getHistory(created.id, orgAId);
+    expect(history.map((entry) => entry.action)).toEqual([
+      'EXPENSE_CREATED',
+      'EXPENSE_PAYMENT_ADDED',
+    ]);
+  });
+
+  it('summarizes the Bogota month per category, honoring month boundaries and org scope', async () => {
+    await service.create(
+      buildCreateDto(catArriendoId, {
+        description: 'Arriendo junio',
+        date: '2026-06-15',
+        total: 500000,
+        payments: [{ amount: 500000, method: 'CASH', date: '2026-06-15' }],
+      }),
+      userAId,
+      orgAId,
+    );
+    await service.create(
+      buildCreateDto(catArriendoId, {
+        description: 'Inicio de mes (00:00 Bogota)',
+        date: new Date('2026-06-01T05:00:00.000Z'),
+        total: 200000,
+        payments: [
+          { amount: 200000, method: 'CASH', date: '2026-06-01T05:00:00.000Z' },
+        ],
+      }),
+      userAId,
+      orgAId,
+    );
+    await service.create(
+      buildCreateDto(catCajaMenorId, {
+        description: 'Caja menor junio',
+        date: '2026-06-20',
+        total: 300000,
+        payments: [{ amount: 300000, method: 'CASH', date: '2026-06-20' }],
+      }),
+      userAId,
+      orgAId,
+    );
+    await service.create(
+      buildCreateDto(catArriendoId, {
+        description: 'Mayo 31 23:59 Bogota — fuera del mes',
+        date: new Date('2026-06-01T04:59:59.000Z'),
+        total: 999999,
+        payments: [
+          {
+            amount: 999999,
+            method: 'CASH',
+            date: '2026-06-01T04:59:59.000Z',
+          },
+        ],
+      }),
+      userAId,
+      orgAId,
+    );
+    await service.create(
+      buildCreateDto(catOrgBId, {
+        description: 'Gasto de la organización B',
+        date: '2026-06-18',
+        total: 777777,
+        payments: [{ amount: 777777, method: 'CASH', date: '2026-06-18' }],
+      }),
+      userBId,
+      orgBId,
+    );
+
+    const summary = await service.getMonthlySummary('2026-06', orgAId);
+
+    expect(summary.month).toBe('2026-06');
+    expect(summary.total.toString()).toBe('1000000');
+    expect(
+      summary.categories.map((row) => ({
+        categoryId: row.categoryId,
+        name: row.name,
+        total: row.total.toString(),
+      })),
+    ).toEqual([
+      { categoryId: catArriendoId, name: 'Arriendo INT', total: '700000' },
+      { categoryId: catCajaMenorId, name: 'Caja menor INT', total: '300000' },
+    ]);
+  });
+
+  it('duplicates an expense with today Bogota date, copied payments and derived status', async () => {
+    const created = await service.create(
+      buildCreateDto(catArriendoId, {
+        description: 'Original a duplicar',
+        date: '2026-08-10',
+        total: 500000,
+        payments: [
+          { amount: 300000, method: 'CASH', date: '2026-08-10' },
+          { amount: 200000, method: 'TRANSFER', date: '2026-08-11' },
+        ],
+      }),
+      userAId,
+      orgAId,
+    );
+    expect(created.status).toBe('PAID');
+
+    const duplicated = await service.duplicate(created.id, userAId, orgAId);
+
+    expect(duplicated.id).not.toBe(created.id);
+    expect(duplicated.categoryId).toBe(catArriendoId);
+    expect(duplicated.description).toBe('Original a duplicar');
+    expect(duplicated.total.toString()).toBe('500000');
+    expect(duplicated.status).toBe('PAID');
+    expect(duplicated.date.toISOString()).toBe(
+      new Date(formatDateInBogota(new Date())).toISOString(),
+    );
+    expect(duplicated.payments).toHaveLength(2);
+    expect(duplicated.payments.map((payment) => payment.method)).toEqual([
+      'CASH',
+      'TRANSFER',
+    ]);
+
+    const history = await service.getHistory(duplicated.id, orgAId);
+    expect(history.map((entry) => entry.action)).toEqual([
+      'EXPENSE_DUPLICATED',
+    ]);
+  });
+});

--- a/backend/src/expenses/expenses.service.int.spec.ts
+++ b/backend/src/expenses/expenses.service.int.spec.ts
@@ -24,7 +24,11 @@ describe('ExpensesService — Integration (Isolation + Payments + Summary)', () 
     overrides: Partial<{
       date: string | Date;
       total: number;
-      payments: { amount: number; method: 'CASH' | 'CARD' | 'TRANSFER'; date: string }[];
+      payments: {
+        amount: number;
+        method: 'CASH' | 'CARD' | 'TRANSFER';
+        date: string;
+      }[];
       description: string;
     }> = {},
   ) => ({
@@ -33,7 +37,11 @@ describe('ExpensesService — Integration (Isolation + Payments + Summary)', () 
     date: (overrides.date ?? '2026-08-15') as string,
     total: overrides.total ?? 500000,
     payments: overrides.payments ?? [
-      { amount: overrides.total ?? 500000, method: 'CASH' as const, date: '2026-08-15' },
+      {
+        amount: overrides.total ?? 500000,
+        method: 'CASH' as const,
+        date: '2026-08-15',
+      },
     ],
   });
 

--- a/backend/src/expenses/expenses.service.spec.ts
+++ b/backend/src/expenses/expenses.service.spec.ts
@@ -16,6 +16,9 @@ describe('ExpensesService', () => {
       create: jest.fn(),
       update: jest.fn(),
     },
+    expensePayment: {
+      create: jest.fn(),
+    },
     auditLog: {
       create: jest.fn(),
     },
@@ -409,6 +412,167 @@ describe('ExpensesService', () => {
       await expect(
         service.update('exp-x', { description: 'Nuevo' }, userId, orgId),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('clears supplier, purchase order and description links when null is passed', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue({
+        ...buildExisting(),
+        supplierId: 'sup-1',
+        purchaseOrderId: 'po-1',
+      });
+      txMock.expense.update.mockResolvedValue({
+        id: 'exp-1',
+        status: 'PAID',
+        total: new Prisma.Decimal(500000),
+        description: null,
+        supplierId: null,
+        purchaseOrderId: null,
+        date: new Date('2026-08-15T00:00:00.000Z'),
+      });
+
+      const result = await service.update(
+        'exp-1',
+        { supplierId: null, purchaseOrderId: null, description: null },
+        userId,
+        orgId,
+      );
+
+      expect(txMock.expense.update).toHaveBeenCalledWith({
+        where: { id: 'exp-1' },
+        data: expect.objectContaining({
+          supplierId: null,
+          purchaseOrderId: null,
+          description: null,
+        }),
+        include: { category: true, supplier: true, payments: true },
+      });
+      expect(result).toMatchObject({
+        supplierId: null,
+        purchaseOrderId: null,
+        description: null,
+      });
+    });
+  });
+
+  describe('addPayment', () => {
+    const buildExisting = () => ({
+      id: 'exp-1',
+      organizationId: orgId,
+      active: true,
+      total: new Prisma.Decimal(500000),
+      status: 'PARTIAL',
+      payments: [
+        { id: 'pay-1', amount: new Prisma.Decimal(300000) },
+        { id: 'pay-2', amount: new Prisma.Decimal(100000) },
+      ],
+    });
+    const buildPaymentDto = () => ({
+      amount: 100000,
+      method: 'CASH',
+      date: '2026-08-20',
+    });
+
+    it('transitions PARTIAL to PAID inside one transaction when the new payment covers the remaining total', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(buildExisting());
+      txMock.expensePayment.create.mockResolvedValue({ id: 'pay-3' });
+      txMock.expense.update.mockResolvedValue({ id: 'exp-1', status: 'PAID' });
+
+      const result = await service.addPayment(
+        'exp-1',
+        buildPaymentDto(),
+        userId,
+        orgId,
+      );
+
+      expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+      expect(txMock.expensePayment.create).toHaveBeenCalledWith({
+        data: {
+          expenseId: 'exp-1',
+          organizationId: orgId,
+          amount: new Prisma.Decimal(100000),
+          method: 'CASH',
+          date: new Date('2026-08-20'),
+        },
+      });
+      expect(txMock.expense.update).toHaveBeenCalledWith({
+        where: { id: 'exp-1' },
+        data: { status: 'PAID' },
+        include: { category: true, supplier: true, payments: true },
+      });
+      expect(txMock.auditLog.create).toHaveBeenCalledTimes(1);
+      expect(txMock.auditLog.create.mock.calls[0][0].data).toMatchObject({
+        userId,
+        action: 'EXPENSE_PAYMENT_ADDED',
+        resource: 'Expense',
+        resourceId: 'exp-1',
+        organizationId: orgId,
+      });
+      expect(result).toEqual({ id: 'exp-1', status: 'PAID' });
+    });
+
+    it('keeps PARTIAL when the new payment still leaves a remainder', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(buildExisting());
+      txMock.expensePayment.create.mockResolvedValue({ id: 'pay-3' });
+      txMock.expense.update.mockResolvedValue({
+        id: 'exp-1',
+        status: 'PARTIAL',
+      });
+
+      const result = await service.addPayment(
+        'exp-1',
+        { ...buildPaymentDto(), amount: 50000 },
+        userId,
+        orgId,
+      );
+
+      expect(txMock.expense.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { status: 'PARTIAL' } }),
+      );
+      expect(result.status).toBe('PARTIAL');
+    });
+
+    it('rejects a payment that would exceed the total with 400 and never opens a transaction', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(buildExisting());
+
+      await expect(
+        service.addPayment(
+          'exp-1',
+          { ...buildPaymentDto(), amount: 150000 },
+          userId,
+          orgId,
+        ),
+      ).rejects.toThrow(
+        'La suma de los pagos no puede superar el total de la salida',
+      );
+
+      expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException for unknown or cross-org expense ids', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.addPayment('exp-x', buildPaymentDto(), userId, orgId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects payments on an inactive expense with 400 and never opens a transaction', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue({
+        ...buildExisting(),
+        active: false,
+      });
+
+      await expect(
+        service.addPayment('exp-1', buildPaymentDto(), userId, orgId),
+      ).rejects.toThrow('No se pueden registrar pagos en una salida eliminada');
+
+      expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when organizationId is missing', async () => {
+      await expect(
+        service.addPayment('exp-1', buildPaymentDto(), userId, undefined),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/backend/src/expenses/expenses.service.spec.ts
+++ b/backend/src/expenses/expenses.service.spec.ts
@@ -29,9 +29,11 @@ describe('ExpensesService', () => {
       findFirst: jest.fn(),
       findMany: jest.fn(),
       count: jest.fn(),
+      groupBy: jest.fn(),
     },
     expenseCategory: {
       findFirst: jest.fn(),
+      findMany: jest.fn(),
     },
     supplier: {
       findFirst: jest.fn(),
@@ -557,6 +559,81 @@ describe('ExpensesService', () => {
     it('throws BadRequestException when organizationId is missing', async () => {
       await expect(
         service.addPayment('exp-1', buildPaymentDto(), userId, undefined),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('getMonthlySummary', () => {
+    it('returns the month total and per-category breakdown sorted by total desc', async () => {
+      prismaMock.expense.groupBy.mockResolvedValue([
+        { categoryId: 'cat-2', _sum: { total: new Prisma.Decimal(500000) } },
+        { categoryId: 'cat-1', _sum: { total: new Prisma.Decimal(1000000) } },
+      ]);
+      prismaMock.expenseCategory.findMany.mockResolvedValue([
+        { id: 'cat-1', name: 'Arriendo' },
+        { id: 'cat-2', name: 'Caja menor' },
+      ]);
+
+      const result = await service.getMonthlySummary('2026-08', orgId);
+
+      expect(prismaMock.expense.groupBy).toHaveBeenCalledWith({
+        by: ['categoryId'],
+        where: {
+          organizationId: orgId,
+          active: true,
+          date: {
+            gte: new Date('2026-08-01T05:00:00.000Z'),
+            lte: new Date('2026-09-01T04:59:59.999Z'),
+          },
+        },
+        _sum: { total: true },
+      });
+      expect(prismaMock.expenseCategory.findMany).toHaveBeenCalledWith({
+        where: { id: { in: ['cat-2', 'cat-1'] } },
+        select: { id: true, name: true },
+      });
+      expect(result).toEqual({
+        month: '2026-08',
+        total: new Prisma.Decimal(1500000),
+        categories: [
+          {
+            categoryId: 'cat-1',
+            name: 'Arriendo',
+            total: new Prisma.Decimal(1000000),
+          },
+          {
+            categoryId: 'cat-2',
+            name: 'Caja menor',
+            total: new Prisma.Decimal(500000),
+          },
+        ],
+      });
+    });
+
+    it('returns zeros for a month without expenses', async () => {
+      prismaMock.expense.groupBy.mockResolvedValue([]);
+      prismaMock.expenseCategory.findMany.mockResolvedValue([]);
+
+      const result = await service.getMonthlySummary('2026-08', orgId);
+
+      expect(result).toEqual({
+        month: '2026-08',
+        total: new Prisma.Decimal(0),
+        categories: [],
+      });
+    });
+
+    it('rejects malformed month strings with 400', async () => {
+      await expect(
+        service.getMonthlySummary('2026-8', orgId),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(prismaMock.expense.groupBy).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when organizationId is missing', async () => {
+      await expect(
+        service.getMonthlySummary('2026-08', undefined),
       ).rejects.toThrow(BadRequestException);
     });
   });

--- a/backend/src/expenses/expenses.service.spec.ts
+++ b/backend/src/expenses/expenses.service.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
+import { formatDateInBogota } from '../common/utils/bogota-date';
 import {
   ExpensesService,
   deriveExpensePaymentStatus,
@@ -634,6 +635,124 @@ describe('ExpensesService', () => {
     it('throws BadRequestException when organizationId is missing', async () => {
       await expect(
         service.getMonthlySummary('2026-08', undefined),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('duplicate', () => {
+    const buildExisting = () => ({
+      id: 'exp-1',
+      organizationId: orgId,
+      active: true,
+      categoryId: 'cat-1',
+      supplierId: 'sup-1',
+      purchaseOrderId: 'po-1',
+      description: 'Arriendo agosto',
+      total: new Prisma.Decimal(500000),
+      status: 'PARTIAL',
+      payments: [
+        {
+          id: 'pay-1',
+          amount: new Prisma.Decimal(300000),
+          method: 'CASH',
+          date: new Date('2026-08-05T00:00:00.000Z'),
+        },
+        {
+          id: 'pay-2',
+          amount: new Prisma.Decimal(200000),
+          method: 'TRANSFER',
+          date: new Date('2026-08-10T00:00:00.000Z'),
+        },
+      ],
+    });
+
+    it('copies fields and payments into a new expense dated today in Bogota inside one transaction', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(buildExisting());
+      txMock.expense.create.mockResolvedValue({
+        id: 'exp-2',
+        status: 'PAID',
+      });
+
+      const result = await service.duplicate('exp-1', userId, orgId);
+
+      expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+      const createArgs = txMock.expense.create.mock.calls[0][0];
+      expect(createArgs.data).toMatchObject({
+        organizationId: orgId,
+        categoryId: 'cat-1',
+        supplierId: 'sup-1',
+        purchaseOrderId: 'po-1',
+        description: 'Arriendo agosto',
+        total: new Prisma.Decimal(500000),
+        status: 'PAID',
+        createdById: userId,
+        date: new Date(formatDateInBogota(new Date())),
+      });
+      expect(createArgs.data.payments.create).toEqual([
+        {
+          organizationId: orgId,
+          amount: new Prisma.Decimal(300000),
+          method: 'CASH',
+          date: new Date('2026-08-05T00:00:00.000Z'),
+        },
+        {
+          organizationId: orgId,
+          amount: new Prisma.Decimal(200000),
+          method: 'TRANSFER',
+          date: new Date('2026-08-10T00:00:00.000Z'),
+        },
+      ]);
+      expect(txMock.auditLog.create).toHaveBeenCalledTimes(1);
+      expect(txMock.auditLog.create.mock.calls[0][0].data).toMatchObject({
+        userId,
+        action: 'EXPENSE_DUPLICATED',
+        resource: 'Expense',
+        resourceId: 'exp-2',
+        organizationId: orgId,
+      });
+      expect(txMock.auditLog.create.mock.calls[0][0].data.metadata).toEqual(
+        expect.objectContaining({ originalId: 'exp-1' }),
+      );
+      expect(result).toEqual({ id: 'exp-2', status: 'PAID' });
+    });
+
+    it('derives the status from the copied payments sum', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(buildExisting());
+      txMock.expense.create.mockResolvedValue({
+        id: 'exp-2',
+        status: 'PAID',
+      });
+
+      const result = await service.duplicate('exp-1', userId, orgId);
+
+      expect(txMock.expense.create.mock.calls[0][0].data.status).toBe('PAID');
+      expect(result.status).toBe('PAID');
+    });
+
+    it('rejects duplicating an inactive expense with 400 and never opens a transaction', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue({
+        ...buildExisting(),
+        active: false,
+      });
+
+      await expect(service.duplicate('exp-1', userId, orgId)).rejects.toThrow(
+        'No se puede duplicar una salida eliminada',
+      );
+
+      expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException for unknown or cross-org ids', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(null);
+
+      await expect(service.duplicate('exp-x', userId, orgId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws BadRequestException when organizationId is missing', async () => {
+      await expect(
+        service.duplicate('exp-1', userId, undefined),
       ).rejects.toThrow(BadRequestException);
     });
   });

--- a/backend/src/expenses/expenses.service.spec.ts
+++ b/backend/src/expenses/expenses.service.spec.ts
@@ -42,6 +42,9 @@ describe('ExpensesService', () => {
     purchaseOrder: {
       findFirst: jest.fn(),
     },
+    auditLog: {
+      findMany: jest.fn(),
+    },
   };
 
   const buildValidCreateDto = () => ({
@@ -754,6 +757,52 @@ describe('ExpensesService', () => {
       await expect(
         service.duplicate('exp-1', userId, undefined),
       ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('getHistory', () => {
+    it('returns the org-scoped audit entries for the expense ordered ascending', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue({ id: 'exp-1' });
+      prismaMock.auditLog.findMany.mockResolvedValue([
+        { id: 'a-1', action: 'EXPENSE_CREATED' },
+        { id: 'a-2', action: 'EXPENSE_UPDATED' },
+      ]);
+
+      const result = await service.getHistory('exp-1', orgId);
+
+      expect(prismaMock.expense.findFirst).toHaveBeenCalledWith({
+        where: { id: 'exp-1', organizationId: orgId },
+        select: { id: true },
+      });
+      expect(prismaMock.auditLog.findMany).toHaveBeenCalledWith({
+        where: {
+          resource: 'Expense',
+          resourceId: 'exp-1',
+          organizationId: orgId,
+        },
+        orderBy: { createdAt: 'asc' },
+        include: { user: { select: { name: true, email: true } } },
+      });
+      expect(result).toEqual([
+        { id: 'a-1', action: 'EXPENSE_CREATED' },
+        { id: 'a-2', action: 'EXPENSE_UPDATED' },
+      ]);
+    });
+
+    it('throws NotFoundException for unknown or cross-org expense ids without reading the audit log', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(null);
+
+      await expect(service.getHistory('exp-x', orgId)).rejects.toThrow(
+        NotFoundException,
+      );
+
+      expect(prismaMock.auditLog.findMany).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when organizationId is missing', async () => {
+      await expect(service.getHistory('exp-1', undefined)).rejects.toThrow(
+        BadRequestException,
+      );
     });
   });
 

--- a/backend/src/expenses/expenses.service.spec.ts
+++ b/backend/src/expenses/expenses.service.spec.ts
@@ -1,0 +1,449 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import {
+  ExpensesService,
+  buildMonthRange,
+  deriveExpensePaymentStatus,
+} from './expenses.service';
+
+describe('ExpensesService', () => {
+  let service: ExpensesService;
+  const orgId = 'org-1';
+  const userId = 'user-1';
+
+  const txMock = {
+    expense: {
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    auditLog: {
+      create: jest.fn(),
+    },
+  };
+
+  const prismaMock = {
+    $transaction: jest.fn(),
+    expense: {
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+    expenseCategory: {
+      findFirst: jest.fn(),
+    },
+    supplier: {
+      findFirst: jest.fn(),
+    },
+    purchaseOrder: {
+      findFirst: jest.fn(),
+    },
+  };
+
+  const buildValidCreateDto = () => ({
+    categoryId: 'cat-1',
+    supplierId: 'sup-1',
+    purchaseOrderId: 'po-1',
+    description: 'Arriendo agosto',
+    date: '2026-08-15',
+    total: 500000,
+    payments: [{ amount: 500000, method: 'CASH', date: '2026-08-15' }],
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prismaMock.$transaction.mockImplementation(
+      async (callback: (tx: typeof txMock) => unknown) => callback(txMock),
+    );
+    service = new ExpensesService(prismaMock as never);
+  });
+
+  describe('deriveExpensePaymentStatus', () => {
+    it('returns PAID when the payments sum equals the total', () => {
+      expect(
+        deriveExpensePaymentStatus(
+          new Prisma.Decimal(500000),
+          new Prisma.Decimal(500000),
+        ),
+      ).toBe('PAID');
+    });
+
+    it('returns PARTIAL when the payments sum is lower than the total', () => {
+      expect(
+        deriveExpensePaymentStatus(
+          new Prisma.Decimal(500000),
+          new Prisma.Decimal(200000),
+        ),
+      ).toBe('PARTIAL');
+    });
+
+    it('returns PAID when the payments sum covers the total exactly after multiple payments', () => {
+      expect(
+        deriveExpensePaymentStatus(
+          new Prisma.Decimal(500000),
+          new Prisma.Decimal(500000.01),
+        ),
+      ).toBe('PAID');
+    });
+  });
+
+  describe('buildMonthRange', () => {
+    it('maps a YYYY-MM month to Bogota day boundaries', () => {
+      const { start, end } = buildMonthRange('2026-08');
+
+      expect(start.toISOString()).toBe('2026-08-01T05:00:00.000Z');
+      expect(end.toISOString()).toBe('2026-09-01T04:59:59.999Z');
+    });
+
+    it('rejects malformed month strings', () => {
+      expect(() => buildMonthRange('2026-8')).toThrow(BadRequestException);
+      expect(() => buildMonthRange('nope')).toThrow(BadRequestException);
+    });
+  });
+
+  describe('create', () => {
+    it('creates a PAID expense when the first payment equals the total', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue({ id: 'cat-1' });
+      prismaMock.supplier.findFirst.mockResolvedValue({ id: 'sup-1' });
+      prismaMock.purchaseOrder.findFirst.mockResolvedValue({ id: 'po-1' });
+      txMock.expense.create.mockResolvedValue({ id: 'exp-1', status: 'PAID' });
+
+      const result = await service.create(buildValidCreateDto(), userId, orgId);
+
+      expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+      const createArgs = txMock.expense.create.mock.calls[0][0];
+      expect(createArgs.data.status).toBe('PAID');
+      expect(createArgs.data.total).toEqual(new Prisma.Decimal(500000));
+      expect(createArgs.data.createdById).toBe(userId);
+      expect(createArgs.data.organizationId).toBe(orgId);
+      expect(createArgs.data.payments.create).toHaveLength(1);
+      expect(createArgs.data.payments.create[0]).toMatchObject({
+        amount: new Prisma.Decimal(500000),
+        method: 'CASH',
+        date: new Date('2026-08-15'),
+        organizationId: orgId,
+      });
+      expect(txMock.auditLog.create).toHaveBeenCalledTimes(1);
+      const auditArgs = txMock.auditLog.create.mock.calls[0][0];
+      expect(auditArgs.data).toMatchObject({
+        userId,
+        action: 'EXPENSE_CREATED',
+        resource: 'Expense',
+        resourceId: 'exp-1',
+        organizationId: orgId,
+      });
+      expect(result).toEqual({ id: 'exp-1', status: 'PAID' });
+    });
+
+    it('creates a PARTIAL expense when the first payment is lower than the total', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue({ id: 'cat-1' });
+      prismaMock.supplier.findFirst.mockResolvedValue(null);
+      prismaMock.purchaseOrder.findFirst.mockResolvedValue(null);
+      txMock.expense.create.mockResolvedValue({
+        id: 'exp-2',
+        status: 'PARTIAL',
+      });
+
+      const result = await service.create(
+        {
+          ...buildValidCreateDto(),
+          supplierId: undefined,
+          purchaseOrderId: undefined,
+          payments: [
+            { amount: 200000, method: 'TRANSFER', date: '2026-08-15' },
+          ],
+        },
+        userId,
+        orgId,
+      );
+
+      expect(txMock.expense.create.mock.calls[0][0].data.status).toBe(
+        'PARTIAL',
+      );
+      expect(result.status).toBe('PARTIAL');
+    });
+
+    it('rejects zero payments with 400 and never opens a transaction', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue({ id: 'cat-1' });
+      prismaMock.supplier.findFirst.mockResolvedValue({ id: 'sup-1' });
+      prismaMock.purchaseOrder.findFirst.mockResolvedValue({ id: 'po-1' });
+
+      await expect(
+        service.create(
+          { ...buildValidCreateDto(), payments: [] },
+          userId,
+          orgId,
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('rejects a payment that exceeds the total with 400', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue({ id: 'cat-1' });
+      prismaMock.supplier.findFirst.mockResolvedValue({ id: 'sup-1' });
+      prismaMock.purchaseOrder.findFirst.mockResolvedValue({ id: 'po-1' });
+
+      await expect(
+        service.create(
+          {
+            ...buildValidCreateDto(),
+            payments: [{ amount: 600000, method: 'CASH', date: '2026-08-15' }],
+          },
+          userId,
+          orgId,
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('rejects a category that does not belong to the organization with 404', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.create(buildValidCreateDto(), userId, orgId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects a supplier that does not belong to the organization with 404', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue({ id: 'cat-1' });
+      prismaMock.supplier.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.create(buildValidCreateDto(), userId, orgId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects a purchase order that does not belong to the organization with 404', async () => {
+      prismaMock.expenseCategory.findFirst.mockResolvedValue({ id: 'cat-1' });
+      prismaMock.supplier.findFirst.mockResolvedValue({ id: 'sup-1' });
+      prismaMock.purchaseOrder.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.create(buildValidCreateDto(), userId, orgId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BadRequestException when organizationId is missing', async () => {
+      await expect(
+        service.create(buildValidCreateDto(), userId, undefined),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('paginates active org-scoped expenses with filters and related data', async () => {
+      prismaMock.expense.findMany.mockResolvedValue([{ id: 'exp-1' }]);
+      prismaMock.expense.count.mockResolvedValue(42);
+
+      const result = await service.findAll(
+        {
+          page: 2,
+          limit: 10,
+          month: '2026-08',
+          categoryId: 'cat-1',
+          supplierId: 'sup-1',
+          status: 'PARTIAL',
+          search: 'arriendo',
+        },
+        orgId,
+      );
+
+      expect(prismaMock.expense.findMany).toHaveBeenCalledWith({
+        where: {
+          organizationId: orgId,
+          active: true,
+          date: {
+            gte: new Date('2026-08-01T05:00:00.000Z'),
+            lte: new Date('2026-09-01T04:59:59.999Z'),
+          },
+          categoryId: 'cat-1',
+          supplierId: 'sup-1',
+          status: 'PARTIAL',
+          description: { contains: 'arriendo', mode: 'insensitive' },
+        },
+        skip: 10,
+        take: 10,
+        orderBy: { date: 'desc' },
+        include: { category: true, supplier: true, payments: true },
+      });
+      expect(prismaMock.expense.count).toHaveBeenCalledWith({
+        where: expect.objectContaining({ organizationId: orgId, active: true }),
+      });
+      expect(result).toEqual({
+        data: [{ id: 'exp-1' }],
+        meta: { total: 42, page: 2, limit: 10, totalPages: 5 },
+      });
+    });
+
+    it('throws BadRequestException when organizationId is missing', async () => {
+      await expect(service.findAll({}, undefined)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('returns the org-scoped expense with payments, category and supplier', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue({
+        id: 'exp-1',
+        organizationId: orgId,
+      });
+
+      const result = await service.findOne('exp-1', orgId);
+
+      expect(prismaMock.expense.findFirst).toHaveBeenCalledWith({
+        where: { id: 'exp-1', organizationId: orgId },
+        include: {
+          category: true,
+          supplier: true,
+          purchaseOrder: true,
+          payments: { orderBy: { date: 'asc' } },
+        },
+      });
+      expect(result).toEqual({ id: 'exp-1', organizationId: orgId });
+    });
+
+    it('throws NotFoundException for unknown or cross-org ids', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(null);
+
+      await expect(service.findOne('exp-x', orgId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    const buildExisting = () => ({
+      id: 'exp-1',
+      organizationId: orgId,
+      total: new Prisma.Decimal(500000),
+      status: 'PAID',
+      description: 'Arriendo agosto',
+      date: new Date('2026-08-15T00:00:00.000Z'),
+      payments: [{ id: 'pay-1', amount: new Prisma.Decimal(500000) }],
+    });
+
+    it('recomputes status to PARTIAL when the total grows beyond payments', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(buildExisting());
+      txMock.expense.update.mockResolvedValue({
+        id: 'exp-1',
+        status: 'PARTIAL',
+        total: new Prisma.Decimal(800000),
+        description: 'Arriendo agosto',
+        date: new Date('2026-08-15T00:00:00.000Z'),
+      });
+
+      const result = await service.update(
+        'exp-1',
+        { total: 800000 },
+        userId,
+        orgId,
+      );
+
+      expect(txMock.expense.update).toHaveBeenCalledWith({
+        where: { id: 'exp-1' },
+        data: expect.objectContaining({ status: 'PARTIAL' }),
+        include: { category: true, supplier: true, payments: true },
+      });
+      expect(txMock.auditLog.create).toHaveBeenCalledTimes(1);
+      expect(txMock.auditLog.create.mock.calls[0][0].data).toMatchObject({
+        userId,
+        action: 'EXPENSE_UPDATED',
+        resource: 'Expense',
+        resourceId: 'exp-1',
+        organizationId: orgId,
+      });
+      expect(result).toEqual({
+        id: 'exp-1',
+        status: 'PARTIAL',
+        total: new Prisma.Decimal(800000),
+        description: 'Arriendo agosto',
+        date: new Date('2026-08-15T00:00:00.000Z'),
+      });
+    });
+
+    it('keeps PAID when the total shrinks to the payments sum', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(buildExisting());
+      txMock.expense.update.mockResolvedValue({
+        id: 'exp-1',
+        status: 'PAID',
+        total: new Prisma.Decimal(500000),
+        description: 'Arriendo agosto',
+        date: new Date('2026-08-15T00:00:00.000Z'),
+      });
+
+      const result = await service.update(
+        'exp-1',
+        { total: 500000 },
+        userId,
+        orgId,
+      );
+
+      expect(txMock.expense.update.mock.calls[0][0].data.status).toBe('PAID');
+      expect(result.status).toBe('PAID');
+    });
+
+    it('rejects a new total below the payments sum with 400', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(buildExisting());
+
+      await expect(
+        service.update('exp-1', { total: 400000 }, userId, orgId),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('rejects a category that does not belong to the organization with 404', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(buildExisting());
+      prismaMock.expenseCategory.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.update('exp-1', { categoryId: 'cat-x' }, userId, orgId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException for unknown or cross-org ids', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.update('exp-x', { description: 'Nuevo' }, userId, orgId),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('remove', () => {
+    it('soft-deletes with active=false and writes an audit log in the same transaction', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue({
+        id: 'exp-1',
+        organizationId: orgId,
+        total: new Prisma.Decimal(500000),
+      });
+      txMock.expense.update.mockResolvedValue({ id: 'exp-1', active: false });
+
+      const result = await service.remove('exp-1', userId, orgId);
+
+      expect(txMock.expense.update).toHaveBeenCalledWith({
+        where: { id: 'exp-1' },
+        data: { active: false },
+      });
+      expect(txMock.auditLog.create).toHaveBeenCalledTimes(1);
+      expect(txMock.auditLog.create.mock.calls[0][0].data).toMatchObject({
+        userId,
+        action: 'EXPENSE_DELETED',
+        resource: 'Expense',
+        resourceId: 'exp-1',
+        organizationId: orgId,
+      });
+      expect(result).toEqual({ id: 'exp-1', active: false });
+    });
+
+    it('throws NotFoundException for unknown or cross-org ids', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(null);
+
+      await expect(service.remove('exp-x', userId, orgId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/backend/src/expenses/expenses.service.spec.ts
+++ b/backend/src/expenses/expenses.service.spec.ts
@@ -643,9 +643,9 @@ describe('ExpensesService', () => {
     });
 
     it('rejects malformed month strings with 400', async () => {
-      await expect(
-        service.getMonthlySummary('2026-8', orgId),
-      ).rejects.toThrow(BadRequestException);
+      await expect(service.getMonthlySummary('2026-8', orgId)).rejects.toThrow(
+        BadRequestException,
+      );
 
       expect(prismaMock.expense.groupBy).not.toHaveBeenCalled();
     });

--- a/backend/src/expenses/expenses.service.spec.ts
+++ b/backend/src/expenses/expenses.service.spec.ts
@@ -57,12 +57,27 @@ describe('ExpensesService', () => {
     payments: [{ amount: 500000, method: 'CASH', date: '2026-08-15' }],
   });
 
+  const cloudinaryServiceMock = {
+    uploadImage: jest.fn(),
+    deleteImage: jest.fn(),
+  };
+
+  const buildReceiptFile = (): Express.Multer.File =>
+    ({
+      buffer: Buffer.from('fake-receipt'),
+      originalname: 'receipt.jpg',
+      mimetype: 'image/jpeg',
+    }) as unknown as Express.Multer.File;
+
   beforeEach(() => {
     jest.clearAllMocks();
     prismaMock.$transaction.mockImplementation(
       async (callback: (tx: typeof txMock) => unknown) => callback(txMock),
     );
-    service = new ExpensesService(prismaMock as never);
+    service = new ExpensesService(
+      prismaMock as never,
+      cloudinaryServiceMock as never,
+    );
   });
 
   describe('deriveExpensePaymentStatus', () => {
@@ -803,6 +818,128 @@ describe('ExpensesService', () => {
       await expect(service.getHistory('exp-1', undefined)).rejects.toThrow(
         BadRequestException,
       );
+    });
+  });
+
+  describe('uploadReceipt', () => {
+    it('uploads the file to the expense-receipts folder and persists the receipt URL with an audit entry in one transaction', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue({
+        id: 'exp-1',
+        createdById: userId,
+        receiptUrl: null,
+      });
+      cloudinaryServiceMock.uploadImage.mockResolvedValue(
+        'https://cloud.example/expense-receipts/r1.jpg',
+      );
+      txMock.expense.update.mockResolvedValue({
+        id: 'exp-1',
+        receiptUrl: 'https://cloud.example/expense-receipts/r1.jpg',
+      });
+
+      const result = await service.uploadReceipt(
+        'exp-1',
+        buildReceiptFile(),
+        userId,
+        orgId,
+      );
+
+      expect(cloudinaryServiceMock.uploadImage).toHaveBeenCalledWith(
+        buildReceiptFile(),
+        'expense-receipts',
+      );
+      expect(cloudinaryServiceMock.deleteImage).not.toHaveBeenCalled();
+      expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+      expect(txMock.expense.update).toHaveBeenCalledWith({
+        where: { id: 'exp-1' },
+        data: { receiptUrl: 'https://cloud.example/expense-receipts/r1.jpg' },
+        include: { category: true, supplier: true, payments: true },
+      });
+      expect(txMock.auditLog.create).toHaveBeenCalledTimes(1);
+      expect(txMock.auditLog.create.mock.calls[0][0].data).toMatchObject({
+        userId,
+        action: 'EXPENSE_RECEIPT_UPLOADED',
+        resource: 'Expense',
+        resourceId: 'exp-1',
+        organizationId: orgId,
+      });
+      expect(result).toEqual({
+        id: 'exp-1',
+        receiptUrl: 'https://cloud.example/expense-receipts/r1.jpg',
+      });
+    });
+
+    it('best-effort deletes the previous receipt when one exists', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue({
+        id: 'exp-1',
+        createdById: userId,
+        receiptUrl: 'https://cloud.example/expense-receipts/old.jpg',
+      });
+      cloudinaryServiceMock.uploadImage.mockResolvedValue(
+        'https://cloud.example/expense-receipts/new.jpg',
+      );
+      cloudinaryServiceMock.deleteImage.mockResolvedValue(undefined);
+      txMock.expense.update.mockResolvedValue({
+        id: 'exp-1',
+        receiptUrl: 'https://cloud.example/expense-receipts/new.jpg',
+      });
+
+      await service.uploadReceipt('exp-1', buildReceiptFile(), userId, orgId);
+
+      expect(cloudinaryServiceMock.deleteImage).toHaveBeenCalledWith(
+        'https://cloud.example/expense-receipts/old.jpg',
+      );
+    });
+
+    it('ignores a failed deletion of the previous receipt and still persists the new one', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue({
+        id: 'exp-1',
+        createdById: userId,
+        receiptUrl: 'https://cloud.example/expense-receipts/old.jpg',
+      });
+      cloudinaryServiceMock.uploadImage.mockResolvedValue(
+        'https://cloud.example/expense-receipts/new.jpg',
+      );
+      cloudinaryServiceMock.deleteImage.mockRejectedValue(
+        new Error('cloud unreachable'),
+      );
+      txMock.expense.update.mockResolvedValue({
+        id: 'exp-1',
+        receiptUrl: 'https://cloud.example/expense-receipts/new.jpg',
+      });
+
+      const result = await service.uploadReceipt(
+        'exp-1',
+        buildReceiptFile(),
+        userId,
+        orgId,
+      );
+
+      expect(txMock.expense.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: {
+            receiptUrl: 'https://cloud.example/expense-receipts/new.jpg',
+          },
+        }),
+      );
+      expect(result.receiptUrl).toBe(
+        'https://cloud.example/expense-receipts/new.jpg',
+      );
+    });
+
+    it('throws NotFoundException for unknown or cross-org expense ids without uploading', async () => {
+      prismaMock.expense.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.uploadReceipt('exp-x', buildReceiptFile(), userId, orgId),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(cloudinaryServiceMock.uploadImage).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when organizationId is missing', async () => {
+      await expect(
+        service.uploadReceipt('exp-1', buildReceiptFile(), userId, undefined),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/backend/src/expenses/expenses.service.spec.ts
+++ b/backend/src/expenses/expenses.service.spec.ts
@@ -2,7 +2,6 @@ import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import {
   ExpensesService,
-  buildMonthRange,
   deriveExpensePaymentStatus,
 } from './expenses.service';
 
@@ -86,20 +85,6 @@ describe('ExpensesService', () => {
           new Prisma.Decimal(500000.01),
         ),
       ).toBe('PAID');
-    });
-  });
-
-  describe('buildMonthRange', () => {
-    it('maps a YYYY-MM month to Bogota day boundaries', () => {
-      const { start, end } = buildMonthRange('2026-08');
-
-      expect(start.toISOString()).toBe('2026-08-01T05:00:00.000Z');
-      expect(end.toISOString()).toBe('2026-09-01T04:59:59.999Z');
-    });
-
-    it('rejects malformed month strings', () => {
-      expect(() => buildMonthRange('2026-8')).toThrow(BadRequestException);
-      expect(() => buildMonthRange('nope')).toThrow(BadRequestException);
     });
   });
 

--- a/backend/src/expenses/expenses.service.ts
+++ b/backend/src/expenses/expenses.service.ts
@@ -518,6 +518,25 @@ export class ExpensesService {
     });
   }
 
+  async getHistory(id: string, organizationId: string | undefined) {
+    const orgId = this.requireOrganizationId(organizationId);
+
+    const expense = await this.prisma.expense.findFirst({
+      where: { id, organizationId: orgId },
+      select: { id: true },
+    });
+
+    if (!expense) {
+      throw new NotFoundException('Salida no encontrada');
+    }
+
+    return this.prisma.auditLog.findMany({
+      where: { resource: 'Expense', resourceId: id, organizationId: orgId },
+      orderBy: { createdAt: 'asc' },
+      include: { user: { select: { name: true, email: true } } },
+    });
+  }
+
   async remove(id: string, userId: string, organizationId: string | undefined) {
     const orgId = this.requireOrganizationId(organizationId);
 

--- a/backend/src/expenses/expenses.service.ts
+++ b/backend/src/expenses/expenses.service.ts
@@ -1,0 +1,378 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { ExpensePaymentStatus, Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateExpenseDto } from './dto/create-expense.dto';
+import { QueryExpensesDto } from './dto/query-expenses.dto';
+import { UpdateExpenseDto } from './dto/update-expense.dto';
+
+const MONTH_REGEX = /^\d{4}-\d{2}$/;
+const BOGOTA_OFFSET_UTC_HOURS = 5;
+
+export function deriveExpensePaymentStatus(
+  total: Prisma.Decimal,
+  paymentsSum: Prisma.Decimal,
+): ExpensePaymentStatus {
+  return paymentsSum.gte(total) ? 'PAID' : 'PARTIAL';
+}
+
+export function buildMonthRange(month: string): {
+  start: Date;
+  end: Date;
+} {
+  if (!MONTH_REGEX.test(month)) {
+    throw new BadRequestException('El formato del mes debe ser YYYY-MM');
+  }
+
+  const [year, monthIndex] = month.split('-').map(Number);
+  const start = new Date(
+    Date.UTC(year, monthIndex - 1, 1, BOGOTA_OFFSET_UTC_HOURS, 0, 0, 0),
+  );
+  const end = new Date(
+    Date.UTC(year, monthIndex, 1, BOGOTA_OFFSET_UTC_HOURS, 0, 0, 0) - 1,
+  );
+
+  return { start, end };
+}
+
+@Injectable()
+export class ExpensesService {
+  constructor(private prisma: PrismaService) {}
+
+  private requireOrganizationId(organizationId: string | undefined): string {
+    if (!organizationId) {
+      throw new BadRequestException(
+        'Organization ID is required for this operation',
+      );
+    }
+    return organizationId;
+  }
+
+  private async assertCategoryInOrganization(
+    categoryId: string,
+    organizationId: string,
+  ): Promise<void> {
+    const category = await this.prisma.expenseCategory.findFirst({
+      where: { id: categoryId, organizationId },
+    });
+    if (!category) {
+      throw new NotFoundException('Categoría de salidas no encontrada');
+    }
+  }
+
+  private async assertSupplierInOrganization(
+    supplierId: string,
+    organizationId: string,
+  ): Promise<void> {
+    const supplier = await this.prisma.supplier.findFirst({
+      where: { id: supplierId, organizationId },
+    });
+    if (!supplier) {
+      throw new NotFoundException('Proveedor no encontrado');
+    }
+  }
+
+  private async assertPurchaseOrderInOrganization(
+    purchaseOrderId: string,
+    organizationId: string,
+  ): Promise<void> {
+    const purchaseOrder = await this.prisma.purchaseOrder.findFirst({
+      where: { id: purchaseOrderId, organizationId },
+    });
+    if (!purchaseOrder) {
+      throw new NotFoundException('Orden de compra no encontrada');
+    }
+  }
+
+  private sumPayments(payments: { amount: Prisma.Decimal }[]): Prisma.Decimal {
+    return payments.reduce(
+      (sum, payment) => sum.add(payment.amount),
+      new Prisma.Decimal(0),
+    );
+  }
+
+  async create(
+    dto: CreateExpenseDto,
+    userId: string,
+    organizationId: string | undefined,
+  ) {
+    const orgId = this.requireOrganizationId(organizationId);
+
+    await this.assertCategoryInOrganization(dto.categoryId, orgId);
+    if (dto.supplierId) {
+      await this.assertSupplierInOrganization(dto.supplierId, orgId);
+    }
+    if (dto.purchaseOrderId) {
+      await this.assertPurchaseOrderInOrganization(dto.purchaseOrderId, orgId);
+    }
+
+    if (dto.payments.length === 0) {
+      throw new BadRequestException(
+        'Cada salida debe registrarse con al menos un pago',
+      );
+    }
+
+    const total = new Prisma.Decimal(dto.total);
+    const paymentsSum = this.sumPayments(
+      dto.payments.map((payment) => ({
+        amount: new Prisma.Decimal(payment.amount),
+      })),
+    );
+
+    if (paymentsSum.gt(total)) {
+      throw new BadRequestException(
+        'La suma de los pagos no puede superar el total de la salida',
+      );
+    }
+
+    const status = deriveExpensePaymentStatus(total, paymentsSum);
+
+    return this.prisma.$transaction(async (tx) => {
+      const expense = await tx.expense.create({
+        data: {
+          organizationId: orgId,
+          categoryId: dto.categoryId,
+          supplierId: dto.supplierId ?? null,
+          purchaseOrderId: dto.purchaseOrderId ?? null,
+          description: dto.description ?? null,
+          date: new Date(dto.date),
+          total,
+          status,
+          createdById: userId,
+          payments: {
+            create: dto.payments.map((payment) => ({
+              organizationId: orgId,
+              amount: new Prisma.Decimal(payment.amount),
+              method: payment.method,
+              date: new Date(payment.date),
+            })),
+          },
+        },
+        include: { payments: true, category: true, supplier: true },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          userId,
+          action: 'EXPENSE_CREATED',
+          resource: 'Expense',
+          resourceId: expense.id,
+          organizationId: orgId,
+          metadata: {
+            summary: `Salida creada por ${total.toString()}`,
+            total: total.toString(),
+            status,
+            payments: dto.payments.map((payment) => ({
+              amount: new Prisma.Decimal(payment.amount).toString(),
+              method: payment.method,
+              date: payment.date,
+            })),
+            timestamp: new Date().toISOString(),
+          },
+        },
+      });
+
+      return expense;
+    });
+  }
+
+  async findAll(query: QueryExpensesDto, organizationId: string | undefined) {
+    const orgId = this.requireOrganizationId(organizationId);
+
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 10;
+    const skip = (page - 1) * limit;
+
+    const where: Prisma.ExpenseWhereInput = {
+      organizationId: orgId,
+      active: true,
+    };
+
+    if (query.month) {
+      const { start, end } = buildMonthRange(query.month);
+      where.date = { gte: start, lte: end };
+    }
+    if (query.categoryId) {
+      where.categoryId = query.categoryId;
+    }
+    if (query.supplierId) {
+      where.supplierId = query.supplierId;
+    }
+    if (query.status) {
+      where.status = query.status;
+    }
+
+    const search = query.search?.trim();
+    if (search) {
+      where.description = { contains: search, mode: 'insensitive' };
+    }
+
+    const [data, total] = await Promise.all([
+      this.prisma.expense.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: { date: 'desc' },
+        include: { category: true, supplier: true, payments: true },
+      }),
+      this.prisma.expense.count({ where }),
+    ]);
+
+    return {
+      data,
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  async findOne(id: string, organizationId: string | undefined) {
+    const orgId = this.requireOrganizationId(organizationId);
+
+    const expense = await this.prisma.expense.findFirst({
+      where: { id, organizationId: orgId },
+      include: {
+        category: true,
+        supplier: true,
+        purchaseOrder: true,
+        payments: { orderBy: { date: 'asc' } },
+      },
+    });
+
+    if (!expense) {
+      throw new NotFoundException('Salida no encontrada');
+    }
+
+    return expense;
+  }
+
+  async update(
+    id: string,
+    dto: UpdateExpenseDto,
+    userId: string,
+    organizationId: string | undefined,
+  ) {
+    const orgId = this.requireOrganizationId(organizationId);
+
+    const existing = await this.prisma.expense.findFirst({
+      where: { id, organizationId: orgId },
+      include: { payments: true },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Salida no encontrada');
+    }
+
+    if (dto.categoryId) {
+      await this.assertCategoryInOrganization(dto.categoryId, orgId);
+    }
+    if (dto.supplierId) {
+      await this.assertSupplierInOrganization(dto.supplierId, orgId);
+    }
+    if (dto.purchaseOrderId) {
+      await this.assertPurchaseOrderInOrganization(dto.purchaseOrderId, orgId);
+    }
+
+    const newTotal =
+      dto.total !== undefined ? new Prisma.Decimal(dto.total) : existing.total;
+    const paymentsSum = this.sumPayments(existing.payments);
+
+    if (newTotal.lt(paymentsSum)) {
+      throw new BadRequestException(
+        'El nuevo total no puede ser menor que la suma de los pagos registrados',
+      );
+    }
+
+    const status = deriveExpensePaymentStatus(newTotal, paymentsSum);
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.expense.update({
+        where: { id },
+        data: {
+          ...(dto.categoryId !== undefined && { categoryId: dto.categoryId }),
+          ...(dto.supplierId !== undefined && { supplierId: dto.supplierId }),
+          ...(dto.purchaseOrderId !== undefined && {
+            purchaseOrderId: dto.purchaseOrderId,
+          }),
+          ...(dto.description !== undefined && {
+            description: dto.description,
+          }),
+          ...(dto.date !== undefined && { date: new Date(dto.date) }),
+          ...(dto.total !== undefined && { total: newTotal }),
+          status,
+        },
+        include: { category: true, supplier: true, payments: true },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          userId,
+          action: 'EXPENSE_UPDATED',
+          resource: 'Expense',
+          resourceId: id,
+          organizationId: orgId,
+          metadata: {
+            summary: 'Salida actualizada',
+            before: {
+              total: existing.total.toString(),
+              status: existing.status,
+              description: existing.description,
+              date: existing.date.toISOString(),
+            },
+            after: {
+              total: updated.total.toString(),
+              status: updated.status,
+              description: updated.description,
+              date: updated.date.toISOString(),
+            },
+            timestamp: new Date().toISOString(),
+          },
+        },
+      });
+
+      return updated;
+    });
+  }
+
+  async remove(id: string, userId: string, organizationId: string | undefined) {
+    const orgId = this.requireOrganizationId(organizationId);
+
+    const existing = await this.prisma.expense.findFirst({
+      where: { id, organizationId: orgId },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Salida no encontrada');
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.expense.update({
+        where: { id },
+        data: { active: false },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          userId,
+          action: 'EXPENSE_DELETED',
+          resource: 'Expense',
+          resourceId: id,
+          organizationId: orgId,
+          metadata: {
+            summary: 'Salida eliminada (borrado lógico)',
+            total: existing.total.toString(),
+            timestamp: new Date().toISOString(),
+          },
+        },
+      });
+
+      return updated;
+    });
+  }
+}

--- a/backend/src/expenses/expenses.service.ts
+++ b/backend/src/expenses/expenses.service.ts
@@ -212,6 +212,45 @@ export class ExpensesService {
     };
   }
 
+  async getMonthlySummary(month: string, organizationId: string | undefined) {
+    const orgId = this.requireOrganizationId(organizationId);
+    const { start, end } = parseBogotaMonthRange(month);
+
+    const grouped = await this.prisma.expense.groupBy({
+      by: ['categoryId'],
+      where: {
+        organizationId: orgId,
+        active: true,
+        date: { gte: start, lte: end },
+      },
+      _sum: { total: true },
+    });
+
+    const categories = await this.prisma.expenseCategory.findMany({
+      where: { id: { in: grouped.map((row) => row.categoryId) } },
+      select: { id: true, name: true },
+    });
+
+    const namesById = new Map(
+      categories.map((category) => [category.id, category.name]),
+    );
+
+    const rows = grouped
+      .map((row) => ({
+        categoryId: row.categoryId,
+        name: namesById.get(row.categoryId) ?? 'Sin categoría',
+        total: row._sum.total ?? new Prisma.Decimal(0),
+      }))
+      .sort((a, b) => b.total.comparedTo(a.total));
+
+    const total = rows.reduce(
+      (sum, row) => sum.add(row.total),
+      new Prisma.Decimal(0),
+    );
+
+    return { month, total, categories: rows };
+  }
+
   async findOne(id: string, organizationId: string | undefined) {
     const orgId = this.requireOrganizationId(organizationId);
 

--- a/backend/src/expenses/expenses.service.ts
+++ b/backend/src/expenses/expenses.service.ts
@@ -8,6 +8,7 @@ import {
   formatDateInBogota,
   parseBogotaMonthRange,
 } from '../common/utils/bogota-date';
+import { CloudinaryService } from '../cloudinary/cloudinary.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateExpenseDto } from './dto/create-expense.dto';
 import { CreateExpensePaymentDto } from './dto/create-expense-payment.dto';
@@ -23,7 +24,10 @@ export function deriveExpensePaymentStatus(
 
 @Injectable()
 export class ExpensesService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private cloudinaryService: CloudinaryService,
+  ) {}
 
   private requireOrganizationId(organizationId: string | undefined): string {
     if (!organizationId) {
@@ -534,6 +538,61 @@ export class ExpensesService {
       where: { resource: 'Expense', resourceId: id, organizationId: orgId },
       orderBy: { createdAt: 'asc' },
       include: { user: { select: { name: true, email: true } } },
+    });
+  }
+
+  async uploadReceipt(
+    id: string,
+    file: Express.Multer.File,
+    userId: string,
+    organizationId: string | undefined,
+  ) {
+    const orgId = this.requireOrganizationId(organizationId);
+
+    const existing = await this.prisma.expense.findFirst({
+      where: { id, organizationId: orgId },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Salida no encontrada');
+    }
+
+    const receiptUrl = await this.cloudinaryService.uploadImage(
+      file,
+      'expense-receipts',
+    );
+
+    if (existing.receiptUrl) {
+      try {
+        await this.cloudinaryService.deleteImage(existing.receiptUrl);
+      } catch (error) {
+        console.error('Error deleting old receipt:', error);
+      }
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.expense.update({
+        where: { id },
+        data: { receiptUrl },
+        include: { category: true, supplier: true, payments: true },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          userId,
+          action: 'EXPENSE_RECEIPT_UPLOADED',
+          resource: 'Expense',
+          resourceId: id,
+          organizationId: orgId,
+          metadata: {
+            summary: 'Comprobante adjuntado',
+            receiptUrl,
+            timestamp: new Date().toISOString(),
+          },
+        },
+      });
+
+      return updated;
     });
   }
 

--- a/backend/src/expenses/expenses.service.ts
+++ b/backend/src/expenses/expenses.service.ts
@@ -4,39 +4,18 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { ExpensePaymentStatus, Prisma } from '@prisma/client';
+import { parseBogotaMonthRange } from '../common/utils/bogota-date';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateExpenseDto } from './dto/create-expense.dto';
 import { CreateExpensePaymentDto } from './dto/create-expense-payment.dto';
 import { QueryExpensesDto } from './dto/query-expenses.dto';
 import { UpdateExpenseDto } from './dto/update-expense.dto';
 
-const MONTH_REGEX = /^\d{4}-\d{2}$/;
-const BOGOTA_OFFSET_UTC_HOURS = 5;
-
 export function deriveExpensePaymentStatus(
   total: Prisma.Decimal,
   paymentsSum: Prisma.Decimal,
 ): ExpensePaymentStatus {
   return paymentsSum.gte(total) ? 'PAID' : 'PARTIAL';
-}
-
-export function buildMonthRange(month: string): {
-  start: Date;
-  end: Date;
-} {
-  if (!MONTH_REGEX.test(month)) {
-    throw new BadRequestException('El formato del mes debe ser YYYY-MM');
-  }
-
-  const [year, monthIndex] = month.split('-').map(Number);
-  const start = new Date(
-    Date.UTC(year, monthIndex - 1, 1, BOGOTA_OFFSET_UTC_HOURS, 0, 0, 0),
-  );
-  const end = new Date(
-    Date.UTC(year, monthIndex, 1, BOGOTA_OFFSET_UTC_HOURS, 0, 0, 0) - 1,
-  );
-
-  return { start, end };
 }
 
 @Injectable()
@@ -193,7 +172,7 @@ export class ExpensesService {
     };
 
     if (query.month) {
-      const { start, end } = buildMonthRange(query.month);
+      const { start, end } = parseBogotaMonthRange(query.month);
       where.date = { gte: start, lte: end };
     }
     if (query.categoryId) {

--- a/backend/src/expenses/expenses.service.ts
+++ b/backend/src/expenses/expenses.service.ts
@@ -457,7 +457,9 @@ export class ExpensesService {
     }
 
     if (!existing.active) {
-      throw new BadRequestException('No se puede duplicar una salida eliminada');
+      throw new BadRequestException(
+        'No se puede duplicar una salida eliminada',
+      );
     }
 
     if (existing.payments.length === 0) {

--- a/backend/src/expenses/expenses.service.ts
+++ b/backend/src/expenses/expenses.service.ts
@@ -6,6 +6,7 @@ import {
 import { ExpensePaymentStatus, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateExpenseDto } from './dto/create-expense.dto';
+import { CreateExpensePaymentDto } from './dto/create-expense-payment.dto';
 import { QueryExpensesDto } from './dto/query-expenses.dto';
 import { UpdateExpenseDto } from './dto/update-expense.dto';
 
@@ -331,6 +332,80 @@ export class ExpensesService {
               description: updated.description,
               date: updated.date.toISOString(),
             },
+            timestamp: new Date().toISOString(),
+          },
+        },
+      });
+
+      return updated;
+    });
+  }
+
+  async addPayment(
+    id: string,
+    dto: CreateExpensePaymentDto,
+    userId: string,
+    organizationId: string | undefined,
+  ) {
+    const orgId = this.requireOrganizationId(organizationId);
+
+    const existing = await this.prisma.expense.findFirst({
+      where: { id, organizationId: orgId },
+      include: { payments: true },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Salida no encontrada');
+    }
+
+    if (!existing.active) {
+      throw new BadRequestException(
+        'No se pueden registrar pagos en una salida eliminada',
+      );
+    }
+
+    const amount = new Prisma.Decimal(dto.amount);
+    const paymentsSum = this.sumPayments(existing.payments).add(amount);
+
+    if (paymentsSum.gt(existing.total)) {
+      throw new BadRequestException(
+        'La suma de los pagos no puede superar el total de la salida',
+      );
+    }
+
+    const status = deriveExpensePaymentStatus(existing.total, paymentsSum);
+
+    return this.prisma.$transaction(async (tx) => {
+      await tx.expensePayment.create({
+        data: {
+          expenseId: id,
+          organizationId: orgId,
+          amount,
+          method: dto.method,
+          date: new Date(dto.date),
+        },
+      });
+
+      const updated = await tx.expense.update({
+        where: { id },
+        data: { status },
+        include: { category: true, supplier: true, payments: true },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          userId,
+          action: 'EXPENSE_PAYMENT_ADDED',
+          resource: 'Expense',
+          resourceId: id,
+          organizationId: orgId,
+          metadata: {
+            summary: `Pago de ${amount.toString()} registrado`,
+            amount: amount.toString(),
+            method: dto.method,
+            date: dto.date,
+            beforeStatus: existing.status,
+            afterStatus: status,
             timestamp: new Date().toISOString(),
           },
         },

--- a/backend/src/expenses/expenses.service.ts
+++ b/backend/src/expenses/expenses.service.ts
@@ -4,7 +4,10 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { ExpensePaymentStatus, Prisma } from '@prisma/client';
-import { parseBogotaMonthRange } from '../common/utils/bogota-date';
+import {
+  formatDateInBogota,
+  parseBogotaMonthRange,
+} from '../common/utils/bogota-date';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateExpenseDto } from './dto/create-expense.dto';
 import { CreateExpensePaymentDto } from './dto/create-expense-payment.dto';
@@ -430,6 +433,88 @@ export class ExpensesService {
       });
 
       return updated;
+    });
+  }
+
+  async duplicate(
+    id: string,
+    userId: string,
+    organizationId: string | undefined,
+  ) {
+    const orgId = this.requireOrganizationId(organizationId);
+
+    const existing = await this.prisma.expense.findFirst({
+      where: { id, organizationId: orgId },
+      include: { payments: true },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Salida no encontrada');
+    }
+
+    if (!existing.active) {
+      throw new BadRequestException('No se puede duplicar una salida eliminada');
+    }
+
+    if (existing.payments.length === 0) {
+      throw new BadRequestException(
+        'Cada salida debe registrarse con al menos un pago',
+      );
+    }
+
+    const paymentsSum = this.sumPayments(existing.payments);
+
+    if (paymentsSum.gt(existing.total)) {
+      throw new BadRequestException(
+        'La suma de los pagos no puede superar el total de la salida',
+      );
+    }
+
+    const status = deriveExpensePaymentStatus(existing.total, paymentsSum);
+    const today = new Date(formatDateInBogota(new Date()));
+
+    return this.prisma.$transaction(async (tx) => {
+      const duplicated = await tx.expense.create({
+        data: {
+          organizationId: orgId,
+          categoryId: existing.categoryId,
+          supplierId: existing.supplierId,
+          purchaseOrderId: existing.purchaseOrderId,
+          description: existing.description,
+          date: today,
+          total: existing.total,
+          status,
+          createdById: userId,
+          payments: {
+            create: existing.payments.map((payment) => ({
+              organizationId: orgId,
+              amount: payment.amount,
+              method: payment.method,
+              date: payment.date,
+            })),
+          },
+        },
+        include: { payments: true, category: true, supplier: true },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          userId,
+          action: 'EXPENSE_DUPLICATED',
+          resource: 'Expense',
+          resourceId: duplicated.id,
+          organizationId: orgId,
+          metadata: {
+            summary: 'Salida duplicada',
+            originalId: id,
+            total: existing.total.toString(),
+            status,
+            timestamp: new Date().toISOString(),
+          },
+        },
+      });
+
+      return duplicated;
     });
   }
 

--- a/backend/src/exports/dto/export.dto.ts
+++ b/backend/src/exports/dto/export.dto.ts
@@ -20,11 +20,11 @@ export class ExportQueryDto {
   format: ExportFormat;
 
   @ApiProperty({
-    enum: ['sales', 'products', 'customers', 'inventory'],
+    enum: ['sales', 'products', 'customers', 'inventory', 'expenses'],
     example: 'sales',
   })
-  @IsEnum(['sales', 'products', 'customers', 'inventory'])
-  type: 'sales' | 'products' | 'customers' | 'inventory';
+  @IsEnum(['sales', 'products', 'customers', 'inventory', 'expenses'])
+  type: 'sales' | 'products' | 'customers' | 'inventory' | 'expenses';
 
   @ApiPropertyOptional({ example: '2024-01-01' })
   @IsOptional()

--- a/backend/src/exports/exports.controller.spec.ts
+++ b/backend/src/exports/exports.controller.spec.ts
@@ -1,0 +1,51 @@
+import { type ExecutionContext } from '@nestjs/common';
+import { OrgRole } from '@prisma/client';
+import { ROLES_KEY } from '../common/decorators/roles.decorator';
+import type { RequestUser } from '../common/interfaces/request-user.interface';
+import { ExportsController } from './exports.controller';
+
+describe('ExportsController (expenses route)', () => {
+  const serviceMock = {
+    exportExpenses: jest.fn(),
+  };
+
+  const adminUser: RequestUser = {
+    userId: 'user-1',
+    email: 'admin@example.com',
+    organizationId: 'org-1',
+    role: OrgRole.ADMIN,
+    tokenVersion: 1,
+    isSuperAdmin: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('requires ADMIN on the expenses export handler', () => {
+    const controller = new ExportsController(serviceMock as never);
+
+    expect(Reflect.getMetadata(ROLES_KEY, controller.exportExpenses)).toEqual([
+      OrgRole.ADMIN,
+    ]);
+  });
+
+  it('delegates exportExpenses with organizationId from the token and the query body', async () => {
+    const controller = new ExportsController(serviceMock as never);
+    const res = {} as Response;
+
+    serviceMock.exportExpenses.mockResolvedValue(undefined);
+
+    await controller.exportExpenses(
+      adminUser,
+      { format: 'excel', type: 'expenses' },
+      res,
+    );
+
+    expect(serviceMock.exportExpenses).toHaveBeenCalledWith(
+      'org-1',
+      { format: 'excel', type: 'expenses' },
+      res,
+    );
+  });
+});

--- a/backend/src/exports/exports.controller.ts
+++ b/backend/src/exports/exports.controller.ts
@@ -101,4 +101,20 @@ export class ExportsController {
       res,
     );
   }
+
+  @Post('expenses')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Export expenses data' })
+  @ApiConsumes('application/json')
+  async exportExpenses(
+    @CurrentUser() user: RequestUser,
+    @Body() query: ExportQueryDto,
+    @Res() res: Response,
+  ) {
+    return this.exportsService.exportExpenses(
+      user.organizationId,
+      query,
+      res,
+    );
+  }
 }

--- a/backend/src/exports/exports.controller.ts
+++ b/backend/src/exports/exports.controller.ts
@@ -79,11 +79,7 @@ export class ExportsController {
     @Body() query: ExportQueryDto,
     @Res() res: Response,
   ) {
-    return this.exportsService.exportCustomers(
-      user.organizationId,
-      query,
-      res,
-    );
+    return this.exportsService.exportCustomers(user.organizationId, query, res);
   }
 
   @Post('inventory')
@@ -95,11 +91,7 @@ export class ExportsController {
     @Body() query: ExportQueryDto,
     @Res() res: Response,
   ) {
-    return this.exportsService.exportInventory(
-      user.organizationId,
-      query,
-      res,
-    );
+    return this.exportsService.exportInventory(user.organizationId, query, res);
   }
 
   @Post('expenses')
@@ -111,10 +103,6 @@ export class ExportsController {
     @Body() query: ExportQueryDto,
     @Res() res: Response,
   ) {
-    return this.exportsService.exportExpenses(
-      user.organizationId,
-      query,
-      res,
-    );
+    return this.exportsService.exportExpenses(user.organizationId, query, res);
   }
 }

--- a/backend/src/exports/exports.service.spec.ts
+++ b/backend/src/exports/exports.service.spec.ts
@@ -1,5 +1,11 @@
+import { Prisma } from '@prisma/client';
 import { ExportsService } from './exports.service';
 import { ExportQueryDto } from './dto/export.dto';
+import * as csv from '@fast-csv/format';
+
+jest.mock('@fast-csv/format', () => ({
+  write: jest.fn(() => ({ pipe: jest.fn() })),
+}));
 
 describe('ExportsService', () => {
   let service: ExportsService;
@@ -18,9 +24,21 @@ describe('ExportsService', () => {
     customer: {
       findMany: jest.fn(),
     },
+    expense: {
+      findMany: jest.fn(),
+    },
   };
 
   const ORG_ID = 'org-1';
+
+  const buildResMock = () => ({
+    setHeader: jest.fn(),
+    end: jest.fn(),
+    write: jest.fn(),
+    flushHeaders: jest.fn(),
+    pipe: jest.fn(),
+    send: jest.fn(),
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -144,6 +162,86 @@ describe('ExportsService', () => {
       expect.objectContaining({
         where: expect.objectContaining({ organizationId: ORG_ID }),
       }),
+    );
+  });
+
+  it('exportExpenses filters by organizationId, active and the expense date range', async () => {
+    prismaMock.expense.findMany.mockResolvedValue([]);
+    const expectedEnd = new Date('2026-08-31');
+    expectedEnd.setHours(23, 59, 59, 999);
+
+    await service.exportExpenses(
+      ORG_ID,
+      {
+        format: 'pdf',
+        type: 'expenses',
+        startDate: '2026-08-01',
+        endDate: '2026-08-31',
+      } as ExportQueryDto,
+      buildResMock(),
+    );
+
+    expect(prismaMock.expense.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          organizationId: ORG_ID,
+          active: true,
+          date: {
+            gte: new Date('2026-08-01'),
+            lte: expectedEnd,
+          },
+        },
+        orderBy: { date: 'desc' },
+        include: { category: { select: { name: true } } },
+      }),
+    );
+  });
+
+  it('exportExpenses writes CSV headers and rows with date, category, description, total and status', async () => {
+    const expenseDate = new Date('2026-08-15T00:00:00.000Z');
+    prismaMock.expense.findMany.mockResolvedValue([
+      {
+        date: expenseDate,
+        category: { name: 'Arriendo' },
+        description: 'Arriendo agosto',
+        total: new Prisma.Decimal(500000),
+        status: 'PAID',
+      },
+    ]);
+
+    await service.exportExpenses(
+      ORG_ID,
+      { format: 'csv', type: 'expenses' } as ExportQueryDto,
+      buildResMock(),
+    );
+
+    expect(csv.write).toHaveBeenCalledWith(
+      [
+        ['Date', 'Category', 'Description', 'Total', 'Status'],
+        [
+          expenseDate.toLocaleDateString(),
+          'Arriendo',
+          'Arriendo agosto',
+          '500000.00',
+          'PAID',
+        ],
+      ],
+      { headers: false },
+    );
+  });
+
+  it('exportExpenses exports an empty result with headers only', async () => {
+    prismaMock.expense.findMany.mockResolvedValue([]);
+
+    await service.exportExpenses(
+      ORG_ID,
+      { format: 'csv', type: 'expenses' } as ExportQueryDto,
+      buildResMock(),
+    );
+
+    expect(csv.write).toHaveBeenCalledWith(
+      [['Date', 'Category', 'Description', 'Total', 'Status']],
+      { headers: false },
     );
   });
 });

--- a/backend/src/exports/exports.service.ts
+++ b/backend/src/exports/exports.service.ts
@@ -17,7 +17,9 @@ export class ExportsService {
     const limit = query.limit ?? 20;
     const skip = (page - 1) * limit;
 
-    const where: Record<string, unknown> = { ...(organizationId ? { organizationId } : {}) };
+    const where: Record<string, unknown> = {
+      ...(organizationId ? { organizationId } : {}),
+    };
 
     if (query.productId) {
       where.productId = query.productId;
@@ -108,7 +110,10 @@ export class ExportsService {
     return this.exportData(expenses, 'expenses', query.format, response);
   }
 
-  private async getSalesData(organizationId: string | undefined, query: ExportQueryDto) {
+  private async getSalesData(
+    organizationId: string | undefined,
+    query: ExportQueryDto,
+  ) {
     const where: any = { ...(organizationId ? { organizationId } : {}) };
     if (query.startDate || query.endDate) {
       where.createdAt = {};
@@ -132,7 +137,10 @@ export class ExportsService {
     });
   }
 
-  private async getProductsData(organizationId: string | undefined, query: ExportQueryDto) {
+  private async getProductsData(
+    organizationId: string | undefined,
+    query: ExportQueryDto,
+  ) {
     return this.prisma.product.findMany({
       where: { ...(organizationId ? { organizationId } : {}), active: true },
       take: query.limit || undefined,

--- a/backend/src/exports/exports.service.ts
+++ b/backend/src/exports/exports.service.ts
@@ -99,6 +99,15 @@ export class ExportsService {
     return this.exportData(movements, 'inventory', query.format, response);
   }
 
+  async exportExpenses(
+    organizationId: string | undefined,
+    query: ExportQueryDto,
+    response: any,
+  ) {
+    const expenses = await this.getExpensesData(organizationId, query);
+    return this.exportData(expenses, 'expenses', query.format, response);
+  }
+
   private async getSalesData(organizationId: string | undefined, query: ExportQueryDto) {
     const where: any = { ...(organizationId ? { organizationId } : {}) };
     if (query.startDate || query.endDate) {
@@ -166,6 +175,32 @@ export class ExportsService {
         product: { select: { name: true, sku: true } },
         user: { select: { name: true } },
       },
+    });
+  }
+
+  private async getExpensesData(
+    organizationId: string | undefined,
+    query: ExportQueryDto,
+  ) {
+    const where: any = {
+      ...(organizationId ? { organizationId } : {}),
+      active: true,
+    };
+    if (query.startDate || query.endDate) {
+      where.date = {};
+      if (query.startDate) where.date.gte = new Date(query.startDate);
+      if (query.endDate) {
+        const end = new Date(query.endDate);
+        end.setHours(23, 59, 59, 999);
+        where.date.lte = end;
+      }
+    }
+
+    return this.prisma.expense.findMany({
+      where,
+      take: query.limit || undefined,
+      orderBy: { date: 'desc' },
+      include: { category: { select: { name: true } } },
     });
   }
 
@@ -309,6 +344,7 @@ export class ExportsService {
         'New Stock',
         'User',
       ],
+      expenses: ['Date', 'Category', 'Description', 'Total', 'Status'],
     };
     return headers[type] || [];
   }
@@ -350,6 +386,13 @@ export class ExportsService {
         item.newStock,
         item.user?.name || 'N/A',
       ],
+      expenses: (item) => [
+        new Date(item.date).toLocaleDateString(),
+        item.category?.name || 'N/A',
+        item.description || 'N/A',
+        Number(item.total).toFixed(2),
+        item.status,
+      ],
     };
     return getters[type](item);
   }
@@ -360,6 +403,7 @@ export class ExportsService {
       products: [50, 25, 25, 20, 20, 15, 15],
       customers: [35, 25, 25, 30, 25, 20],
       inventory: [25, 40, 25, 15, 20, 20, 25],
+      expenses: [25, 40, 40, 20, 20],
     };
     return widths[type] || [];
   }

--- a/frontend/src/app/expenses/expenses-page.evidence.test.tsx
+++ b/frontend/src/app/expenses/expenses-page.evidence.test.tsx
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+
+const { exportDataMock } = vi.hoisted(() => ({ exportDataMock: vi.fn() }));
+
+const useExpensesMock = vi.fn();
+const useExpenseSummaryMock = vi.fn();
+const useExpenseCategoriesMock = vi.fn();
+const useSuppliersMock = vi.fn();
+const deleteMutateAsyncMock = vi.fn();
+const duplicateMutateAsyncMock = vi.fn();
+const uploadReceiptMutateAsyncMock = vi.fn();
+const toastSuccessMock = vi.fn();
+const toastErrorMock = vi.fn();
+
+vi.mock("@/components/layout/DashboardLayout", () => ({
+  DashboardLayout: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/hooks/useExpenses", () => ({
+  useExpenses: (params?: unknown) => useExpensesMock(params),
+  useExpenseSummary: (month?: string) => useExpenseSummaryMock(month),
+  useExpenseCategories: () => useExpenseCategoriesMock(),
+  useDeleteExpense: () => ({ mutateAsync: deleteMutateAsyncMock }),
+  useDuplicateExpense: () => ({ mutateAsync: duplicateMutateAsyncMock }),
+  useUploadExpenseReceipt: () => ({ mutateAsync: uploadReceiptMutateAsyncMock }),
+}));
+
+vi.mock("@/hooks/useSuppliers", () => ({
+  useSuppliers: () => useSuppliersMock(),
+}));
+
+vi.mock("@/components/expenses/ExpenseFormModal", () => ({
+  ExpenseFormModal: () => <section>ExpenseFormModal</section>,
+}));
+
+vi.mock("@/components/expenses/AddPaymentModal", () => ({
+  AddPaymentModal: () => <section>AddPaymentModal</section>,
+}));
+
+vi.mock("@/components/expenses/HistoryModal", () => ({
+  HistoryModal: () => <section>HistoryModal</section>,
+}));
+
+vi.mock("@/contexts/ToastContext", () => ({
+  useToast: () => ({
+    success: toastSuccessMock,
+    error: toastErrorMock,
+    info: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      exportData: exportDataMock,
+    },
+  };
+});
+
+import ExpensesPage from "./page";
+
+const expenseFixture = {
+  id: "exp-1",
+  organizationId: "org-1",
+  categoryId: "cat-1",
+  category: {
+    id: "cat-1",
+    organizationId: "org-1",
+    name: "Arriendo",
+    active: true,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+  },
+  supplierId: null,
+  purchaseOrderId: null,
+  description: "Renta agosto",
+  date: "2026-08-01T00:00:00.000Z",
+  total: "500000",
+  status: "PARTIAL",
+  receiptUrl: null,
+  active: true,
+  createdById: "user-1",
+  createdAt: "2026-08-01T00:00:00.000Z",
+  updatedAt: "2026-08-01T00:00:00.000Z",
+  payments: [
+    {
+      id: "pay-1",
+      expenseId: "exp-1",
+      organizationId: "org-1",
+      amount: "300000",
+      method: "CASH",
+      date: "2026-08-01T00:00:00.000Z",
+      createdAt: "2026-08-01T00:00:00.000Z",
+    },
+  ],
+};
+
+describe("Expenses page evidence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    exportDataMock.mockResolvedValue(undefined);
+    deleteMutateAsyncMock.mockResolvedValue({} as never);
+    duplicateMutateAsyncMock.mockResolvedValue({} as never);
+    uploadReceiptMutateAsyncMock.mockResolvedValue({} as never);
+
+    useExpenseSummaryMock.mockReturnValue({
+      data: {
+        month: "2026-08",
+        total: "800000",
+        categories: [
+          { categoryId: "cat-1", name: "Arriendo", total: "500000" },
+          { categoryId: "cat-2", name: "Caja menor", total: "300000" },
+        ],
+      },
+      isLoading: false,
+    });
+
+    useExpensesMock.mockReturnValue({
+      data: {
+        data: [expenseFixture],
+        meta: { total: 1, page: 1, limit: 15, totalPages: 1 },
+      },
+      isLoading: false,
+    });
+
+    useExpenseCategoriesMock.mockReturnValue({
+      data: [
+        {
+          id: "cat-1",
+          organizationId: "org-1",
+          name: "Arriendo",
+          active: true,
+          createdAt: "2026-08-01T00:00:00.000Z",
+          updatedAt: "2026-08-01T00:00:00.000Z",
+        },
+      ],
+      isLoading: false,
+    });
+
+    useSuppliersMock.mockReturnValue({ data: { data: [] }, isLoading: false });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the month total and per-category summary cards (EXP-8)", () => {
+    render(<ExpensesPage />);
+
+    expect(screen.getByText("Total del mes")).toBeTruthy();
+    expect(screen.getByText(/800\.000/)).toBeTruthy();
+    expect(screen.getAllByText("Arriendo").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Caja menor")).toBeTruthy();
+    expect(useExpenseSummaryMock).toHaveBeenCalledWith("2026-08");
+  });
+
+  it("renders the expense list with status badge and COP totals", () => {
+    render(<ExpensesPage />);
+
+    expect(screen.getByText("Renta agosto")).toBeTruthy();
+    expect(screen.getAllByText("Parcial").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/500\.000/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("applies the month filter to the list query", () => {
+    render(<ExpensesPage />);
+
+    expect(useExpensesMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ month: "2026-08" }),
+    );
+
+    fireEvent.change(screen.getByLabelText("Mes"), {
+      target: { value: "2026-07" },
+    });
+
+    expect(useExpensesMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ month: "2026-07", page: 1 }),
+    );
+  });
+
+  it("exports the filtered list through the exports endpoint (EXP-9)", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpensesPage />);
+
+    await user.click(screen.getByRole("button", { name: /Exportar/i }));
+
+    expect(exportDataMock).toHaveBeenCalledWith(
+      "/exports/expenses",
+      expect.objectContaining({ type: "expenses" }),
+    );
+    expect(toastSuccessMock).toHaveBeenCalled();
+  });
+
+  it("opens the create form modal", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpensesPage />);
+
+    await user.click(screen.getByRole("button", { name: /Nuevo gasto/i }));
+
+    expect(screen.getByText("ExpenseFormModal")).toBeTruthy();
+  });
+
+  it("opens the add payment modal from the row actions", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpensesPage />);
+
+    await user.click(screen.getByRole("button", { name: "Agregar pago" }));
+
+    expect(screen.getByText("AddPaymentModal")).toBeTruthy();
+  });
+
+  it("opens the history modal from the row actions", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpensesPage />);
+
+    await user.click(screen.getByRole("button", { name: "Ver historial" }));
+
+    expect(screen.getByText("HistoryModal")).toBeTruthy();
+  });
+
+  it("deletes an expense after confirmation (EXP-5)", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpensesPage />);
+
+    await user.click(screen.getByRole("button", { name: "Eliminar gasto" }));
+    expect(screen.getByText("Eliminar gasto")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Sí, eliminar" }));
+
+    expect(deleteMutateAsyncMock).toHaveBeenCalledWith("exp-1");
+    expect(toastSuccessMock).toHaveBeenCalledWith("Gasto eliminado");
+  });
+
+  it("duplicates an expense after confirmation (EXP-10)", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpensesPage />);
+
+    await user.click(screen.getByRole("button", { name: "Duplicar gasto" }));
+    expect(screen.getByText("Duplicar gasto")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Sí, duplicar" }));
+
+    expect(duplicateMutateAsyncMock).toHaveBeenCalledWith("exp-1");
+    expect(toastSuccessMock).toHaveBeenCalledWith("Gasto duplicado");
+  });
+
+  it("uploads a receipt from the row actions", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpensesPage />);
+
+    const file = new File(["receipt"], "recibo.png", { type: "image/png" });
+    const input = screen.getByLabelText("Subir comprobante");
+    await user.upload(input, file);
+
+    expect(uploadReceiptMutateAsyncMock).toHaveBeenCalledWith({
+      id: "exp-1",
+      file,
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith("Comprobante subido");
+  });
+});

--- a/frontend/src/app/expenses/page.tsx
+++ b/frontend/src/app/expenses/page.tsx
@@ -1,0 +1,532 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { DashboardLayout } from "@/components/layout/DashboardLayout";
+import { useSuppliers } from "@/hooks/useSuppliers";
+import {
+  useDeleteExpense,
+  useDuplicateExpense,
+  useExpenseCategories,
+  useExpenses,
+  useExpenseSummary,
+  useUploadExpenseReceipt,
+} from "@/hooks/useExpenses";
+import { useToast } from "@/contexts/ToastContext";
+import { api, getApiErrorMessage } from "@/lib/api";
+import { formatCurrency, formatDate, getBogotaDateInputValue } from "@/lib/utils";
+import { Button } from "@/components/ui/Button";
+import { Pagination } from "@/components/ui/Pagination";
+import { FilterBar } from "@/components/ui/FilterBar";
+import { Table, TableHeader, TableRow, TableCell } from "@/components/ui/Table";
+import { LoadingState } from "@/components/ui/LoadingState";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { ExpenseStatusBadge } from "@/components/expenses/ExpenseStatusBadge";
+import { ExpenseSummaryCards } from "@/components/expenses/ExpenseSummaryCards";
+import { ExpenseFormModal } from "@/components/expenses/ExpenseFormModal";
+import { AddPaymentModal } from "@/components/expenses/AddPaymentModal";
+import { HistoryModal } from "@/components/expenses/HistoryModal";
+import {
+  Copy,
+  History,
+  Pencil,
+  Plus,
+  Trash2,
+  Upload,
+  Wallet,
+  Download,
+} from "lucide-react";
+import { chipStyles } from "@/lib/chipStyles";
+import type { Expense, ExpenseStatus } from "@/types";
+
+const STATUS_OPTIONS: Array<{ value: "" | ExpenseStatus; label: string }> = [
+  { value: "", label: "Todos los estados" },
+  { value: "PARTIAL", label: "Parcial" },
+  { value: "PAID", label: "Pagado" },
+];
+
+export default function ExpensesPage() {
+  const toast = useToast();
+  const [month, setMonth] = useState(() =>
+    getBogotaDateInputValue().slice(0, 7),
+  );
+  const [categoryId, setCategoryId] = useState("");
+  const [supplierId, setSupplierId] = useState("");
+  const [status, setStatus] = useState<"" | ExpenseStatus>("");
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
+  const [exportFormat, setExportFormat] = useState<"excel" | "csv">("excel");
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
+  const [paymentExpense, setPaymentExpense] = useState<Expense | null>(null);
+  const [historyExpense, setHistoryExpense] = useState<Expense | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Expense | null>(null);
+  const [duplicateTarget, setDuplicateTarget] = useState<Expense | null>(null);
+
+  const { data: summary } = useExpenseSummary(month);
+  const { data: categoriesData } = useExpenseCategories();
+  const { data: suppliersData } = useSuppliers({ limit: 200, status: "active" });
+  const { data, isLoading } = useExpenses({
+    page,
+    limit: 15,
+    month,
+    categoryId: categoryId || undefined,
+    supplierId: supplierId || undefined,
+    status: status || undefined,
+    search: search.trim() || undefined,
+  });
+
+  const deleteExpense = useDeleteExpense();
+  const duplicateExpense = useDuplicateExpense();
+  const uploadReceipt = useUploadExpenseReceipt();
+
+  const expenses = data?.data ?? [];
+  const meta = data?.meta;
+  const categories = categoriesData ?? [];
+  const suppliers = suppliersData?.data ?? [];
+
+  const hasFilters = !!categoryId || !!supplierId || !!status || !!search;
+
+  const clearFilters = () => {
+    setPage(1);
+    setCategoryId("");
+    setSupplierId("");
+    setStatus("");
+    setSearch("");
+  };
+
+  const exportRange = useMemo(() => {
+    const [year, monthNumber] = month.split("-").map(Number);
+    if (!year || !monthNumber) {
+      return {};
+    }
+    const lastDay = new Date(Date.UTC(year, monthNumber, 0)).getUTCDate();
+    return {
+      startDate: `${month}-01`,
+      endDate: `${month}-${String(lastDay).padStart(2, "0")}`,
+    };
+  }, [month]);
+
+  const handleExport = async () => {
+    try {
+      await api.exportData("/exports/expenses", {
+        format: exportFormat,
+        type: "expenses",
+        ...exportRange,
+      });
+      toast.success("Exportación generada correctamente");
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "Error al exportar gastos"));
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteExpense.mutateAsync(deleteTarget.id);
+      toast.success("Gasto eliminado");
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "No se pudo eliminar el gasto"));
+    }
+  };
+
+  const handleDuplicate = async () => {
+    if (!duplicateTarget) return;
+    try {
+      await duplicateExpense.mutateAsync(duplicateTarget.id);
+      toast.success("Gasto duplicado");
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "No se pudo duplicar el gasto"));
+    }
+  };
+
+  const handleReceiptUpload = async (expense: Expense, file: File) => {
+    try {
+      await uploadReceipt.mutateAsync({ id: expense.id, file });
+      toast.success("Comprobante subido");
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "No se pudo subir el comprobante"));
+    }
+  };
+
+  const openCreate = () => {
+    setEditingExpense(null);
+    setFormOpen(true);
+  };
+
+  const openEdit = (expense: Expense) => {
+    setEditingExpense(expense);
+    setFormOpen(true);
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-5 lg:space-y-7">
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-3 mb-1">
+              <div className="w-1 h-7 rounded-full bg-primary shrink-0" />
+              <h1 className="text-2xl lg:text-3xl font-bold text-foreground">
+                Salidas
+              </h1>
+              {meta && (
+                <span
+                  className={`hidden sm:inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold ${chipStyles.primary}`}
+                >
+                  {meta.total} registros
+                </span>
+              )}
+            </div>
+            <p className="text-sm text-muted-foreground ml-4">
+              Registra los gastos y pagos de tu negocio
+            </p>
+          </div>
+          <div className="flex items-center gap-2 w-full sm:w-auto">
+            <select
+              aria-label="Formato de exportación"
+              value={exportFormat}
+              onChange={(e) =>
+                setExportFormat(e.target.value as "excel" | "csv")
+              }
+              className="h-8 px-2.5 rounded-lg text-xs font-semibold bg-muted/40 border border-border/60 text-foreground focus:outline-none focus:border-primary/50"
+            >
+              <option value="excel">Excel</option>
+              <option value="csv">CSV</option>
+            </select>
+            <Button
+              variant="secondary"
+              size="sm"
+              type="button"
+              onClick={handleExport}
+              className="shrink-0"
+            >
+              <Download className="w-3.5 h-3.5" /> Exportar
+            </Button>
+            <Button type="button" onClick={openCreate} className="shrink-0">
+              <Plus className="w-4 h-4" /> Nuevo gasto
+            </Button>
+          </div>
+        </div>
+
+        <ExpenseSummaryCards month={month} summary={summary} />
+
+        <FilterBar
+          searchValue={search}
+          onSearchChange={(value) => {
+            setPage(1);
+            setSearch(value);
+          }}
+          searchPlaceholder="Buscar por descripción..."
+          filterControls={
+            <>
+              <input
+                type="month"
+                aria-label="Mes"
+                value={month}
+                onChange={(e) => {
+                  setPage(1);
+                  setMonth(e.target.value);
+                }}
+                className="h-8 px-2 rounded-lg text-xs font-semibold bg-muted/40 border border-border/60 text-foreground focus:outline-none focus:border-primary/50"
+              />
+              <select
+                value={categoryId}
+                onChange={(e) => {
+                  setPage(1);
+                  setCategoryId(e.target.value);
+                }}
+                className="h-8 px-2.5 rounded-lg text-xs font-semibold bg-muted/40 border border-border/60 text-foreground focus:outline-none focus:border-primary/50 max-w-[180px]"
+              >
+                <option value="">Todas las categorías</option>
+                {categories.map((category) => (
+                  <option key={category.id} value={category.id}>
+                    {category.name}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={supplierId}
+                onChange={(e) => {
+                  setPage(1);
+                  setSupplierId(e.target.value);
+                }}
+                className="h-8 px-2.5 rounded-lg text-xs font-semibold bg-muted/40 border border-border/60 text-foreground focus:outline-none focus:border-primary/50 max-w-[180px]"
+              >
+                <option value="">Todos los proveedores</option>
+                {suppliers.map((supplier) => (
+                  <option key={supplier.id} value={supplier.id}>
+                    {supplier.name}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={status}
+                onChange={(e) => {
+                  setPage(1);
+                  setStatus(e.target.value as "" | ExpenseStatus);
+                }}
+                className="h-8 px-2.5 rounded-lg text-xs font-semibold bg-muted/40 border border-border/60 text-foreground focus:outline-none focus:border-primary/50"
+              >
+                {STATUS_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              {hasFilters && (
+                <button
+                  onClick={clearFilters}
+                  className="flex items-center gap-1.5 h-8 px-2.5 rounded-lg text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted/60 border border-border/60 transition-colors"
+                >
+                  Limpiar
+                </button>
+              )}
+            </>
+          }
+        />
+
+        {isLoading ? (
+          <LoadingState
+            icon={<Wallet className="w-4 h-4 text-primary/50" />}
+            message="Cargando salidas..."
+          />
+        ) : (
+          <>
+            <div className="rounded-3xl border border-accent/30 bg-accent/10 overflow-hidden">
+              <div className="overflow-x-auto">
+                <Table variant="accent" className="min-w-[860px]">
+                  <TableHeader>
+                    <TableRow>
+                      <TableCell
+                        as="th"
+                        className="text-left text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+                      >
+                        Fecha
+                      </TableCell>
+                      <TableCell
+                        as="th"
+                        className="text-left text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+                      >
+                        Categoría
+                      </TableCell>
+                      <TableCell
+                        as="th"
+                        className="text-left text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+                      >
+                        Descripción
+                      </TableCell>
+                      <TableCell
+                        as="th"
+                        className="text-left text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+                      >
+                        Proveedor
+                      </TableCell>
+                      <TableCell
+                        as="th"
+                        className="text-left text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+                      >
+                        Estado
+                      </TableCell>
+                      <TableCell
+                        as="th"
+                        className="text-right text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+                      >
+                        Total
+                      </TableCell>
+                      <TableCell
+                        as="th"
+                        className="text-right text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+                      >
+                        Acciones
+                      </TableCell>
+                    </TableRow>
+                  </TableHeader>
+                  <tbody>
+                    {expenses.length === 0 ? (
+                      <tr>
+                        <td colSpan={7} className="text-center py-14">
+                          <EmptyState
+                            icon={
+                              <Wallet className="w-6 h-6 text-muted-foreground/30" />
+                            }
+                            title="No hay salidas registradas"
+                          />
+                        </td>
+                      </tr>
+                    ) : (
+                      expenses.map((expense) => (
+                        <TableRow key={expense.id}>
+                          <TableCell className="text-muted-foreground whitespace-nowrap font-mono">
+                            {formatDate(expense.date)}
+                          </TableCell>
+                          <TableCell>
+                            <span className="text-xs font-semibold text-foreground">
+                              {expense.category?.name ?? "—"}
+                            </span>
+                          </TableCell>
+                          <TableCell className="max-w-[220px] truncate">
+                            <span className="text-xs text-muted-foreground">
+                              {expense.description ?? "—"}
+                            </span>
+                          </TableCell>
+                          <TableCell className="max-w-[180px] truncate">
+                            <span className="text-xs font-semibold text-foreground">
+                              {expense.supplier?.name ?? "—"}
+                            </span>
+                          </TableCell>
+                          <TableCell>
+                            <ExpenseStatusBadge status={expense.status} />
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <span className="stat-number text-sm font-bold text-foreground">
+                              {formatCurrency(Number(expense.total))}
+                            </span>
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <div className="flex items-center justify-end gap-1">
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                type="button"
+                                aria-label="Agregar pago"
+                                title="Agregar pago"
+                                disabled={expense.status === "PAID"}
+                                onClick={() => setPaymentExpense(expense)}
+                                className="p-1.5 h-7 w-7"
+                              >
+                                <Wallet className="w-3.5 h-3.5" />
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                type="button"
+                                aria-label="Ver historial"
+                                title="Ver historial"
+                                onClick={() => setHistoryExpense(expense)}
+                                className="p-1.5 h-7 w-7"
+                              >
+                                <History className="w-3.5 h-3.5" />
+                              </Button>
+                              <label
+                                className="inline-flex items-center justify-center p-1.5 h-7 w-7 rounded-lg cursor-pointer text-muted-foreground hover:text-foreground hover:bg-muted"
+                                title="Subir comprobante"
+                              >
+                                <input
+                                  type="file"
+                                  accept="image/*"
+                                  aria-label="Subir comprobante"
+                                  className="hidden"
+                                  onChange={(e) => {
+                                    const file = e.target.files?.[0];
+                                    if (file) {
+                                      handleReceiptUpload(expense, file);
+                                    }
+                                    e.target.value = "";
+                                  }}
+                                />
+                                <Upload className="w-3.5 h-3.5" />
+                              </label>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                type="button"
+                                aria-label="Duplicar gasto"
+                                title="Duplicar gasto"
+                                onClick={() => setDuplicateTarget(expense)}
+                                className="p-1.5 h-7 w-7"
+                              >
+                                <Copy className="w-3.5 h-3.5" />
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                type="button"
+                                aria-label="Editar gasto"
+                                title="Editar gasto"
+                                onClick={() => openEdit(expense)}
+                                className="p-1.5 h-7 w-7"
+                              >
+                                <Pencil className="w-3.5 h-3.5" />
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                type="button"
+                                aria-label="Eliminar gasto"
+                                title="Eliminar gasto"
+                                onClick={() => setDeleteTarget(expense)}
+                                className="p-1.5 h-7 w-7 hover:text-red-500"
+                              >
+                                <Trash2 className="w-3.5 h-3.5" />
+                              </Button>
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      ))
+                    )}
+                  </tbody>
+                </Table>
+              </div>
+            </div>
+
+            {meta && meta.totalPages > 1 && (
+              <Pagination
+                currentPage={page}
+                totalPages={meta.totalPages}
+                onPageChange={setPage}
+                totalItems={meta.total}
+                itemLabel="salida"
+              />
+            )}
+          </>
+        )}
+      </div>
+
+      {formOpen && (
+        <ExpenseFormModal
+          isOpen
+          expense={editingExpense}
+          onClose={() => {
+            setFormOpen(false);
+            setEditingExpense(null);
+          }}
+        />
+      )}
+
+      {paymentExpense && (
+        <AddPaymentModal
+          isOpen
+          expense={paymentExpense}
+          onClose={() => setPaymentExpense(null)}
+        />
+      )}
+
+      {historyExpense && (
+        <HistoryModal
+          isOpen
+          expense={historyExpense}
+          onClose={() => setHistoryExpense(null)}
+        />
+      )}
+
+      <ConfirmDialog
+        isOpen={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleDelete}
+        title="Eliminar gasto"
+        message="El gasto se ocultará de los listados y el resumen del mes. Esta acción no se puede deshacer."
+        confirmText="Sí, eliminar"
+      />
+
+      <ConfirmDialog
+        isOpen={!!duplicateTarget}
+        onClose={() => setDuplicateTarget(null)}
+        onConfirm={handleDuplicate}
+        title="Duplicar gasto"
+        message="Se creará una copia del gasto con la fecha de hoy y sus pagos."
+        confirmText="Sí, duplicar"
+      />
+    </DashboardLayout>
+  );
+}

--- a/frontend/src/components/expenses/AddPaymentModal.tsx
+++ b/frontend/src/components/expenses/AddPaymentModal.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState } from "react";
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/Button";
+import { Select } from "@/components/ui/Select";
+import { useAddExpensePayment } from "@/hooks/useExpenses";
+import { useToast } from "@/contexts/ToastContext";
+import { getApiErrorMessage } from "@/lib/api";
+import { formatCurrency, getBogotaDateInputValue } from "@/lib/utils";
+import type { Expense, ExpensePayment } from "@/types";
+
+interface Props {
+  expense: Expense;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const PAYMENT_METHOD_OPTIONS = [
+  { value: "CASH", label: "Efectivo" },
+  { value: "CARD", label: "Tarjeta" },
+  { value: "TRANSFER", label: "Transferencia" },
+];
+
+export function AddPaymentModal({ expense, isOpen, onClose }: Props) {
+  const toast = useToast();
+  const addPayment = useAddExpensePayment();
+
+  const [amount, setAmount] = useState("");
+  const [method, setMethod] = useState<ExpensePayment["method"]>("CASH");
+  const [date, setDate] = useState(getBogotaDateInputValue());
+
+  const paidSum = (expense.payments ?? []).reduce(
+    (acc, p) => acc + (Number(p.amount) || 0),
+    0,
+  );
+  const remaining = Number(expense.total) - paidSum;
+
+  const numericAmount = Number(amount) || 0;
+  const error =
+    numericAmount <= 0
+      ? "Ingresa un valor válido"
+      : numericAmount > remaining
+        ? "El pago supera el saldo pendiente"
+        : null;
+
+  const handleSubmit = async () => {
+    if (error) return;
+    try {
+      await addPayment.mutateAsync({
+        id: expense.id,
+        data: { amount: numericAmount, method, date },
+      });
+      toast.success("Pago registrado");
+      onClose();
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, "No se pudo registrar el pago"));
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Agregar pago"
+      size="sm"
+    >
+      <div className="space-y-4">
+        <div className="rounded-lg border border-border/60 bg-muted/30 px-4 py-3 flex items-center justify-between">
+          <span className="text-xs font-semibold text-muted-foreground">
+            Saldo pendiente
+          </span>
+          <span className="text-sm font-bold text-foreground stat-number">
+            {formatCurrency(remaining)}
+          </span>
+        </div>
+
+        <div>
+          <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Valor
+          </label>
+          <input
+            type="number"
+            min={0}
+            step="0.01"
+            placeholder="Valor del pago"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm focus:outline-none focus:border-primary/50"
+          />
+        </div>
+
+        <Select
+          label="Método de pago"
+          value={method}
+          onChange={(e) =>
+            setMethod(e.target.value as ExpensePayment["method"])
+          }
+          options={PAYMENT_METHOD_OPTIONS}
+        />
+
+        <div>
+          <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Fecha
+          </label>
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm focus:outline-none focus:border-primary/50"
+          />
+        </div>
+
+        {error && (
+          <p className="text-xs font-medium text-red-500">{error}</p>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!!error}
+            loading={addPayment.isPending}
+          >
+            Registrar pago
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/expenses/ExpenseFormModal.tsx
+++ b/frontend/src/components/expenses/ExpenseFormModal.tsx
@@ -1,0 +1,432 @@
+"use client";
+
+import { useId, useState } from "react";
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/Button";
+import { Select } from "@/components/ui/Select";
+import { ImageUpload } from "@/components/ui/ImageUpload";
+import {
+  useCreateExpense,
+  useExpenseCategories,
+  useUpdateExpense,
+  useUploadExpenseReceipt,
+} from "@/hooks/useExpenses";
+import { useSuppliers } from "@/hooks/useSuppliers";
+import { usePurchaseOrders } from "@/hooks/usePurchaseOrders";
+import { useToast } from "@/contexts/ToastContext";
+import { getApiErrorMessage } from "@/lib/api";
+import { formatCurrency, getBogotaDateInputValue } from "@/lib/utils";
+import { Plus, Trash2 } from "lucide-react";
+import type { Expense, ExpensePayment } from "@/types";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  expense?: Expense | null;
+}
+
+interface PaymentRow {
+  tempId: string;
+  amount: string;
+  method: ExpensePayment["method"];
+  date: string;
+}
+
+const PAYMENT_METHOD_OPTIONS = [
+  { value: "CASH", label: "Efectivo" },
+  { value: "CARD", label: "Tarjeta" },
+  { value: "TRANSFER", label: "Transferencia" },
+];
+
+function genId() {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+function newRow(): PaymentRow {
+  return {
+    tempId: genId(),
+    amount: "",
+    method: "CASH",
+    date: getBogotaDateInputValue(),
+  };
+}
+
+export function ExpenseFormModal({ isOpen, onClose, expense }: Props) {
+  const toast = useToast();
+  const uid = useId();
+  const createExpense = useCreateExpense();
+  const updateExpense = useUpdateExpense();
+  const uploadReceipt = useUploadExpenseReceipt();
+
+  const { data: categoriesData } = useExpenseCategories();
+  const { data: suppliersData } = useSuppliers({ limit: 200, status: "active" });
+  const { data: ordersData } = usePurchaseOrders({ limit: 200 });
+
+  const categories = categoriesData ?? [];
+  const suppliers = suppliersData?.data ?? [];
+  const orders = ordersData?.data ?? [];
+
+  const [categoryId, setCategoryId] = useState(expense?.categoryId ?? "");
+  const [supplierId, setSupplierId] = useState(expense?.supplierId ?? "");
+  const [purchaseOrderId, setPurchaseOrderId] = useState(
+    expense?.purchaseOrderId ?? "",
+  );
+  const [description, setDescription] = useState(expense?.description ?? "");
+  const [date, setDate] = useState(
+    expense ? expense.date.slice(0, 10) : getBogotaDateInputValue(),
+  );
+  const [total, setTotal] = useState(expense ? String(expense.total) : "");
+  const [rows, setRows] = useState<PaymentRow[]>(() =>
+    expense ? [] : [newRow()],
+  );
+  const [pendingReceiptFile, setPendingReceiptFile] = useState<File | null>(
+    null,
+  );
+
+  const numericTotal = Number(total) || 0;
+  const paymentsSum = rows.reduce(
+    (acc, row) => acc + (Number(row.amount) || 0),
+    0,
+  );
+  const hasValidPayment = rows.some((row) => (Number(row.amount) || 0) > 0);
+  const existingPaymentsSum = expense
+    ? (expense.payments ?? []).reduce(
+        (acc, payment) => acc + (Number(payment.amount) || 0),
+        0,
+      )
+    : 0;
+
+  const error = !categoryId
+    ? "Selecciona una categoría"
+    : !date
+      ? "Selecciona una fecha"
+      : numericTotal <= 0
+        ? "Ingresa un total válido"
+        : expense
+          ? numericTotal < existingPaymentsSum
+            ? "El nuevo total no puede ser menor a los pagos registrados"
+            : null
+          : !hasValidPayment
+            ? "Agrega al menos un pago válido"
+            : paymentsSum > numericTotal
+              ? "El total de pagos supera el total del gasto"
+              : null;
+
+  const handleSubmit = async () => {
+    if (error) return;
+    try {
+      if (expense) {
+        await updateExpense.mutateAsync({
+          id: expense.id,
+          data: {
+            categoryId,
+            supplierId: supplierId || null,
+            purchaseOrderId: purchaseOrderId || null,
+            description: description.trim() || null,
+            date,
+            total: numericTotal,
+          },
+        });
+        toast.success("Gasto actualizado");
+      } else {
+        const created = await createExpense.mutateAsync({
+          categoryId,
+          supplierId: supplierId || undefined,
+          purchaseOrderId: purchaseOrderId || undefined,
+          description: description.trim() || undefined,
+          date,
+          total: numericTotal,
+          payments: rows
+            .filter((row) => (Number(row.amount) || 0) > 0)
+            .map((row) => ({
+              amount: Number(row.amount),
+              method: row.method,
+              date: row.date,
+            })),
+        });
+        if (pendingReceiptFile) {
+          try {
+            await uploadReceipt.mutateAsync({
+              id: created.id,
+              file: pendingReceiptFile,
+            });
+          } catch (err) {
+            toast.error(
+              getApiErrorMessage(
+                err,
+                "El gasto se creó pero no se pudo subir el comprobante",
+              ),
+            );
+          }
+        }
+        toast.success("Gasto registrado");
+      }
+      onClose();
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, "No se pudo guardar el gasto"));
+    }
+  };
+
+  const updateRow = (tempId: string, patch: Partial<PaymentRow>) => {
+    setRows((prev) =>
+      prev.map((row) => (row.tempId === tempId ? { ...row, ...patch } : row)),
+    );
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={expense ? "Editar gasto" : "Nuevo gasto"}
+      size="lg"
+    >
+      <div className="space-y-5">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <Select
+            label="Categoría"
+            value={categoryId}
+            onChange={(e) => setCategoryId(e.target.value)}
+            options={[
+              { value: "", label: "Selecciona una categoría" },
+              ...categories
+                .filter((category) => category.active)
+                .map((category) => ({
+                  value: category.id,
+                  label: category.name,
+                })),
+            ]}
+          />
+
+          <Select
+            label="Proveedor"
+            value={supplierId}
+            onChange={(e) => setSupplierId(e.target.value)}
+            options={[
+              { value: "", label: "Sin proveedor" },
+              ...suppliers.map((supplier) => ({
+                value: supplier.id,
+                label: supplier.name,
+              })),
+            ]}
+          />
+
+          <Select
+            label="Orden de compra"
+            value={purchaseOrderId}
+            onChange={(e) => setPurchaseOrderId(e.target.value)}
+            options={[
+              { value: "", label: "Sin orden de compra" },
+              ...orders.map((order) => ({
+                value: order.id,
+                label: `OC-${order.orderNumber}`,
+              })),
+            ]}
+          />
+
+          <div>
+            <label
+              htmlFor={`${uid}-date`}
+              className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            >
+              Fecha
+            </label>
+            <input
+              id={`${uid}-date`}
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              className="w-full rounded-lg border border-border bg-card px-3 py-2.5 text-sm focus:outline-none focus:border-primary/50"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor={`${uid}-total`}
+              className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            >
+              Total (COP)
+            </label>
+            <input
+              id={`${uid}-total`}
+              type="number"
+              min={0}
+              step="0.01"
+              placeholder="Total del gasto"
+              value={total}
+              onChange={(e) => setTotal(e.target.value)}
+              className="w-full rounded-lg border border-border bg-card px-3 py-2.5 text-sm focus:outline-none focus:border-primary/50"
+            />
+          </div>
+
+          <div className="sm:col-span-2">
+            <label
+              htmlFor={`${uid}-description`}
+              className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            >
+              Descripción
+            </label>
+            <textarea
+              id={`${uid}-description`}
+              rows={2}
+              placeholder="Descripción (opcional)"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm focus:outline-none focus:border-primary/50 resize-none"
+            />
+          </div>
+        </div>
+
+        {!expense && (
+          <div className="rounded-xl border border-border/60 overflow-hidden">
+            <div className="flex items-center justify-between px-4 py-2.5 border-b border-border/60 bg-muted/30">
+              <span className="text-xs font-semibold text-foreground">
+                Pagos
+              </span>
+              <Button
+                size="sm"
+                type="button"
+                variant="secondary"
+                onClick={() => setRows((prev) => [...prev, newRow()])}
+              >
+                <Plus className="w-3.5 h-3.5" /> Agregar pago
+              </Button>
+            </div>
+            <div className="space-y-3 p-4">
+              {rows.map((row, index) => (
+                <div key={row.tempId} className="flex flex-wrap gap-2 items-end">
+                  <div className="min-w-[120px] flex-1">
+                    <label
+                      htmlFor={`${uid}-amount-${row.tempId}`}
+                      className="mb-1 block text-[11px] font-semibold uppercase tracking-wide text-muted-foreground"
+                    >
+                      Valor
+                    </label>
+                    <input
+                      id={`${uid}-amount-${row.tempId}`}
+                      type="number"
+                      min={0}
+                      step="0.01"
+                      placeholder="Valor del pago"
+                      value={row.amount}
+                      onChange={(e) =>
+                        updateRow(row.tempId, { amount: e.target.value })
+                      }
+                      className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm focus:outline-none focus:border-primary/50"
+                    />
+                  </div>
+                  <div>
+                    <label
+                      htmlFor={`${uid}-method-${row.tempId}`}
+                      className="mb-1 block text-[11px] font-semibold uppercase tracking-wide text-muted-foreground"
+                    >
+                      Método
+                    </label>
+                    <select
+                      id={`${uid}-method-${row.tempId}`}
+                      aria-label={`Método de pago ${index + 1}`}
+                      value={row.method}
+                      onChange={(e) =>
+                        updateRow(row.tempId, {
+                          method: e.target.value as ExpensePayment["method"],
+                        })
+                      }
+                      className="rounded-lg border border-border bg-card px-3 py-2 text-sm focus:outline-none focus:border-primary/50"
+                    >
+                      {PAYMENT_METHOD_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label
+                      htmlFor={`${uid}-paydate-${row.tempId}`}
+                      className="mb-1 block text-[11px] font-semibold uppercase tracking-wide text-muted-foreground"
+                    >
+                      Fecha pago
+                    </label>
+                    <input
+                      id={`${uid}-paydate-${row.tempId}`}
+                      type="date"
+                      aria-label="Fecha del pago"
+                      value={row.date}
+                      onChange={(e) =>
+                        updateRow(row.tempId, { date: e.target.value })
+                      }
+                      className="rounded-lg border border-border bg-card px-3 py-2 text-sm focus:outline-none focus:border-primary/50"
+                    />
+                  </div>
+                  <button
+                    type="button"
+                    aria-label="Eliminar pago"
+                    onClick={() =>
+                      setRows((prev) =>
+                        prev.filter((r) => r.tempId !== row.tempId),
+                      )
+                    }
+                    disabled={rows.length === 1}
+                    className="p-2 rounded-lg text-muted-foreground hover:text-rose-500 hover:bg-rose-500/10 disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </div>
+              ))}
+              <p className="text-xs text-muted-foreground">
+                Total de pagos:{" "}
+                <span className="font-bold text-foreground stat-number">
+                  {formatCurrency(paymentsSum)}
+                </span>
+              </p>
+            </div>
+          </div>
+        )}
+
+        <div>
+          <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Comprobante
+          </p>
+          {expense ? (
+            <ImageUpload
+              value={expense.receiptUrl ?? undefined}
+              onChange={() => {}}
+              onUpload={async (file) => {
+                const updated = await uploadReceipt.mutateAsync({
+                  id: expense.id,
+                  file,
+                });
+                return updated.receiptUrl ?? "";
+              }}
+            />
+          ) : (
+            <ImageUpload
+              onChange={() => {}}
+              onUpload={(file) => {
+                setPendingReceiptFile(file);
+                return Promise.resolve(URL.createObjectURL(file));
+              }}
+            />
+          )}
+        </div>
+
+        {error && (
+          <p className="text-xs font-medium text-red-500">{error}</p>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2 border-t border-border/60">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!!error}
+            loading={createExpense.isPending || updateExpense.isPending}
+          >
+            {expense ? "Guardar cambios" : "Registrar gasto"}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/expenses/ExpenseStatusBadge.tsx
+++ b/frontend/src/components/expenses/ExpenseStatusBadge.tsx
@@ -1,0 +1,12 @@
+import { Badge } from "@/components/ui/Badge";
+import type { ExpenseStatus } from "@/types";
+
+export function ExpenseStatusBadge({ status }: { status: ExpenseStatus }) {
+  const isPaid = status === "PAID";
+
+  return (
+    <Badge variant={isPaid ? "success" : "warning"}>
+      {isPaid ? "Pagado" : "Parcial"}
+    </Badge>
+  );
+}

--- a/frontend/src/components/expenses/ExpenseSummaryCards.tsx
+++ b/frontend/src/components/expenses/ExpenseSummaryCards.tsx
@@ -1,0 +1,43 @@
+import { Card } from "@/components/ui/Card";
+import { formatCurrency } from "@/lib/utils";
+import { Wallet } from "lucide-react";
+import type { ExpenseMonthlySummary } from "@/types";
+
+interface Props {
+  month?: string;
+  summary?: ExpenseMonthlySummary;
+}
+
+export function ExpenseSummaryCards({ month, summary }: Props) {
+  return (
+    <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      <Card className="p-5 border-primary/25 bg-primary/5">
+        <div className="flex items-center justify-between">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Total del mes
+          </p>
+          <Wallet className="w-4 h-4 text-primary" />
+        </div>
+        <p className="mt-2 text-2xl font-bold text-foreground stat-number">
+          {formatCurrency(Number(summary?.total ?? 0))}
+        </p>
+        {month && (
+          <p className="mt-1 text-xs text-muted-foreground font-mono">
+            {month}
+          </p>
+        )}
+      </Card>
+
+      {(summary?.categories ?? []).map((category) => (
+        <Card key={category.categoryId} className="p-5">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground truncate">
+            {category.name}
+          </p>
+          <p className="mt-2 text-2xl font-bold text-foreground stat-number">
+            {formatCurrency(Number(category.total ?? 0))}
+          </p>
+        </Card>
+      ))}
+    </section>
+  );
+}

--- a/frontend/src/components/expenses/HistoryModal.tsx
+++ b/frontend/src/components/expenses/HistoryModal.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Modal } from "@/components/ui/Modal";
+import { useExpenseHistory } from "@/hooks/useExpenses";
+import { formatDateTime } from "@/lib/utils";
+import { History } from "lucide-react";
+import type { Expense } from "@/types";
+
+interface Props {
+  expense: Expense;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const ACTION_LABELS: Record<string, string> = {
+  EXPENSE_CREATED: "Gasto creado",
+  EXPENSE_UPDATED: "Gasto actualizado",
+  EXPENSE_PAYMENT_ADDED: "Pago agregado",
+  EXPENSE_DUPLICATED: "Gasto duplicado",
+  EXPENSE_RECEIPT_UPLOADED: "Comprobante subido",
+  EXPENSE_DELETED: "Gasto eliminado",
+};
+
+export function HistoryModal({ expense, isOpen, onClose }: Props) {
+  const { data: entries = [], isLoading } = useExpenseHistory(expense.id);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Historial del gasto"
+      size="md"
+    >
+      {isLoading ? (
+        <div className="flex flex-col items-center justify-center py-10 gap-3">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+          <p className="text-xs text-muted-foreground">Cargando historial...</p>
+        </div>
+      ) : entries.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-10 gap-2">
+          <History className="w-6 h-6 text-muted-foreground/30" />
+          <p className="text-xs text-muted-foreground">
+            Sin movimientos registrados
+          </p>
+        </div>
+      ) : (
+        <ol className="space-y-4">
+          {entries.map((entry) => (
+            <li
+              key={entry.id}
+              className="flex items-start gap-3 rounded-lg border border-border/60 bg-muted/20 px-4 py-3"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold text-foreground">
+                  {ACTION_LABELS[entry.action] ?? entry.action}
+                </p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  {entry.user?.name ?? "—"}
+                </p>
+              </div>
+              <span className="text-xs text-muted-foreground font-mono whitespace-nowrap">
+                {formatDateTime(entry.createdAt)}
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </Modal>
+  );
+}

--- a/frontend/src/components/expenses/add-payment-modal.test.tsx
+++ b/frontend/src/components/expenses/add-payment-modal.test.tsx
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import type { Expense } from "@/types";
+
+const addPaymentMutateAsyncMock = vi.fn();
+const toastSuccessMock = vi.fn();
+const toastErrorMock = vi.fn();
+
+vi.mock("@/components/ui/Modal", () => ({
+  Modal: ({
+    isOpen,
+    title,
+    children,
+  }: {
+    isOpen: boolean;
+    title?: string;
+    children: ReactNode;
+  }) =>
+    isOpen ? (
+      <section>
+        {title ? <h2>{title}</h2> : null}
+        {children}
+      </section>
+    ) : null,
+}));
+
+vi.mock("@/components/ui/Button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/hooks/useExpenses", () => ({
+  useAddExpensePayment: () => ({
+    mutateAsync: addPaymentMutateAsyncMock,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/contexts/ToastContext", () => ({
+  useToast: () => ({
+    success: toastSuccessMock,
+    error: toastErrorMock,
+    info: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {},
+  getApiErrorMessage: () => "Overpayment",
+}));
+
+import { AddPaymentModal } from "./AddPaymentModal";
+
+function makeExpense(): Expense {
+  return {
+    id: "exp-1",
+    organizationId: "org-1",
+    categoryId: "cat-1",
+    supplierId: null,
+    purchaseOrderId: null,
+    description: "Renta agosto",
+    date: "2026-08-01T00:00:00.000Z",
+    total: "500000",
+    status: "PARTIAL",
+    receiptUrl: null,
+    active: true,
+    createdById: "user-1",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    payments: [
+      {
+        id: "pay-1",
+        expenseId: "exp-1",
+        organizationId: "org-1",
+        amount: "300000",
+        method: "CASH",
+        date: "2026-08-01T00:00:00.000Z",
+        createdAt: "2026-08-01T00:00:00.000Z",
+      },
+    ],
+    // Decimal fields arrive as strings at runtime (backend Decimal serialization)
+  } as unknown as Expense;
+}
+
+describe("AddPaymentModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    addPaymentMutateAsyncMock.mockResolvedValue({} as never);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows the remaining balance and submits a valid payment", async () => {
+    const user = userEvent.setup();
+
+    render(<AddPaymentModal expense={makeExpense()} isOpen onClose={vi.fn()} />);
+
+    expect(screen.getByText(/Saldo pendiente/)).toBeTruthy();
+
+    fireEvent.change(screen.getByPlaceholderText("Valor del pago"), {
+      target: { value: "100000" },
+    });
+    await user.click(screen.getByRole("button", { name: /Registrar pago/i }));
+
+    expect(addPaymentMutateAsyncMock).toHaveBeenCalledWith({
+      id: "exp-1",
+      data: {
+        amount: 100000,
+        method: "CASH",
+        date: expect.any(String),
+      },
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith("Pago registrado");
+  });
+
+  it("surfaces an overpayment error before calling the API (EXP-2)", async () => {
+    const user = userEvent.setup();
+
+    render(<AddPaymentModal expense={makeExpense()} isOpen onClose={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Valor del pago"), {
+      target: { value: "300000" },
+    });
+    await user.click(screen.getByRole("button", { name: /Registrar pago/i }));
+
+    expect(
+      screen.getByText("El pago supera el saldo pendiente"),
+    ).toBeInTheDocument();
+    expect(addPaymentMutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a server overpayment rejection through the error toast", async () => {
+    const user = userEvent.setup();
+    addPaymentMutateAsyncMock.mockRejectedValueOnce(new Error("boom"));
+
+    render(<AddPaymentModal expense={makeExpense()} isOpen onClose={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Valor del pago"), {
+      target: { value: "50000" },
+    });
+    await user.click(screen.getByRole("button", { name: /Registrar pago/i }));
+
+    expect(toastErrorMock).toHaveBeenCalledWith("Overpayment");
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/expenses/expense-form-modal.test.tsx
+++ b/frontend/src/components/expenses/expense-form-modal.test.tsx
@@ -1,0 +1,289 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import type { Expense } from "@/types";
+
+const createMutateAsyncMock = vi.fn();
+const updateMutateAsyncMock = vi.fn();
+const uploadReceiptMutateAsyncMock = vi.fn();
+const toastSuccessMock = vi.fn();
+const toastErrorMock = vi.fn();
+
+vi.mock("@/components/ui/Modal", () => ({
+  Modal: ({
+    isOpen,
+    title,
+    children,
+  }: {
+    isOpen: boolean;
+    title?: string;
+    children: ReactNode;
+  }) =>
+    isOpen ? (
+      <section>
+        {title ? <h2>{title}</h2> : null}
+        {children}
+      </section>
+    ) : null,
+}));
+
+vi.mock("@/components/ui/Button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/ImageUpload", () => ({
+  ImageUpload: () => <div>ImageUpload</div>,
+}));
+
+vi.mock("@/hooks/useExpenses", () => ({
+  useExpenseCategories: () => ({
+    data: [
+      {
+        id: "cat-1",
+        organizationId: "org-1",
+        name: "Arriendo",
+        active: true,
+        createdAt: "2026-08-01T00:00:00.000Z",
+        updatedAt: "2026-08-01T00:00:00.000Z",
+      },
+      {
+        id: "cat-2",
+        organizationId: "org-1",
+        name: "Caja menor",
+        active: true,
+        createdAt: "2026-08-01T00:00:00.000Z",
+        updatedAt: "2026-08-01T00:00:00.000Z",
+      },
+    ],
+    isLoading: false,
+  }),
+  useCreateExpense: () => ({
+    mutateAsync: createMutateAsyncMock,
+    isPending: false,
+  }),
+  useUpdateExpense: () => ({
+    mutateAsync: updateMutateAsyncMock,
+    isPending: false,
+  }),
+  useUploadExpenseReceipt: () => ({
+    mutateAsync: uploadReceiptMutateAsyncMock,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/hooks/useSuppliers", () => ({
+  useSuppliers: () => ({ data: { data: [] }, isLoading: false }),
+}));
+
+vi.mock("@/hooks/usePurchaseOrders", () => ({
+  usePurchaseOrders: () => ({ data: { data: [] }, isLoading: false }),
+}));
+
+vi.mock("@/contexts/ToastContext", () => ({
+  useToast: () => ({
+    success: toastSuccessMock,
+    error: toastErrorMock,
+    info: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {},
+  getApiErrorMessage: () => "Error de red",
+}));
+
+import { ExpenseFormModal } from "./ExpenseFormModal";
+
+function makeExpense(): Expense {
+  return {
+    id: "exp-1",
+    organizationId: "org-1",
+    categoryId: "cat-1",
+    category: {
+      id: "cat-1",
+      organizationId: "org-1",
+      name: "Arriendo",
+      active: true,
+      createdAt: "2026-08-01T00:00:00.000Z",
+      updatedAt: "2026-08-01T00:00:00.000Z",
+    },
+    supplierId: null,
+    purchaseOrderId: null,
+    description: "Renta agosto",
+    date: "2026-08-01T00:00:00.000Z",
+    total: "500000",
+    status: "PARTIAL",
+    receiptUrl: null,
+    active: true,
+    createdById: "user-1",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    payments: [
+      {
+        id: "pay-1",
+        expenseId: "exp-1",
+        organizationId: "org-1",
+        amount: "300000",
+        method: "CASH",
+        date: "2026-08-01T00:00:00.000Z",
+        createdAt: "2026-08-01T00:00:00.000Z",
+      },
+    ],
+    // Decimal fields arrive as strings at runtime (backend Decimal serialization)
+  } as unknown as Expense;
+}
+
+describe("ExpenseFormModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createMutateAsyncMock.mockResolvedValue({ id: "exp-1" } as never);
+    updateMutateAsyncMock.mockResolvedValue({} as never);
+    uploadReceiptMutateAsyncMock.mockResolvedValue({} as never);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("submits a create payload with the inline first payment", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpenseFormModal isOpen onClose={vi.fn()} />);
+
+    await user.selectOptions(screen.getByLabelText("Categoría"), "cat-1");
+    fireEvent.change(screen.getByLabelText("Fecha"), {
+      target: { value: "2026-08-10" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Total del gasto"), {
+      target: { value: "500000" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Valor del pago"), {
+      target: { value: "500000" },
+    });
+    await user.click(screen.getByRole("button", { name: /Registrar gasto/i }));
+
+    expect(createMutateAsyncMock).toHaveBeenCalledTimes(1);
+    expect(createMutateAsyncMock).toHaveBeenCalledWith({
+      categoryId: "cat-1",
+      supplierId: undefined,
+      purchaseOrderId: undefined,
+      description: undefined,
+      date: "2026-08-10",
+      total: 500000,
+      payments: [
+        { amount: 500000, method: "CASH", date: expect.any(String) },
+      ],
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith("Gasto registrado");
+  });
+
+  it("blocks submission when there is no valid payment (EXP-1)", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpenseFormModal isOpen onClose={vi.fn()} />);
+
+    await user.selectOptions(screen.getByLabelText("Categoría"), "cat-1");
+    fireEvent.change(screen.getByLabelText("Fecha"), {
+      target: { value: "2026-08-10" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Total del gasto"), {
+      target: { value: "500000" },
+    });
+    await user.click(screen.getByRole("button", { name: /Registrar gasto/i }));
+
+    expect(
+      screen.getByText("Agrega al menos un pago válido"),
+    ).toBeInTheDocument();
+    expect(createMutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks submission when payments exceed the total (EXP-2 overpayment guard)", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpenseFormModal isOpen onClose={vi.fn()} />);
+
+    await user.selectOptions(screen.getByLabelText("Categoría"), "cat-1");
+    fireEvent.change(screen.getByLabelText("Fecha"), {
+      target: { value: "2026-08-10" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Total del gasto"), {
+      target: { value: "100" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Valor del pago"), {
+      target: { value: "200" },
+    });
+    await user.click(screen.getByRole("button", { name: /Registrar gasto/i }));
+
+    expect(
+      screen.getByText("El total de pagos supera el total del gasto"),
+    ).toBeInTheDocument();
+    expect(createMutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it("boots edit mode from the expense snapshot and submits an update", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ExpenseFormModal
+        isOpen
+        expense={makeExpense()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByDisplayValue("Renta agosto")).toBeTruthy();
+
+    fireEvent.change(screen.getByPlaceholderText("Descripción (opcional)"), {
+      target: { value: "Renta septiembre" },
+    });
+    await user.click(screen.getByRole("button", { name: /Guardar cambios/i }));
+
+    expect(updateMutateAsyncMock).toHaveBeenCalledWith({
+      id: "exp-1",
+      data: {
+        categoryId: "cat-1",
+        supplierId: null,
+        purchaseOrderId: null,
+        description: "Renta septiembre",
+        date: "2026-08-01",
+        total: 500000,
+      },
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith("Gasto actualizado");
+  });
+
+  it("blocks an edit whose new total is below the sum of payments (EXP-5)", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ExpenseFormModal
+        isOpen
+        expense={makeExpense()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Total del gasto"), {
+      target: { value: "200000" },
+    });
+    await user.click(screen.getByRole("button", { name: /Guardar cambios/i }));
+
+    expect(
+      screen.getByText("El nuevo total no puede ser menor a los pagos registrados"),
+    ).toBeInTheDocument();
+    expect(updateMutateAsyncMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/expenses/expense-status-badge.test.tsx
+++ b/frontend/src/components/expenses/expense-status-badge.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ExpenseStatusBadge } from "./ExpenseStatusBadge";
+
+describe("ExpenseStatusBadge", () => {
+  it("renders Pagado for PAID", () => {
+    render(<ExpenseStatusBadge status="PAID" />);
+
+    expect(screen.getByText("Pagado")).toBeInTheDocument();
+  });
+
+  it("renders Parcial for PARTIAL", () => {
+    render(<ExpenseStatusBadge status="PARTIAL" />);
+
+    expect(screen.getByText("Parcial")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/expenses/history-modal.test.tsx
+++ b/frontend/src/components/expenses/history-modal.test.tsx
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { Expense, ExpenseAuditEntry } from "@/types";
+
+const useExpenseHistoryMock = vi.fn();
+
+vi.mock("@/components/ui/Modal", () => ({
+  Modal: ({
+    isOpen,
+    title,
+    children,
+  }: {
+    isOpen: boolean;
+    title?: string;
+    children: ReactNode;
+  }) =>
+    isOpen ? (
+      <section>
+        {title ? <h2>{title}</h2> : null}
+        {children}
+      </section>
+    ) : null,
+}));
+
+vi.mock("@/hooks/useExpenses", () => ({
+  useExpenseHistory: (id: string) => useExpenseHistoryMock(id),
+}));
+
+import { HistoryModal } from "./HistoryModal";
+
+const expense = {
+  id: "exp-1",
+  organizationId: "org-1",
+  categoryId: "cat-1",
+  supplierId: null,
+  purchaseOrderId: null,
+  description: "Renta agosto",
+  date: "2026-08-01T00:00:00.000Z",
+  total: "500000",
+  status: "PARTIAL",
+  receiptUrl: null,
+  active: true,
+  createdById: "user-1",
+  createdAt: "2026-08-01T00:00:00.000Z",
+  updatedAt: "2026-08-01T00:00:00.000Z",
+  // Decimal fields arrive as strings at runtime (backend Decimal serialization)
+} as unknown as Expense;
+
+const entries: ExpenseAuditEntry[] = [
+  {
+    id: "a-1",
+    userId: "user-1",
+    action: "EXPENSE_CREATED",
+    resource: "Expense",
+    resourceId: "exp-1",
+    metadata: {},
+    createdAt: "2026-08-01T10:00:00.000Z",
+    organizationId: "org-1",
+    user: { name: "Ana Admin", email: "ana@example.com" },
+  },
+  {
+    id: "a-2",
+    userId: "user-1",
+    action: "EXPENSE_PAYMENT_ADDED",
+    resource: "Expense",
+    resourceId: "exp-1",
+    metadata: {},
+    createdAt: "2026-08-02T10:00:00.000Z",
+    organizationId: "org-1",
+    user: { name: "Ana Admin", email: "ana@example.com" },
+  },
+];
+
+describe("HistoryModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useExpenseHistoryMock.mockReturnValue({
+      data: entries,
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("lists human-readable audit entries with user and date", () => {
+    render(<HistoryModal expense={expense} isOpen onClose={vi.fn()} />);
+
+    expect(useExpenseHistoryMock).toHaveBeenCalledWith("exp-1");
+    expect(screen.getByText("Gasto creado")).toBeInTheDocument();
+    expect(screen.getByText("Pago agregado")).toBeInTheDocument();
+    expect(screen.getAllByText("Ana Admin").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("shows a loading message while history is pending", () => {
+    useExpenseHistoryMock.mockReturnValue({ data: undefined, isLoading: true });
+
+    render(<HistoryModal expense={expense} isOpen onClose={vi.fn()} />);
+
+    expect(screen.getByText(/Cargando historial/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/layout/DashboardLayout.test.tsx
+++ b/frontend/src/components/layout/DashboardLayout.test.tsx
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { DashboardLayout } from "./DashboardLayout";
+
+const replaceMock = vi.fn();
+const pushMock = vi.fn();
+const useAuthMock = vi.fn();
+let currentPathname = "/expenses";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: replaceMock, push: pushMock }),
+  usePathname: () => currentPathname,
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock("./Sidebar", () => ({
+  Sidebar: () => null,
+}));
+
+vi.mock("@/components/billing/PlanLimitBanner", () => ({
+  PlanLimitBanner: () => null,
+}));
+
+function setUser(role: string) {
+  useAuthMock.mockReturnValue({
+    isAuthenticated: true,
+    loading: false,
+    user: { id: "user-1", name: "Ana Perez", role, active: true },
+    organization: undefined,
+  });
+}
+
+describe("DashboardLayout route gating for /expenses", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentPathname = "/expenses";
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps ADMIN users on /expenses", () => {
+    setUser("ADMIN");
+
+    render(
+      <DashboardLayout>
+        <p>Salidas</p>
+      </DashboardLayout>
+    );
+
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects CASHIER users away from /expenses to /pos", () => {
+    setUser("CASHIER");
+
+    render(
+      <DashboardLayout>
+        <p>Salidas</p>
+      </DashboardLayout>
+    );
+
+    expect(replaceMock).toHaveBeenCalledWith("/pos");
+  });
+
+  it("redirects INVENTORY_USER users away from /expenses to /dashboard", () => {
+    setUser("INVENTORY_USER");
+
+    render(
+      <DashboardLayout>
+        <p>Salidas</p>
+      </DashboardLayout>
+    );
+
+    expect(replaceMock).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("does not redirect when the pathname is not gated", () => {
+    currentPathname = "/profile";
+    setUser("CASHIER");
+
+    render(
+      <DashboardLayout>
+        <p>Perfil</p>
+      </DashboardLayout>
+    );
+
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -16,6 +16,7 @@ const routeRoleMap: Array<{ prefix: string; roles: UserRole[] }> = [
   { prefix: "/suppliers", roles: ["ADMIN", "INVENTORY_USER"] },
   { prefix: "/purchase-orders", roles: ["ADMIN", "INVENTORY_USER"] },
   { prefix: "/sales", roles: ["ADMIN", "CASHIER"] },
+  { prefix: "/expenses", roles: ["ADMIN"] },
   { prefix: "/customers", roles: ["ADMIN", "CASHIER"] },
   { prefix: "/reports", roles: ["ADMIN"] },
   { prefix: "/users", roles: ["ADMIN"] },

--- a/frontend/src/components/layout/Sidebar.test.tsx
+++ b/frontend/src/components/layout/Sidebar.test.tsx
@@ -6,6 +6,7 @@ import { api } from "@/lib/api";
 
 const pushMock = vi.fn();
 const switchOrganizationMock = vi.fn();
+const useAuthMock = vi.fn();
 
 vi.mock("next/navigation", () => ({
   usePathname: () => "/dashboard",
@@ -32,17 +33,7 @@ vi.mock("@/contexts/ThemeContext", () => ({
 }));
 
 vi.mock("@/contexts/AuthContext", () => ({
-  useAuth: () => ({
-    user: {
-      id: "user-1",
-      name: "Ana Perez",
-      role: "ADMIN",
-      active: true,
-      organizationId: "org-a",
-    },
-    logout: vi.fn(),
-    switchOrganization: switchOrganizationMock,
-  }),
+  useAuth: () => useAuthMock(),
 }));
 
 vi.mock("@/lib/api", () => ({
@@ -80,6 +71,17 @@ const organizations = [
 describe("Sidebar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useAuthMock.mockReturnValue({
+      user: {
+        id: "user-1",
+        name: "Ana Perez",
+        role: "ADMIN",
+        active: true,
+        organizationId: "org-a",
+      },
+      logout: vi.fn(),
+      switchOrganization: switchOrganizationMock,
+    });
   });
 
   it("renders the organization switcher for multi-org users", async () => {
@@ -111,6 +113,75 @@ describe("Sidebar", () => {
 
     expect(
       screen.queryByLabelText(/Cambiar organizacion/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the Salidas nav item for ADMIN users", async () => {
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { organizations },
+    });
+
+    render(<Sidebar />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Org A")).toBeInTheDocument();
+    });
+
+    const link = screen.getByRole("link", { name: "Salidas" });
+    expect(link).toHaveAttribute("href", "/expenses");
+  });
+
+  it("hides the Salidas nav item for CASHIER users", async () => {
+    useAuthMock.mockReturnValue({
+      user: {
+        id: "user-2",
+        name: "Carlos Cajero",
+        role: "CASHIER",
+        active: true,
+        organizationId: "org-a",
+      },
+      logout: vi.fn(),
+      switchOrganization: switchOrganizationMock,
+    });
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { organizations: [organizations[0]] },
+    });
+
+    render(<Sidebar />, { wrapper });
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith("/auth/organizations");
+    });
+
+    expect(
+      screen.queryByRole("link", { name: "Salidas" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the Salidas nav item for INVENTORY_USER users", async () => {
+    useAuthMock.mockReturnValue({
+      user: {
+        id: "user-3",
+        name: "Inventario User",
+        role: "INVENTORY_USER",
+        active: true,
+        organizationId: "org-a",
+      },
+      logout: vi.fn(),
+      switchOrganization: switchOrganizationMock,
+    });
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { organizations: [organizations[0]] },
+    });
+
+    render(<Sidebar />, { wrapper });
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith("/auth/organizations");
+    });
+
+    expect(
+      screen.queryByRole("link", { name: "Salidas" })
     ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -26,6 +26,7 @@ import {
   Clock3,
   ClipboardList,
   Truck,
+  Wallet,
 } from "lucide-react";
 import { useTheme } from "@/contexts/ThemeContext";
 import { cn } from "@/lib/utils";
@@ -76,6 +77,12 @@ const navItems: NavItem[] = [
     href: "/sales",
     icon: <Receipt className="w-4 h-4" />,
     roles: ["ADMIN", "CASHIER"],
+  },
+  {
+    label: "Salidas",
+    href: "/expenses",
+    icon: <Wallet className="w-4 h-4" />,
+    roles: ["ADMIN"],
   },
   {
     label: "Clientes",

--- a/frontend/src/hooks/useExpenses.test.ts
+++ b/frontend/src/hooks/useExpenses.test.ts
@@ -27,6 +27,7 @@ import {
   useUpdateExpenseCategory,
   useUploadExpenseReceipt,
 } from "./useExpenses";
+import type { CreateExpensePayload, ExpensePaymentPayload } from "./useExpenses";
 
 vi.mock("@/lib/api", () => ({
   api: {
@@ -234,7 +235,7 @@ describe("useExpenses", () => {
         wrapper: wrapperWith(queryClient),
       });
 
-      const payload = {
+      const payload: CreateExpensePayload = {
         categoryId: "cat-1",
         description: "Arriendo agosto",
         date: "2026-08-01",
@@ -290,7 +291,11 @@ describe("useExpenses", () => {
         wrapper: wrapperWith(queryClient),
       });
 
-      const payload = { amount: 100000, method: "TRANSFER", date: "2026-08-10" };
+      const payload: ExpensePaymentPayload = {
+        amount: 100000,
+        method: "TRANSFER",
+        date: "2026-08-10",
+      };
       await result.current.mutateAsync({ id: "exp-1", data: payload });
 
       expect(apiMock.post).toHaveBeenCalledWith("/expenses/exp-1/payments", payload);

--- a/frontend/src/hooks/useExpenses.test.ts
+++ b/frontend/src/hooks/useExpenses.test.ts
@@ -1,0 +1,388 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+import { api } from "@/lib/api";
+import type {
+  Expense,
+  ExpenseAuditEntry,
+  ExpenseCategory,
+  ExpenseMonthlySummary,
+  ExpensePayment,
+  PaginatedResponse,
+} from "@/types";
+import {
+  useAddExpensePayment,
+  useCreateExpense,
+  useCreateExpenseCategory,
+  useDeleteExpense,
+  useDeleteExpenseCategory,
+  useDuplicateExpense,
+  useExpense,
+  useExpenseCategories,
+  useExpenseHistory,
+  useExpenses,
+  useExpenseSummary,
+  useUpdateExpense,
+  useUpdateExpenseCategory,
+  useUploadExpenseReceipt,
+} from "./useExpenses";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    upload: vi.fn(),
+  },
+}));
+
+type MockApi = {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  upload: ReturnType<typeof vi.fn>;
+};
+
+const apiMock = api as unknown as MockApi;
+
+function makeCategory(overrides: Partial<ExpenseCategory> = {}): ExpenseCategory {
+  return {
+    id: "cat-1",
+    organizationId: "org-a",
+    name: "Arriendo",
+    active: true,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makePayment(overrides: Partial<ExpensePayment> = {}): ExpensePayment {
+  return {
+    id: "pay-1",
+    expenseId: "exp-1",
+    organizationId: "org-a",
+    amount: 500000,
+    method: "CASH",
+    date: "2026-08-01T00:00:00.000Z",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeExpense(overrides: Partial<Expense> = {}): Expense {
+  return {
+    id: "exp-1",
+    organizationId: "org-a",
+    categoryId: "cat-1",
+    category: makeCategory(),
+    supplierId: null,
+    purchaseOrderId: null,
+    description: "Arriendo agosto",
+    date: "2026-08-01T00:00:00.000Z",
+    total: 500000,
+    status: "PAID",
+    receiptUrl: null,
+    active: true,
+    createdById: "user-1",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    payments: [makePayment()],
+    ...overrides,
+  };
+}
+
+function makePage(items: Expense[]): PaginatedResponse<Expense> {
+  return {
+    data: items,
+    meta: { total: items.length, page: 1, limit: 10, totalPages: 1 },
+  };
+}
+
+function makeSummary(): ExpenseMonthlySummary {
+  return {
+    month: "2026-08",
+    total: 500000,
+    categories: [{ categoryId: "cat-1", name: "Arriendo", total: 500000 }],
+  };
+}
+
+function makeAuditEntry(): ExpenseAuditEntry {
+  return {
+    id: "audit-1",
+    userId: "user-1",
+    action: "EXPENSE_CREATED",
+    resource: "Expense",
+    resourceId: "exp-1",
+    metadata: { summary: "Salida creada" },
+    createdAt: "2026-08-01T00:00:00.000Z",
+    organizationId: "org-a",
+    user: { name: "Ana Perez", email: "ana@example.com" },
+  };
+}
+
+function wrapperWith(queryClient: QueryClient) {
+  return function wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+describe("useExpenses", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("queries", () => {
+    it("fetches the paginated list with query params under the expenses key", async () => {
+      const params = { page: 1, limit: 10, month: "2026-08" };
+      const page = makePage([makeExpense()]);
+      apiMock.get.mockResolvedValue({ data: page });
+
+      const { result } = renderHook(() => useExpenses(params), {
+        wrapper: wrapperWith(makeQueryClient()),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(apiMock.get).toHaveBeenCalledWith("/expenses", params);
+      expect(result.current.data).toEqual(page);
+    });
+
+    it("fetches a single expense by id", async () => {
+      const expense = makeExpense();
+      apiMock.get.mockResolvedValue({ data: expense });
+
+      const { result } = renderHook(() => useExpense("exp-1"), {
+        wrapper: wrapperWith(makeQueryClient()),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(apiMock.get).toHaveBeenCalledWith("/expenses/exp-1");
+      expect(result.current.data).toEqual(expense);
+    });
+
+    it("does not fetch a single expense without an id", () => {
+      renderHook(() => useExpense(""), {
+        wrapper: wrapperWith(makeQueryClient()),
+      });
+
+      expect(apiMock.get).not.toHaveBeenCalled();
+    });
+
+    it("fetches the monthly summary for the requested month", async () => {
+      const summary = makeSummary();
+      apiMock.get.mockResolvedValue({ data: summary });
+
+      const { result } = renderHook(() => useExpenseSummary("2026-08"), {
+        wrapper: wrapperWith(makeQueryClient()),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(apiMock.get).toHaveBeenCalledWith("/expenses/summary/monthly", {
+        month: "2026-08",
+      });
+      expect(result.current.data).toEqual(summary);
+    });
+
+    it("fetches the audit history of an expense", async () => {
+      const entries = [makeAuditEntry()];
+      apiMock.get.mockResolvedValue({ data: entries });
+
+      const { result } = renderHook(() => useExpenseHistory("exp-1"), {
+        wrapper: wrapperWith(makeQueryClient()),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(apiMock.get).toHaveBeenCalledWith("/expenses/exp-1/history");
+      expect(result.current.data).toEqual(entries);
+    });
+
+    it("fetches the expense categories", async () => {
+      const categories = [makeCategory()];
+      apiMock.get.mockResolvedValue({ data: categories });
+
+      const { result } = renderHook(() => useExpenseCategories(), {
+        wrapper: wrapperWith(makeQueryClient()),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(apiMock.get).toHaveBeenCalledWith("/expense-categories");
+      expect(result.current.data).toEqual(categories);
+    });
+  });
+
+  describe("mutations", () => {
+    it("creates an expense and invalidates expense queries", async () => {
+      const queryClient = makeQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      const expense = makeExpense();
+      apiMock.post.mockResolvedValue({ data: expense });
+
+      const { result } = renderHook(() => useCreateExpense(), {
+        wrapper: wrapperWith(queryClient),
+      });
+
+      const payload = {
+        categoryId: "cat-1",
+        description: "Arriendo agosto",
+        date: "2026-08-01",
+        total: 500000,
+        payments: [
+          { amount: 500000, method: "CASH", date: "2026-08-01" },
+        ],
+      };
+
+      await result.current.mutateAsync(payload);
+
+      expect(apiMock.post).toHaveBeenCalledWith("/expenses", payload);
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["expenses"] });
+    });
+
+    it("updates an expense and invalidates expense queries", async () => {
+      const queryClient = makeQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      apiMock.patch.mockResolvedValue({ data: makeExpense() });
+
+      const { result } = renderHook(() => useUpdateExpense(), {
+        wrapper: wrapperWith(queryClient),
+      });
+
+      const payload = { description: "Arriendo septiembre" };
+      await result.current.mutateAsync({ id: "exp-1", data: payload });
+
+      expect(apiMock.patch).toHaveBeenCalledWith("/expenses/exp-1", payload);
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["expenses"] });
+    });
+
+    it("deletes an expense and invalidates expense queries", async () => {
+      const queryClient = makeQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      apiMock.delete.mockResolvedValue({ data: makeExpense() });
+
+      const { result } = renderHook(() => useDeleteExpense(), {
+        wrapper: wrapperWith(queryClient),
+      });
+
+      await result.current.mutateAsync("exp-1");
+
+      expect(apiMock.delete).toHaveBeenCalledWith("/expenses/exp-1");
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["expenses"] });
+    });
+
+    it("adds a payment and invalidates expense queries", async () => {
+      const queryClient = makeQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      apiMock.post.mockResolvedValue({ data: makeExpense() });
+
+      const { result } = renderHook(() => useAddExpensePayment(), {
+        wrapper: wrapperWith(queryClient),
+      });
+
+      const payload = { amount: 100000, method: "TRANSFER", date: "2026-08-10" };
+      await result.current.mutateAsync({ id: "exp-1", data: payload });
+
+      expect(apiMock.post).toHaveBeenCalledWith("/expenses/exp-1/payments", payload);
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["expenses"] });
+    });
+
+    it("duplicates an expense and invalidates expense queries", async () => {
+      const queryClient = makeQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      apiMock.post.mockResolvedValue({ data: makeExpense() });
+
+      const { result } = renderHook(() => useDuplicateExpense(), {
+        wrapper: wrapperWith(queryClient),
+      });
+
+      await result.current.mutateAsync("exp-1");
+
+      expect(apiMock.post).toHaveBeenCalledWith("/expenses/exp-1/duplicate");
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["expenses"] });
+    });
+
+    it("uploads a receipt via multipart and invalidates expense queries", async () => {
+      const queryClient = makeQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      apiMock.upload.mockResolvedValue({ data: makeExpense() });
+
+      const { result } = renderHook(() => useUploadExpenseReceipt(), {
+        wrapper: wrapperWith(queryClient),
+      });
+
+      const file = new File(["receipt"], "comprobante.jpg", {
+        type: "image/jpeg",
+      });
+      await result.current.mutateAsync({ id: "exp-1", file });
+
+      expect(apiMock.upload).toHaveBeenCalledWith("/expenses/exp-1/upload", file);
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["expenses"] });
+    });
+
+    it("creates a category and invalidates category queries", async () => {
+      const queryClient = makeQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      apiMock.post.mockResolvedValue({ data: makeCategory() });
+
+      const { result } = renderHook(() => useCreateExpenseCategory(), {
+        wrapper: wrapperWith(queryClient),
+      });
+
+      await result.current.mutateAsync({ name: "Impuestos" });
+
+      expect(apiMock.post).toHaveBeenCalledWith("/expense-categories", {
+        name: "Impuestos",
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["expense-categories"],
+      });
+    });
+
+    it("updates a category and invalidates category queries", async () => {
+      const queryClient = makeQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      apiMock.patch.mockResolvedValue({ data: makeCategory() });
+
+      const { result } = renderHook(() => useUpdateExpenseCategory(), {
+        wrapper: wrapperWith(queryClient),
+      });
+
+      await result.current.mutateAsync({ id: "cat-1", data: { name: "Seguros" } });
+
+      expect(apiMock.patch).toHaveBeenCalledWith("/expense-categories/cat-1", {
+        name: "Seguros",
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["expense-categories"],
+      });
+    });
+
+    it("deletes a category and invalidates category queries", async () => {
+      const queryClient = makeQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      apiMock.delete.mockResolvedValue({ data: makeCategory() });
+
+      const { result } = renderHook(() => useDeleteExpenseCategory(), {
+        wrapper: wrapperWith(queryClient),
+      });
+
+      await result.current.mutateAsync("cat-1");
+
+      expect(apiMock.delete).toHaveBeenCalledWith("/expense-categories/cat-1");
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["expense-categories"],
+      });
+    });
+  });
+});

--- a/frontend/src/hooks/useExpenses.ts
+++ b/frontend/src/hooks/useExpenses.ts
@@ -1,0 +1,202 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import type {
+  Expense,
+  ExpenseAuditEntry,
+  ExpenseCategory,
+  ExpenseMonthlySummary,
+  ExpenseQueryParams,
+  PaginatedResponse,
+} from "@/types";
+
+export interface ExpensePaymentPayload {
+  amount: number;
+  method: "CASH" | "CARD" | "TRANSFER";
+  date: string;
+}
+
+export interface CreateExpensePayload {
+  categoryId: string;
+  supplierId?: string;
+  purchaseOrderId?: string;
+  description?: string;
+  date: string;
+  total: number;
+  payments: ExpensePaymentPayload[];
+}
+
+export interface UpdateExpensePayload {
+  categoryId?: string;
+  supplierId?: string | null;
+  purchaseOrderId?: string | null;
+  description?: string | null;
+  date?: string;
+  total?: number;
+}
+
+export interface ExpenseCategoryPayload {
+  name: string;
+}
+
+export function useExpenses(params?: ExpenseQueryParams) {
+  return useQuery({
+    queryKey: ["expenses", params],
+    queryFn: () =>
+      api
+        .get<PaginatedResponse<Expense>>("/expenses", params)
+        .then((res) => res.data),
+  });
+}
+
+export function useExpense(id: string) {
+  return useQuery({
+    queryKey: ["expense", id],
+    queryFn: () => api.get<Expense>(`/expenses/${id}`).then((res) => res.data),
+    enabled: !!id,
+  });
+}
+
+export function useExpenseSummary(month: string) {
+  return useQuery({
+    queryKey: ["expenses", "summary", month],
+    queryFn: () =>
+      api
+        .get<ExpenseMonthlySummary>("/expenses/summary/monthly", { month })
+        .then((res) => res.data),
+    enabled: !!month,
+  });
+}
+
+export function useExpenseHistory(id: string) {
+  return useQuery({
+    queryKey: ["expenses", "history", id],
+    queryFn: () =>
+      api
+        .get<ExpenseAuditEntry[]>(`/expenses/${id}/history`)
+        .then((res) => res.data),
+    enabled: !!id,
+  });
+}
+
+export function useExpenseCategories() {
+  return useQuery({
+    queryKey: ["expense-categories"],
+    queryFn: () =>
+      api
+        .get<ExpenseCategory[]>("/expense-categories")
+        .then((res) => res.data),
+  });
+}
+
+export function useCreateExpense() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateExpensePayload) =>
+      api.post<Expense>("/expenses", data).then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+    },
+  });
+}
+
+export function useUpdateExpense() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateExpensePayload }) =>
+      api.patch<Expense>(`/expenses/${id}`, data).then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+    },
+  });
+}
+
+export function useDeleteExpense() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      api.delete<Expense>(`/expenses/${id}`).then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+    },
+  });
+}
+
+export function useAddExpensePayment() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      data,
+    }: {
+      id: string;
+      data: ExpensePaymentPayload;
+    }) =>
+      api.post<Expense>(`/expenses/${id}/payments`, data).then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+    },
+  });
+}
+
+export function useDuplicateExpense() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      api.post<Expense>(`/expenses/${id}/duplicate`).then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+    },
+  });
+}
+
+export function useUploadExpenseReceipt() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, file }: { id: string; file: File }) =>
+      api.upload<Expense>(`/expenses/${id}/upload`, file).then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+    },
+  });
+}
+
+export function useCreateExpenseCategory() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: ExpenseCategoryPayload) =>
+      api
+        .post<ExpenseCategory>("/expense-categories", data)
+        .then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["expense-categories"] });
+    },
+  });
+}
+
+export function useUpdateExpenseCategory() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: ExpenseCategoryPayload }) =>
+      api
+        .patch<ExpenseCategory>(`/expense-categories/${id}`, data)
+        .then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["expense-categories"] });
+    },
+  });
+}
+
+export function useDeleteExpenseCategory() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      api
+        .delete<ExpenseCategory>(`/expense-categories/${id}`)
+        .then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["expense-categories"] });
+    },
+  });
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -466,3 +466,77 @@ export interface BillingStatus {
   trialEndsAt: string | null;
   billingStatus: "PENDING" | "PAID" | "OVERDUE";
 }
+
+export type ExpenseStatus = "PARTIAL" | "PAID";
+
+export interface ExpensePayment {
+  id: string;
+  expenseId: string;
+  organizationId: string;
+  amount: number;
+  method: "CASH" | "CARD" | "TRANSFER";
+  date: string;
+  createdAt: string;
+}
+
+export interface ExpenseCategory {
+  id: string;
+  organizationId: string;
+  name: string;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Expense {
+  id: string;
+  organizationId: string;
+  categoryId: string;
+  category?: ExpenseCategory;
+  supplierId: string | null;
+  supplier?: Supplier | null;
+  purchaseOrderId: string | null;
+  purchaseOrder?: PurchaseOrder | null;
+  description: string | null;
+  date: string;
+  total: number;
+  status: ExpenseStatus;
+  receiptUrl: string | null;
+  active: boolean;
+  createdById: string;
+  createdAt: string;
+  updatedAt: string;
+  payments?: ExpensePayment[];
+}
+
+export interface ExpenseMonthlySummary {
+  month: string;
+  total: number;
+  categories: Array<{
+    categoryId: string;
+    name: string;
+    total: number;
+  }>;
+}
+
+export interface ExpenseAuditEntry {
+  id: string;
+  userId: string | null;
+  action: string;
+  resource: string;
+  resourceId: string | null;
+  metadata: unknown;
+  createdAt: string;
+  organizationId: string;
+  user?: { name: string; email: string } | null;
+}
+
+export type ExpenseQueryParams = {
+  page?: number;
+  limit?: number;
+  month?: string;
+  categoryId?: string;
+  supplierId?: string;
+  status?: ExpenseStatus;
+  search?: string;
+};


### PR DESCRIPTION
Closes #18

## Feature: Salidas (Expenses) module — final integration

This is the **final PR of the feature-branch chain**: tracker `feat/expenses` → `master`. It adds **no new content** — every slice was individually reviewed and merged into this tracker (PR #9, #11, #13, #15, #17, each closing its own issue #8, #10, #12, #14, #16).

### Chain Context

- Strategy: **Feature Branch Chain** (5 slices) — `chained-pr` contract
- State: all 5 slices merged into the tracker; this PR is the single merge to main 📍

```
master  ◄── feat/expenses (tracker, this PR)
                ├─ unit-1 (merged #9)
                ├─ unit-2 (merged #11)
                ├─ unit-3 (merged #13)
                ├─ unit-4 (merged #15)
                └─ unit-5 (merged #17)
```

### What the module does

- **Data**: `Expense`, `ExpensePayment`, `ExpenseCategory` (`Decimal(12,2)`, multi-tenant) + migration with Spanish category backfill; 5 seeded categories (Arriendo, Pago mensual, Seguridad, Salida de empleados, Caja menor)
- **Reglas**: an expense is created with ≥1 payment; derived PARTIAL/PAID status; overpayment rejected; manual recurrence via duplicate; ADMIN-only; audit on every mutation; optional supplier/PO links; COP
- **Endpoints**: CRUD, add payment, monthly summary (Bogota boundaries), duplicate, history, receipt upload (Cloudinary), export (Excel/CSV)
- **Frontend**: "Salidas" sidebar + `/expenses` (ADMIN-only) — summary cards, filtered list, form/payment/history modals, export

### Test evidence (all slices combined)

- Backend: **405/405** tests (36 suites) incl. integration tests against PostgreSQL; build exit 0
- Frontend: **143 passed / 5 failed** — the 5 failures are pre-existing and unrelated (pos scanner ×2, sales `cn` mock ×2, admin spinner ×1)
- Migrations applied locally and in production (Supabase)

### Contributor Checklist

- [x] Issue linked (`Closes #18`)
- [x] Conventional commits, no `Co-Authored-By`
- [x] Tests kept with each work unit
- [x] N/A shellcheck (no shell scripts changed)
