### PR TITLE
feat(expenses): read-only detail view and paid-button clarification

### DIFF
--- a/frontend/src/app/expenses/expenses-page.evidence.test.tsx
+++ b/frontend/src/app/expenses/expenses-page.evidence.test.tsx
@@ -44,6 +44,10 @@ vi.mock("@/components/expenses/HistoryModal", () => ({
   HistoryModal: () => <section>HistoryModal</section>,
 }));
 
+vi.mock("@/components/expenses/ExpenseDetailModal", () => ({
+  ExpenseDetailModal: () => <section>ExpenseDetailModal</section>,
+}));
+
 vi.mock("@/contexts/ToastContext", () => ({
   useToast: () => ({
     success: toastSuccessMock,
@@ -94,6 +98,24 @@ const expenseFixture = {
       organizationId: "org-1",
       amount: "300000",
       method: "CASH",
+      date: "2026-08-01T00:00:00.000Z",
+      createdAt: "2026-08-01T00:00:00.000Z",
+    },
+  ],
+};
+
+const paidExpenseFixture = {
+  ...expenseFixture,
+  id: "exp-2",
+  status: "PAID",
+  description: "Renta julio",
+  payments: [
+    {
+      id: "pay-2",
+      expenseId: "exp-2",
+      organizationId: "org-1",
+      amount: "500000",
+      method: "TRANSFER",
       date: "2026-08-01T00:00:00.000Z",
       createdAt: "2026-08-01T00:00:00.000Z",
     },
@@ -225,6 +247,42 @@ describe("Expenses page evidence", () => {
     await user.click(screen.getByRole("button", { name: "Ver historial" }));
 
     expect(screen.getByText("HistoryModal")).toBeTruthy();
+  });
+
+  it("opens the expense detail modal from the row actions", async () => {
+    const user = userEvent.setup();
+
+    render(<ExpensesPage />);
+
+    await user.click(screen.getByRole("button", { name: "Ver detalle" }));
+
+    expect(screen.getByText("ExpenseDetailModal")).toBeTruthy();
+  });
+
+  it("keeps the add payment button enabled with the Agregar pago label for partial expenses", () => {
+    render(<ExpensesPage />);
+
+    const button = screen.getByRole("button", { name: "Agregar pago" });
+    expect(button).not.toBeDisabled();
+    expect(button).toHaveAttribute("title", "Agregar pago");
+  });
+
+  it("disables the add payment button and exposes the reason for paid expenses", () => {
+    useExpensesMock.mockReturnValue({
+      data: {
+        data: [paidExpenseFixture],
+        meta: { total: 1, page: 1, limit: 15, totalPages: 1 },
+      },
+      isLoading: false,
+    });
+
+    render(<ExpensesPage />);
+
+    const button = screen.getByRole("button", {
+      name: "La salida ya está pagada",
+    });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("title", "La salida ya está pagada");
   });
 
   it("deletes an expense after confirmation (EXP-5)", async () => {

--- a/frontend/src/app/expenses/page.tsx
+++ b/frontend/src/app/expenses/page.tsx
@@ -26,8 +26,10 @@ import { ExpenseSummaryCards } from "@/components/expenses/ExpenseSummaryCards";
 import { ExpenseFormModal } from "@/components/expenses/ExpenseFormModal";
 import { AddPaymentModal } from "@/components/expenses/AddPaymentModal";
 import { HistoryModal } from "@/components/expenses/HistoryModal";
+import { ExpenseDetailModal } from "@/components/expenses/ExpenseDetailModal";
 import {
   Copy,
+  Eye,
   History,
   Pencil,
   Plus,
@@ -61,6 +63,7 @@ export default function ExpensesPage() {
   const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
   const [paymentExpense, setPaymentExpense] = useState<Expense | null>(null);
   const [historyExpense, setHistoryExpense] = useState<Expense | null>(null);
+  const [detailExpense, setDetailExpense] = useState<Expense | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Expense | null>(null);
   const [duplicateTarget, setDuplicateTarget] = useState<Expense | null>(null);
 
@@ -355,7 +358,13 @@ export default function ExpensesPage() {
                         </td>
                       </tr>
                     ) : (
-                      expenses.map((expense) => (
+                      expenses.map((expense) => {
+                        const isPaid = expense.status === "PAID";
+                        const paymentButtonLabel = isPaid
+                          ? "La salida ya está pagada"
+                          : "Agregar pago";
+
+                        return (
                         <TableRow key={expense.id}>
                           <TableCell className="text-muted-foreground whitespace-nowrap font-mono">
                             {formatDate(expense.date)}
@@ -389,9 +398,20 @@ export default function ExpensesPage() {
                                 size="sm"
                                 variant="ghost"
                                 type="button"
-                                aria-label="Agregar pago"
-                                title="Agregar pago"
-                                disabled={expense.status === "PAID"}
+                                aria-label="Ver detalle"
+                                title="Ver detalle"
+                                onClick={() => setDetailExpense(expense)}
+                                className="p-1.5 h-7 w-7"
+                              >
+                                <Eye className="w-3.5 h-3.5" />
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                type="button"
+                                aria-label={paymentButtonLabel}
+                                title={paymentButtonLabel}
+                                disabled={isPaid}
                                 onClick={() => setPaymentExpense(expense)}
                                 className="p-1.5 h-7 w-7"
                               >
@@ -463,7 +483,8 @@ export default function ExpensesPage() {
                             </div>
                           </TableCell>
                         </TableRow>
-                      ))
+                        );
+                      })
                     )}
                   </tbody>
                 </Table>
@@ -507,6 +528,14 @@ export default function ExpensesPage() {
           isOpen
           expense={historyExpense}
           onClose={() => setHistoryExpense(null)}
+        />
+      )}
+
+      {detailExpense && (
+        <ExpenseDetailModal
+          isOpen
+          expense={detailExpense}
+          onClose={() => setDetailExpense(null)}
         />
       )}
 

--- a/frontend/src/components/expenses/ExpenseDetailModal.tsx
+++ b/frontend/src/components/expenses/ExpenseDetailModal.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import Image from "next/image";
+import { Modal } from "@/components/ui/Modal";
+import { ExpenseStatusBadge } from "@/components/expenses/ExpenseStatusBadge";
+import { useExpenseHistory } from "@/hooks/useExpenses";
+import { cn } from "@/lib/utils";
+import { formatCurrency, formatDate, formatDateTime } from "@/lib/utils";
+import { History, Wallet } from "lucide-react";
+import type { Expense, ExpensePayment } from "@/types";
+
+interface Props {
+  expense: Expense;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const PAYMENT_METHOD_LABELS: Record<ExpensePayment["method"], string> = {
+  CASH: "Efectivo",
+  CARD: "Tarjeta",
+  TRANSFER: "Transferencia",
+};
+
+const ACTION_LABELS: Record<string, string> = {
+  EXPENSE_CREATED: "Gasto creado",
+  EXPENSE_UPDATED: "Gasto actualizado",
+  EXPENSE_PAYMENT_ADDED: "Pago agregado",
+  EXPENSE_DUPLICATED: "Gasto duplicado",
+  EXPENSE_RECEIPT_UPLOADED: "Comprobante subido",
+  EXPENSE_DELETED: "Gasto eliminado",
+};
+
+function InfoItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-border/60 bg-muted/20 px-4 py-3">
+      <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-0.5 text-sm font-semibold text-foreground">{value}</p>
+    </div>
+  );
+}
+
+export function ExpenseDetailModal({ expense, isOpen, onClose }: Props) {
+  const { data: entries = [], isLoading } = useExpenseHistory(expense.id);
+
+  const payments = expense.payments ?? [];
+  const paidSum = payments.reduce(
+    (acc, payment) => acc + (Number(payment.amount) || 0),
+    0,
+  );
+  const remaining = Math.max(Number(expense.total) - paidSum, 0);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Detalle del gasto" size="lg">
+      <div className="space-y-6">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Total
+            </p>
+            <p className="stat-number text-2xl font-bold text-foreground">
+              {formatCurrency(Number(expense.total))}
+            </p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {formatDate(expense.date)}
+            </p>
+          </div>
+          <ExpenseStatusBadge status={expense.status} />
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <InfoItem
+            label="Categoría"
+            value={expense.category?.name ?? "—"}
+          />
+          <InfoItem label="Proveedor" value={expense.supplier?.name ?? "—"} />
+          <InfoItem
+            label="Orden de compra"
+            value={
+              expense.purchaseOrder
+                ? `OC-${expense.purchaseOrder.orderNumber}`
+                : "—"
+            }
+          />
+          <InfoItem label="Descripción" value={expense.description ?? "—"} />
+        </div>
+
+        <div>
+          <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Comprobante
+          </p>
+          {expense.receiptUrl ? (
+            <div className="relative h-64 max-w-md rounded-lg border border-border/60 bg-muted/20 overflow-hidden">
+              <Image
+                src={expense.receiptUrl}
+                alt="Comprobante del gasto"
+                fill
+                sizes="(max-width: 768px) 100vw, 448px"
+                unoptimized
+                className="object-contain"
+              />
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">Sin comprobante</p>
+          )}
+        </div>
+
+        <div className="rounded-xl border border-border/60 overflow-hidden">
+          <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border/60 bg-muted/30">
+            <Wallet className="w-4 h-4 text-primary" />
+            <span className="text-xs font-semibold text-foreground">Pagos</span>
+          </div>
+          <div className="p-4">
+            {payments.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                Sin pagos registrados
+              </p>
+            ) : (
+              <ul className="space-y-2">
+                {payments.map((payment) => (
+                  <li
+                    key={payment.id}
+                    className={cn(
+                      "flex flex-wrap items-center justify-between gap-2",
+                      "rounded-lg border border-border/60 bg-muted/20 px-4 py-3",
+                    )}
+                  >
+                    <div className="min-w-0">
+                      <p className="stat-number text-sm font-bold text-foreground">
+                        {formatCurrency(Number(payment.amount))}
+                      </p>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        {PAYMENT_METHOD_LABELS[payment.method] ?? payment.method}{" "}
+                        · {formatDate(payment.date)}
+                      </p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <div className="mt-3 flex items-center justify-between rounded-lg border border-border/60 bg-muted/30 px-4 py-3">
+              <span className="text-xs font-semibold text-muted-foreground">
+                Saldo pendiente
+              </span>
+              <span className="stat-number text-sm font-bold text-foreground">
+                {formatCurrency(remaining)}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div className="flex items-center gap-2 mb-2">
+            <History className="w-4 h-4 text-primary" />
+            <span className="text-xs font-semibold text-foreground">
+              Historial
+            </span>
+          </div>
+          {isLoading ? (
+            <div className="flex flex-col items-center justify-center py-8 gap-3">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+              <p className="text-xs text-muted-foreground">
+                Cargando historial...
+              </p>
+            </div>
+          ) : entries.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              Sin movimientos registrados
+            </p>
+          ) : (
+            <ol className="space-y-3">
+              {entries.map((entry) => (
+                <li
+                  key={entry.id}
+                  className="flex items-start gap-3 rounded-lg border border-border/60 bg-muted/20 px-4 py-3"
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-semibold text-foreground">
+                      {ACTION_LABELS[entry.action] ?? entry.action}
+                    </p>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      {entry.user?.name ?? "—"}
+                    </p>
+                  </div>
+                  <span className="text-xs text-muted-foreground font-mono whitespace-nowrap">
+                    {formatDateTime(entry.createdAt)}
+                  </span>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/expenses/expense-detail-modal.test.tsx
+++ b/frontend/src/components/expenses/expense-detail-modal.test.tsx
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { Expense, ExpenseAuditEntry } from "@/types";
+
+const useExpenseHistoryMock = vi.fn();
+
+vi.mock("@/components/ui/Modal", () => ({
+  Modal: ({
+    isOpen,
+    title,
+    children,
+  }: {
+    isOpen: boolean;
+    title?: string;
+    children: ReactNode;
+  }) =>
+    isOpen ? (
+      <section>
+        {title ? <h2>{title}</h2> : null}
+        {children}
+      </section>
+    ) : null,
+}));
+
+vi.mock("@/hooks/useExpenses", () => ({
+  useExpenseHistory: (id: string) => useExpenseHistoryMock(id),
+}));
+
+import { ExpenseDetailModal } from "./ExpenseDetailModal";
+
+const expense = {
+  id: "exp-1",
+  organizationId: "org-1",
+  categoryId: "cat-1",
+  category: {
+    id: "cat-1",
+    organizationId: "org-1",
+    name: "Arriendo",
+    active: true,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+  },
+  supplierId: "sup-1",
+  supplier: {
+    id: "sup-1",
+    organizationId: "org-1",
+    name: "Proveedor Uno",
+    document: "900123456",
+    active: true,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+  },
+  purchaseOrderId: "po-1",
+  purchaseOrder: {
+    id: "po-1",
+    orderNumber: 101,
+    supplierId: "sup-1",
+    createdById: "user-1",
+    status: "RECEIVED",
+    subtotal: 0,
+    taxAmount: 0,
+    total: 0,
+  },
+  description: "Renta agosto",
+  date: "2026-08-01T00:00:00.000Z",
+  total: "500000",
+  status: "PARTIAL",
+  receiptUrl: "https://cdn.example.com/receipt.png",
+  active: true,
+  createdById: "user-1",
+  createdAt: "2026-08-01T00:00:00.000Z",
+  updatedAt: "2026-08-01T00:00:00.000Z",
+  payments: [
+    {
+      id: "pay-1",
+      expenseId: "exp-1",
+      organizationId: "org-1",
+      amount: "300000",
+      method: "CASH",
+      date: "2026-08-01T00:00:00.000Z",
+      createdAt: "2026-08-01T00:00:00.000Z",
+    },
+    {
+      id: "pay-2",
+      expenseId: "exp-1",
+      organizationId: "org-1",
+      amount: "50000",
+      method: "CARD",
+      date: "2026-08-05T00:00:00.000Z",
+      createdAt: "2026-08-05T00:00:00.000Z",
+    },
+  ],
+  // Decimal fields arrive as strings at runtime (backend Decimal serialization)
+} as unknown as Expense;
+
+const entries: ExpenseAuditEntry[] = [
+  {
+    id: "a-1",
+    userId: "user-1",
+    action: "EXPENSE_CREATED",
+    resource: "Expense",
+    resourceId: "exp-1",
+    metadata: {},
+    createdAt: "2026-08-01T10:00:00.000Z",
+    organizationId: "org-1",
+    user: { name: "Ana Admin", email: "ana@example.com" },
+  },
+  {
+    id: "a-2",
+    userId: "user-1",
+    action: "EXPENSE_PAYMENT_ADDED",
+    resource: "Expense",
+    resourceId: "exp-1",
+    metadata: {},
+    createdAt: "2026-08-02T10:00:00.000Z",
+    organizationId: "org-1",
+    user: { name: "Ana Admin", email: "ana@example.com" },
+  },
+];
+
+describe("ExpenseDetailModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useExpenseHistoryMock.mockReturnValue({
+      data: entries,
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders total, status, category, supplier, purchase order and description", () => {
+    render(<ExpenseDetailModal expense={expense} isOpen onClose={vi.fn()} />);
+
+    expect(screen.getByText("Detalle del gasto")).toBeInTheDocument();
+    expect(screen.getByText(/500\.000/)).toBeInTheDocument();
+    expect(screen.getByText("Parcial")).toBeInTheDocument();
+    expect(screen.getByText("Arriendo")).toBeInTheDocument();
+    expect(screen.getByText("Proveedor Uno")).toBeInTheDocument();
+    expect(screen.getByText("OC-101")).toBeInTheDocument();
+    expect(screen.getByText("Renta agosto")).toBeInTheDocument();
+  });
+
+  it("shows the receipt image when the expense has one", () => {
+    render(<ExpenseDetailModal expense={expense} isOpen onClose={vi.fn()} />);
+
+    const image = screen.getByAltText("Comprobante del gasto");
+    expect(image).toHaveAttribute("src", "https://cdn.example.com/receipt.png");
+  });
+
+  it("shows a placeholder when the expense has no receipt", () => {
+    render(
+      <ExpenseDetailModal
+        expense={{ ...expense, receiptUrl: null } as unknown as Expense}
+        isOpen
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Sin comprobante")).toBeInTheDocument();
+  });
+
+  it("renders payments with method labels and the remaining amount", () => {
+    render(<ExpenseDetailModal expense={expense} isOpen onClose={vi.fn()} />);
+
+    expect(screen.getByText(/^\$\s300\.000$/)).toBeInTheDocument();
+    expect(screen.getByText(/^\$\s50\.000$/)).toBeInTheDocument();
+    expect(screen.getByText(/Efectivo/)).toBeInTheDocument();
+    expect(screen.getByText(/Tarjeta/)).toBeInTheDocument();
+    expect(screen.getByText("Saldo pendiente")).toBeInTheDocument();
+    expect(screen.getByText(/^\$\s150\.000$/)).toBeInTheDocument();
+  });
+
+  it("renders audit history entries inside the same modal", () => {
+    render(<ExpenseDetailModal expense={expense} isOpen onClose={vi.fn()} />);
+
+    expect(useExpenseHistoryMock).toHaveBeenCalledWith("exp-1");
+    expect(screen.getByText("Gasto creado")).toBeInTheDocument();
+    expect(screen.getByText("Pago agregado")).toBeInTheDocument();
+    expect(screen.getAllByText("Ana Admin").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("shows a loading message while history is pending", () => {
+    useExpenseHistoryMock.mockReturnValue({ data: undefined, isLoading: true });
+
+    render(<ExpenseDetailModal expense={expense} isOpen onClose={vi.fn()} />);
+
+    expect(screen.getByText(/Cargando historial/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #20

## Summary

Two UX improvements to the Salidas (expenses) module, frontend-only:

- **`ExpenseDetailModal`** ("Ver"): a read-only detail view combining the expense info (total COP, status badge, date, category, supplier, purchase order, description, receipt image), the payments list with the remaining amount to pay, and the audit history — replacing the need to jump between the separate edit/history modals.
- **Clarified "Agregar pago"**: on PAID expenses the button remains disabled but now exposes "La salida ya está pagada" via `title`/`aria-label` instead of being silent.

## Changes

| File | Change |
|------|--------|
| `frontend/src/components/expenses/ExpenseDetailModal.tsx` | New read-only detail modal |
| `frontend/src/components/expenses/expense-detail-modal.test.tsx` | Tests for the modal |
| `frontend/src/app/expenses/page.tsx` | "Ver" row action + paid-button reason |
| `frontend/src/app/expenses/expenses-page.evidence.test.tsx` | Page tests updated |

## Test Plan

- [x] RED→GREEN: 19/19 on touched files (detail modal renders info/payments/remaining/history; "Ver" opens the modal; paid button exposes the explanation)
- [x] Full frontend suite: **152 passed / 5 failed** — the 5 failures are the pre-existing baseline (pos scanner ×2, sales `cn` mock ×2, admin spinner ×1), untouched
- [x] Scoped ESLint clean on touched files

## Contributor Checklist

- [x] Issue linked (`Closes #20`)
- [x] Conventional commits, no `Co-Authored-By`
- [x] Tests kept with the work unit
- [x] N/A shellcheck (no shell scripts changed)
