### PR TITLE
feat(settings): PR1 foundation + tax (taxable flags, constants, opt-in tax resolver)

### DIFF
--- a/backend/prisma/migrations/20260815010000_add_settings_version_and_taxable_flags/migration.sql
+++ b/backend/prisma/migrations/20260815010000_add_settings_version_and_taxable_flags/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "Organization" ADD COLUMN     "settingsVersion" INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "Category" ADD COLUMN     "taxable" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "Product" ADD COLUMN     "taxable" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -15,6 +15,7 @@ model Organization {
   phone              String?
   address            String?
   settings           Json                   @default("{}")
+  settingsVersion    Int                    @default(0)
   active             Boolean                @default(true)
   createdAt          DateTime               @default(now())
   updatedAt          DateTime               @updatedAt
@@ -136,6 +137,7 @@ model Category {
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt
   defaultTaxRate Decimal?     @db.Decimal(5, 2)
+  taxable        Boolean      @default(false)
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   products       Product[]
@@ -153,6 +155,7 @@ model Product {
   costPrice           Decimal             @db.Decimal(10, 2)
   salePrice           Decimal             @db.Decimal(10, 2)
   taxRate             Decimal             @default(0) @db.Decimal(5, 2)
+  taxable             Boolean             @default(false)
   stock               Int                 @default(0)
   minStock            Int                 @default(0)
   imageUrl            String?

--- a/backend/src/common/constants/locale.constants.ts
+++ b/backend/src/common/constants/locale.constants.ts
@@ -1,0 +1,3 @@
+export const CURRENCY = 'COP';
+export const LOCALE = 'es-CO';
+export const TIMEZONE = 'America/Bogota';

--- a/backend/src/common/utils/tax.util.spec.ts
+++ b/backend/src/common/utils/tax.util.spec.ts
@@ -1,121 +1,65 @@
-import { resolveEffectiveTaxRate, hasExplicitTaxOverride } from './tax.util';
+import { resolveEffectiveTaxRate } from './tax.util';
 import { Decimal } from '@prisma/client/runtime/library';
 
-describe('resolveEffectiveTaxRate', () => {
-  const SETTINGS_RATE = 19;
-  const CATEGORY_RATE = 16;
-  const PRODUCT_RATE = 5;
-
-  describe('product-level override takes precedence', () => {
-    it('should use product taxRate when it is non-zero', () => {
-      const result = resolveEffectiveTaxRate(
-        PRODUCT_RATE,
-        CATEGORY_RATE,
-        SETTINGS_RATE,
-      );
-      expect(result).toBe(PRODUCT_RATE);
+describe('resolveEffectiveTaxRate(product, category)', () => {
+  describe('product opted-in (taxable=true) takes precedence', () => {
+    it('returns the product rate when both product and category are opted in', () => {
+      const product = { taxable: true, taxRate: 5 };
+      const category = { taxable: true, defaultTaxRate: 16 };
+      expect(resolveEffectiveTaxRate(product, category)).toBe(5);
     });
 
-    it('should use product taxRate even when category is null', () => {
-      const result = resolveEffectiveTaxRate(PRODUCT_RATE, null, SETTINGS_RATE);
-      expect(result).toBe(PRODUCT_RATE);
-    });
-
-    it('should accept Decimal product taxRate', () => {
-      const result = resolveEffectiveTaxRate(
-        new Decimal('8.5'),
-        CATEGORY_RATE,
-        SETTINGS_RATE,
-      );
-      expect(result).toBe(8.5);
+    it('returns the product rate even when the category is opted in with a different rate', () => {
+      const product = { taxable: true, taxRate: new Decimal('8.5') };
+      const category = { taxable: true, defaultTaxRate: 16 };
+      expect(resolveEffectiveTaxRate(product, category)).toBe(8.5);
     });
   });
 
-  describe('category default fallback', () => {
-    it('should use category defaultRate when product taxRate is 0', () => {
-      const result = resolveEffectiveTaxRate(0, CATEGORY_RATE, SETTINGS_RATE);
-      expect(result).toBe(CATEGORY_RATE);
+  describe('category opted-in fallback', () => {
+    it('returns the category defaultTaxRate when the product is not opted in', () => {
+      const product = { taxable: false, taxRate: 0 };
+      const category = { taxable: true, defaultTaxRate: 16 };
+      expect(resolveEffectiveTaxRate(product, category)).toBe(16);
     });
 
-    it('should use category defaultRate when product taxRate is null', () => {
-      const result = resolveEffectiveTaxRate(
-        null,
-        CATEGORY_RATE,
-        SETTINGS_RATE,
-      );
-      expect(result).toBe(CATEGORY_RATE);
-    });
-
-    it('should use category defaultRate when product taxRate is undefined', () => {
-      const result = resolveEffectiveTaxRate(
-        undefined,
-        CATEGORY_RATE,
-        SETTINGS_RATE,
-      );
-      expect(result).toBe(CATEGORY_RATE);
-    });
-
-    it('should accept Decimal category rate', () => {
-      const result = resolveEffectiveTaxRate(
-        0,
-        new Decimal('10.5'),
-        SETTINGS_RATE,
-      );
-      expect(result).toBe(10.5);
+    it('accepts a Decimal category rate', () => {
+      const product = { taxable: false, taxRate: 0 };
+      const category = { taxable: true, defaultTaxRate: new Decimal('10.5') };
+      expect(resolveEffectiveTaxRate(product, category)).toBe(10.5);
     });
   });
 
-  describe('settings global fallback', () => {
-    it('should use settings rate when product is 0 and category is null', () => {
-      const result = resolveEffectiveTaxRate(0, null, SETTINGS_RATE);
-      expect(result).toBe(SETTINGS_RATE);
+  describe('no tax by default (opt-in only)', () => {
+    it('returns 0 when neither product nor category is opted in', () => {
+      const product = { taxable: false, taxRate: 0 };
+      const category = { taxable: false, defaultTaxRate: 0 };
+      expect(resolveEffectiveTaxRate(product, category)).toBe(0);
     });
 
-    it('should use settings rate when product is 0 and category is 0', () => {
-      const result = resolveEffectiveTaxRate(0, 0, SETTINGS_RATE);
-      expect(result).toBe(SETTINGS_RATE);
+    it('returns 0 when the category is opted in but has no rate', () => {
+      const product = { taxable: false, taxRate: 0 };
+      const category = { taxable: true, defaultTaxRate: null };
+      expect(resolveEffectiveTaxRate(product, category)).toBe(0);
     });
 
-    it('should accept Decimal settings rate', () => {
-      const result = resolveEffectiveTaxRate(0, null, new Decimal('19'));
-      expect(result).toBe(19);
+    it('returns 0 when the category is null', () => {
+      const product = { taxable: false, taxRate: 0 };
+      expect(resolveEffectiveTaxRate(product, null)).toBe(0);
     });
   });
 
-  describe('edge cases', () => {
-    it('should handle all zeros — returns settings rate', () => {
-      const result = resolveEffectiveTaxRate(0, 0, 0);
-      expect(result).toBe(0);
+  describe('defensive: opted-in without a usable rate', () => {
+    it('falls back to the category when the product is opted in but has no rate', () => {
+      const product = { taxable: true, taxRate: null };
+      const category = { taxable: true, defaultTaxRate: 16 };
+      expect(resolveEffectiveTaxRate(product, category)).toBe(16);
     });
 
-    it('should handle negative product rate as "not set" — falls to category', () => {
-      // Defensive: negative rates should not happen but should not crash
-      const result = resolveEffectiveTaxRate(-1, CATEGORY_RATE, SETTINGS_RATE);
-      expect(result).toBe(CATEGORY_RATE);
+    it('returns 0 when the product is opted in with rate 0 and category is not opted in', () => {
+      const product = { taxable: true, taxRate: 0 };
+      const category = { taxable: false, defaultTaxRate: 0 };
+      expect(resolveEffectiveTaxRate(product, category)).toBe(0);
     });
-  });
-});
-
-describe('hasExplicitTaxOverride', () => {
-  it('returns true for non-zero product taxRate', () => {
-    expect(hasExplicitTaxOverride(19)).toBe(true);
-    expect(hasExplicitTaxOverride(0.01)).toBe(true);
-  });
-
-  it('returns false for zero product taxRate', () => {
-    expect(hasExplicitTaxOverride(0)).toBe(false);
-  });
-
-  it('returns false for null/undefined', () => {
-    expect(hasExplicitTaxOverride(null)).toBe(false);
-    expect(hasExplicitTaxOverride(undefined)).toBe(false);
-  });
-
-  it('returns true for Decimal non-zero', () => {
-    expect(hasExplicitTaxOverride(new Decimal('5'))).toBe(true);
-  });
-
-  it('returns false for Decimal zero', () => {
-    expect(hasExplicitTaxOverride(new Decimal('0'))).toBe(false);
   });
 });

--- a/backend/src/common/utils/tax.util.ts
+++ b/backend/src/common/utils/tax.util.ts
@@ -1,68 +1,52 @@
 import { Decimal } from '@prisma/client/runtime/library';
 
-/**
- * Resolves the effective tax rate for a product following this precedence:
- *
- *   1. Product-level taxRate (explicit override) → ALWAYS wins
- *   2. Category defaultTaxRate                   → fallback
- *   3. Settings global taxRate                   → final fallback
- *
- * "Explicit override" on a product means the taxRate was explicitly provided
- * (non-null/undefined in the input). Since Product.taxRate has @default(0),
- * a value of 0 stored in the DB means "not explicitly set" for the purpose
- * of fallback resolution.
- *
- * @param productTaxRate        - The product's own taxRate (from DB or DTO)
- * @param categoryDefaultRate   - The product's category defaultTaxRate (nullable)
- * @param settingsRate          - The global settings taxRate
- * @returns                     - The effective tax rate as a number
- */
-export function resolveEffectiveTaxRate(
-  productTaxRate: number | Decimal | null | undefined,
-  categoryDefaultRate: number | Decimal | null | undefined,
-  settingsRate: number | Decimal,
-): number {
-  const settings = toNumber(settingsRate);
+export interface TaxableProduct {
+  taxable: boolean;
+  taxRate?: number | Decimal | null;
+}
 
-  // 1. Product-level explicit override
-  if (productTaxRate != null) {
-    const productRate = toNumber(productTaxRate);
-    // A non-zero product taxRate is treated as an explicit override
-    if (productRate > 0) {
-      return productRate;
-    }
-  }
-
-  // 2. Category default fallback
-  if (categoryDefaultRate != null) {
-    const categoryRate = toNumber(categoryDefaultRate);
-    if (categoryRate > 0) {
-      return categoryRate;
-    }
-  }
-
-  // 3. Global settings fallback
-  return settings;
+export interface TaxableCategory {
+  taxable: boolean;
+  defaultTaxRate?: number | Decimal | null;
 }
 
 /**
- * Determines whether a product's taxRate was explicitly set (override)
- * vs relying on the default value of 0.
+ * Resolves the effective tax rate for a product using opt-in precedence:
  *
- * A taxRate of exactly 0 is considered "not explicitly set" since
- * Product.taxRate has @default(0) in the schema.
+ *   1. Product opted-in (`taxable=true`) with a usable rate → product rate
+ *   2. Category opted-in (`taxable=true`) with a usable rate → category rate
+ *   3. Otherwise → 0 (no tax by default)
+ *
+ * Tax is opt-in only. There is no global rate and no magic-number fallback.
+ *
+ * @param product  - the product (needs `taxable` + `taxRate`)
+ * @param category - the product's category (needs `taxable` + `defaultTaxRate`)
+ * @returns        - the effective tax rate as a number
  */
-export function hasExplicitTaxOverride(
-  productTaxRate: number | Decimal | null | undefined,
-): boolean {
-  if (productTaxRate == null) return false;
-  return toNumber(productTaxRate) > 0;
+export function resolveEffectiveTaxRate(
+  product: TaxableProduct,
+  category?: TaxableCategory | null,
+): number {
+  if (product.taxable) {
+    const rate = toNumber(product.taxRate);
+    if (rate > 0) return rate;
+  }
+
+  if (category?.taxable) {
+    const rate = toNumber(category.defaultTaxRate);
+    if (rate > 0) return rate;
+  }
+
+  return 0;
 }
 
 /**
  * Safely converts a Decimal or number to a plain JS number.
+ * Returns 0 for null/undefined — an opted-in entity without a rate is
+ * treated as "no rate".
  */
-function toNumber(value: number | Decimal): number {
+function toNumber(value: number | Decimal | null | undefined): number {
+  if (value == null) return 0;
   if (typeof value === 'number') return value;
   return Number(value.toString());
 }

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,2 +1,6 @@
 export const APP_NAME = 'MeperPOS';
 export const APP_DESCRIPTION = 'Sistema de inventario y punto de venta';
+
+export const CURRENCY = 'COP';
+export const LOCALE = 'es-CO';
+export const TIMEZONE = 'America/Bogota';


### PR DESCRIPTION
## Scope — PR1: foundation + tax (Work Unit 1)

First slice of the `settings-refactor` change (~234 changed lines, under the 400-line budget).

### In this PR
- **1.1** Prisma migration: `Organization.settingsVersion Int @default(0)` (optimistic lock), `Product.taxable Boolean @default(false)`, `Category.taxable Boolean @default(false)`.
- **1.2** Locale/currency/timezone constants: `backend/src/common/constants/locale.constants.ts` + `frontend/src/lib/constants.ts` (`CURRENCY='COP'`, `LOCALE='es-CO'`, `TIMEZONE='America/Bogota'`). Consumers are NOT refactored yet (later PR).
- **2.1/2.2** Tax resolver rewritten to `resolveEffectiveTaxRate(product, category)` — opt-in precedence (product → category → 0), no global rate, no `?? 19`. Strict TDD (RED → GREEN, 9 specs).

### Requirements
- SR-1 (settingsVersion lock foundation), SR-4 (opt-in tax, no global rate, unified resolution), SR-6 (currency/locale/timezone centralization).

### Start / End
- **Start**: `settings-refactor` tracker head.
- **End**: additive migration + constants + new tax resolver signature, all specs green.

### Dependencies
```
settings-refactor (tracker)
└── 📍 settings-refactor-pr1-foundation-tax   ← this PR (PR1)
```

### Out of scope (later PRs)
- Consumer migration (`products.service.ts`, `sales.service.ts`, `imports.service.ts`) — still call the old 3-arg signature; migrated in PR3.
- Typed settings engine (PR2), frontend sub-sidebar (PR4/5).

### Verification
- Backend: `npm run test -- --testPathPatterns=tax.util` → 9 passed.
- Schema: `npx prisma validate` → valid. Migration SQL generated via `npx prisma migrate diff` (local DB unreachable; `migrate dev` NOT applied).
