### PR TITLE
feat(settings): typed settings engine with merge-on-write and optimistic lock

### DIFF
--- a/backend/src/settings/defaults.ts
+++ b/backend/src/settings/defaults.ts
@@ -1,0 +1,19 @@
+import { CURRENCY, LOCALE, TIMEZONE } from '../common/constants/locale.constants';
+import type { InvoicingSettings, LocaleSettings } from './schema';
+
+/**
+ * Single defaults registry for the typed settings engine.
+ *
+ * Invalid persisted values fall back to these defaults on read (see validator).
+ * Currency/locale/timezone are centralized constants, not per-org settings.
+ */
+export const DEFAULT_INVOICING: InvoicingSettings = {
+  printHeader: '',
+  printFooter: '',
+};
+
+export const DEFAULT_LOCALE: LocaleSettings = {
+  currency: CURRENCY,
+  locale: LOCALE,
+  timezone: TIMEZONE,
+};

--- a/backend/src/settings/dto/settings.dto.ts
+++ b/backend/src/settings/dto/settings.dto.ts
@@ -1,29 +1,7 @@
-import { IsString, IsOptional, IsNumber, Min } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
-import { ApiPropertyOptional } from '@nestjs/swagger/dist/decorators';
+import { IsString, IsOptional, IsObject } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateSettingsDto {
-  @ApiPropertyOptional({ example: 'Mi Empresa S.A.S.' })
-  @IsString()
-  @IsOptional()
-  companyName?: string;
-
-  @ApiPropertyOptional({ example: 'USD' })
-  @IsString()
-  @IsOptional()
-  currency?: string;
-
-  @ApiPropertyOptional({ example: 19, minimum: 0, maximum: 100 })
-  @IsNumber()
-  @IsOptional()
-  @Min(0)
-  taxRate?: number;
-
-  @ApiPropertyOptional({ example: 'REC-' })
-  @IsString()
-  @IsOptional()
-  receiptPrefix?: string;
-
   @ApiPropertyOptional({ example: 'Empresa ABC - Comprobante #' })
   @IsString()
   @IsOptional()
@@ -34,31 +12,8 @@ export class UpdateSettingsDto {
   @IsOptional()
   printFooter?: string;
 
-  @ApiPropertyOptional({ example: 'https://example.com/logo.png' })
-  @IsString()
+  @ApiPropertyOptional({ example: { theme: 'dark' } })
+  @IsObject()
   @IsOptional()
-  logoUrl?: string;
-}
-
-export class SettingsResponseDto {
-  @ApiProperty({ example: 'Mi Negocio' })
-  companyName: string;
-
-  @ApiProperty({ example: 'COP' })
-  currency: string;
-
-  @ApiProperty({ example: 19 })
-  taxRate: number;
-
-  @ApiProperty({ example: 'REC-' })
-  receiptPrefix: string;
-
-  @ApiProperty({ example: 'Comprobante de Pago' })
-  printHeader?: string;
-
-  @ApiProperty({ example: 'Gracias por su compra' })
-  printFooter?: string;
-
-  @ApiPropertyOptional({ example: 'https://example.com/logo.png' })
-  logoUrl?: string;
+  custom?: Record<string, unknown>;
 }

--- a/backend/src/settings/migration.spec.ts
+++ b/backend/src/settings/migration.spec.ts
@@ -1,0 +1,84 @@
+import { normalizeSettingsJson } from './migration';
+
+describe('normalizeSettingsJson', () => {
+  const ctx = { logoUrl: null };
+
+  it('moves companyName to Organization.name and removes it from settings', () => {
+    const result = normalizeSettingsJson(
+      { companyName: 'Acme', printHeader: 'H' },
+      ctx,
+    );
+
+    expect(result.organizationName).toBe('Acme');
+    expect(result.settings.companyName).toBeUndefined();
+    expect(result.settings.printHeader).toBe('H');
+  });
+
+  it('moves logoUrl to top-level when top-level is empty', () => {
+    const result = normalizeSettingsJson(
+      { logoUrl: 'https://cdn/new.png' },
+      ctx,
+    );
+
+    expect(result.logoUrl).toBe('https://cdn/new.png');
+    expect(result.settings.logoUrl).toBeUndefined();
+  });
+
+  it('keeps the existing top-level logoUrl (top-level wins)', () => {
+    const result = normalizeSettingsJson(
+      { logoUrl: 'https://cdn/new.png' },
+      { logoUrl: 'https://cdn/existing.png' },
+    );
+
+    expect(result.logoUrl).toBeUndefined();
+    expect(result.settings.logoUrl).toBeUndefined();
+  });
+
+  it('moves receiptPrefix to the SALE sequence prefix', () => {
+    const result = normalizeSettingsJson({ receiptPrefix: 'INV-' }, ctx);
+
+    expect(result.receiptPrefix).toBe('INV-');
+    expect(result.settings.receiptPrefix).toBeUndefined();
+  });
+
+  it('moves unknown ad-hoc keys into custom and preserves downgradeFlags', () => {
+    const result = normalizeSettingsJson(
+      {
+        printHeader: 'H',
+        adhoc: 'x',
+        another: 1,
+        downgradeFlags: { a: true },
+      },
+      ctx,
+    );
+
+    expect(result.settings.custom).toEqual({ adhoc: 'x', another: 1 });
+    expect(result.settings.downgradeFlags).toEqual({ a: true });
+    expect(result.settings.printHeader).toBe('H');
+  });
+
+  it('merges into an existing custom section', () => {
+    const result = normalizeSettingsJson(
+      { custom: { existing: 'yes' }, adhoc: 'x' },
+      ctx,
+    );
+
+    expect(result.settings.custom).toEqual({ existing: 'yes', adhoc: 'x' });
+  });
+
+  it('is a no-op for already-normalized settings (re-runnable)', () => {
+    const input = {
+      printHeader: 'H',
+      printFooter: 'F',
+      downgradeFlags: { a: 1 },
+      custom: { k: 'v' },
+    };
+
+    const result = normalizeSettingsJson(input, ctx);
+
+    expect(result.organizationName).toBeUndefined();
+    expect(result.logoUrl).toBeUndefined();
+    expect(result.receiptPrefix).toBeUndefined();
+    expect(result.settings).toEqual(input);
+  });
+});

--- a/backend/src/settings/migration.ts
+++ b/backend/src/settings/migration.ts
@@ -1,0 +1,147 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { CORE_KEY_SET, SYSTEM_KEY_SET } from './schema';
+
+/** Type guard for plain objects. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Current Organization state needed to decide relocation targets. */
+export interface NormalizeContext {
+  /** Current `Organization.logoUrl` — the top-level value wins on conflict. */
+  logoUrl: string | null;
+}
+
+/** Result of normalizing one organization's settings JSON. */
+export interface NormalizedSettings {
+  /** The settings JSON to persist (relocated legacy keys removed). */
+  settings: Record<string, unknown>;
+  /** New `Organization.name`, set only when `settings.companyName` was present. */
+  organizationName?: string;
+  /** New `Organization.logoUrl`, set only when `settings.logoUrl` moved. */
+  logoUrl?: string;
+  /** New SALE sequence prefix, set only when `settings.receiptPrefix` was present. */
+  receiptPrefix?: string;
+}
+
+/**
+ * Idempotent, key-presence-guarded JSON normalize for the settings refactor:
+ *
+ * - `companyName`  → `Organization.name` (then removed from the blob)
+ * - `logoUrl`      → `Organization.logoUrl` (top-level wins; then removed)
+ * - `receiptPrefix`→ SALE sequence `prefix` (then removed)
+ * - unknown ad-hoc keys → `custom` section
+ * - `downgradeFlags` (system key) is preserved untouched
+ *
+ * Each relocation only fires when its source key is present, so the function is
+ * a no-op once the sources have been removed (re-runnable).
+ */
+export function normalizeSettingsJson(
+  raw: Record<string, unknown>,
+  ctx: NormalizeContext,
+): NormalizedSettings {
+  const next: Record<string, unknown> = {};
+  const custom: Record<string, unknown> = {};
+
+  let organizationName: string | undefined;
+  let logoUrl: string | undefined;
+  let receiptPrefix: string | undefined;
+
+  for (const [key, value] of Object.entries(raw)) {
+    if (SYSTEM_KEY_SET.has(key)) {
+      next[key] = value;
+    } else if (CORE_KEY_SET.has(key)) {
+      next[key] = value;
+    } else if (key === 'custom') {
+      if (isRecord(value)) Object.assign(custom, value);
+    } else if (key === 'companyName') {
+      if (typeof value === 'string' && value.length > 0) {
+        organizationName = value;
+      }
+    } else if (key === 'logoUrl') {
+      if (typeof value === 'string' && value.length > 0 && !ctx.logoUrl) {
+        logoUrl = value;
+      }
+    } else if (key === 'receiptPrefix') {
+      if (typeof value === 'string' && value.length > 0) {
+        receiptPrefix = value;
+      }
+    } else {
+      custom[key] = value;
+    }
+  }
+
+  if (Object.keys(custom).length > 0) {
+    next.custom = custom;
+  }
+
+  return { settings: next, organizationName, logoUrl, receiptPrefix };
+}
+
+/**
+ * Applies the JSON normalize across organizations. Not wired into any
+ * endpoint; invoked once as a data migration (re-runnable).
+ */
+@Injectable()
+export class SettingsMigrationService {
+  constructor(private prisma: PrismaService) {}
+
+  async migrateOrganization(organizationId: string): Promise<NormalizedSettings> {
+    const org = await this.prisma.organization.findUnique({
+      where: { id: organizationId },
+      select: { name: true, logoUrl: true, settings: true },
+    });
+
+    if (!org) {
+      throw new NotFoundException('Organization not found');
+    }
+
+    const raw = isRecord(org.settings) ? org.settings : {};
+    const normalized = normalizeSettingsJson(raw, { logoUrl: org.logoUrl });
+
+    const data: {
+      name?: string;
+      logoUrl?: string;
+      settings: Prisma.InputJsonValue;
+    } = { settings: normalized.settings as Prisma.InputJsonValue };
+
+    if (normalized.organizationName !== undefined) {
+      data.name = normalized.organizationName;
+    }
+    if (normalized.logoUrl !== undefined) {
+      data.logoUrl = normalized.logoUrl;
+    }
+
+    await this.prisma.organization.update({
+      where: { id: organizationId },
+      data,
+    });
+
+    if (normalized.receiptPrefix !== undefined) {
+      const sequence = await this.prisma.organizationSequence.findFirst({
+        where: { organizationId, type: 'SALE' },
+        orderBy: { year: 'desc' },
+      });
+      if (sequence) {
+        await this.prisma.organizationSequence.update({
+          where: { id: sequence.id },
+          data: { prefix: normalized.receiptPrefix },
+        });
+      }
+    }
+
+    return normalized;
+  }
+
+  async migrateAll(): Promise<number> {
+    const organizations = await this.prisma.organization.findMany({
+      select: { id: true },
+    });
+    for (const organization of organizations) {
+      await this.migrateOrganization(organization.id);
+    }
+    return organizations.length;
+  }
+}

--- a/backend/src/settings/schema.ts
+++ b/backend/src/settings/schema.ts
@@ -1,0 +1,49 @@
+/**
+ * Typed settings engine schema.
+ *
+ * The `Organization.settings` JSON blob is described by two kinds of keys:
+ *
+ * - **Core params** (`printHeader`, `printFooter`): typed, code-defined, runtime
+ *   validated, editable by users.
+ * - **System keys** (`downgradeFlags`): managed by the backend, never writable
+ *   through the user settings PUT.
+ *
+ * Anything else persisted in the blob is surfaced/preserved under `custom`.
+ */
+
+/** System-managed keys that user writes must never touch. */
+export const SYSTEM_KEYS = ['downgradeFlags'] as const;
+
+/** Typed core params that live at the root of the settings JSON blob. */
+export const CORE_KEYS = ['printHeader', 'printFooter'] as const;
+
+export type SystemKey = (typeof SYSTEM_KEYS)[number];
+export type CoreKey = (typeof CORE_KEYS)[number];
+
+export const SYSTEM_KEY_SET: ReadonlySet<string> = new Set(SYSTEM_KEYS);
+export const CORE_KEY_SET: ReadonlySet<string> = new Set(CORE_KEYS);
+
+export interface InvoicingSettings {
+  printHeader: string;
+  printFooter: string;
+}
+
+export interface LocaleSettings {
+  currency: string;
+  locale: string;
+  timezone: string;
+}
+
+/** The single, fully-hydrated settings view exposed to readers. */
+export interface SettingsView {
+  organization: {
+    name: string;
+    logoUrl: string | null;
+  };
+  invoicing: InvoicingSettings;
+  receipt: {
+    prefix: string | null;
+  };
+  locale: LocaleSettings;
+  custom: Record<string, unknown>;
+}

--- a/backend/src/settings/settings.module.ts
+++ b/backend/src/settings/settings.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { SettingsService } from './settings.service';
+import { SettingsMigrationService } from './migration';
 import { SettingsController } from './settings.controller';
 import { CloudinaryModule } from '../cloudinary/cloudinary.module';
 import { OrganizationRequiredGuard } from '../common/guards/organization-required.guard';
@@ -8,7 +9,12 @@ import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organ
 @Module({
   imports: [CloudinaryModule],
   controllers: [SettingsController],
-  providers: [SettingsService, OrganizationRequiredGuard, AdminOrganizationInterceptor],
-  exports: [SettingsService],
+  providers: [
+    SettingsService,
+    SettingsMigrationService,
+    OrganizationRequiredGuard,
+    AdminOrganizationInterceptor,
+  ],
+  exports: [SettingsService, SettingsMigrationService],
 })
 export class SettingsModule {}

--- a/backend/src/settings/settings.service.spec.ts
+++ b/backend/src/settings/settings.service.spec.ts
@@ -1,4 +1,8 @@
-import { BadRequestException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
 import { SettingsService } from './settings.service';
 
 describe('SettingsService', () => {
@@ -7,7 +11,11 @@ describe('SettingsService', () => {
   const prismaMock = {
     organization: {
       findUnique: jest.fn(),
+      updateMany: jest.fn(),
       update: jest.fn(),
+    },
+    organizationSequence: {
+      findFirst: jest.fn(),
     },
   };
 
@@ -20,104 +28,222 @@ describe('SettingsService', () => {
     service = new SettingsService(prismaMock as never, cloudinaryMock as never);
   });
 
-  it('find returns settings from organization.settings JSON', async () => {
-    prismaMock.organization.findUnique.mockResolvedValue({
-      settings: {
-        companyName: 'Acme Corp',
-        currency: 'USD',
-        taxRate: 10,
-        receiptPrefix: 'ACME-',
-      },
-    });
-
-    const result = await service.find('org-1');
-
-    expect(prismaMock.organization.findUnique).toHaveBeenCalledWith({
-      where: { id: 'org-1' },
-      select: { settings: true },
-    });
-    expect(result).toEqual({
-      companyName: 'Acme Corp',
-      currency: 'USD',
-      taxRate: 10,
-      receiptPrefix: 'ACME-',
-    });
-  });
-
-  it('find returns empty object when organization has no settings', async () => {
-    prismaMock.organization.findUnique.mockResolvedValue({ settings: {} });
-
-    const result = await service.find('org-1');
-
-    expect(result).toEqual({});
-  });
-
-  it('find returns empty object when organization is not found', async () => {
-    prismaMock.organization.findUnique.mockResolvedValue(null);
-
-    const result = await service.find('org-1');
-
-    expect(result).toEqual({});
-  });
-
-  it('update persists settings into organization.settings', async () => {
-    prismaMock.organization.update.mockResolvedValue({
-      id: 'org-1',
-      settings: { companyName: 'New Name' },
-    });
-
-    const result = await service.update('org-1', {
-      companyName: 'New Name',
-    } as any);
-
-    expect(prismaMock.organization.update).toHaveBeenCalledWith({
-      where: { id: 'org-1' },
-      data: { settings: { companyName: 'New Name' } },
-    });
-    expect(result).toEqual({
-      id: 'org-1',
-      settings: { companyName: 'New Name' },
-    });
-  });
-
-  it('uploadLogo uploads image and stores url in organization.settings', async () => {
-    const file = { originalname: 'logo.png' } as Express.Multer.File;
-    cloudinaryMock.uploadImage.mockResolvedValue(
-      'https://cloudinary.com/logo.png',
-    );
-    prismaMock.organization.update.mockResolvedValue({
-      id: 'org-1',
-      settings: { logoUrl: 'https://cloudinary.com/logo.png' },
-    });
-
-    const result = await service.uploadLogo('org-1', file);
-
-    expect(cloudinaryMock.uploadImage).toHaveBeenCalledWith(file, 'logos');
-    expect(prismaMock.organization.update).toHaveBeenCalledWith({
-      where: { id: 'org-1' },
-      data: {
+  describe('find', () => {
+    it('hydrates a full SettingsView from Organization + SALE sequence', async () => {
+      prismaMock.organization.findUnique.mockResolvedValue({
+        name: 'Acme Corp',
+        logoUrl: 'https://cdn/acme.png',
         settings: {
-          logoUrl: 'https://cloudinary.com/logo.png',
+          printHeader: 'Acme - Comprobante',
+          printFooter: 'Gracias por su compra',
+          downgradeFlags: { usersOverLimit: true },
+          custom: { theme: 'dark' },
+          legacyKey: 'preserved',
         },
-      },
+        settingsVersion: 2,
+      });
+      prismaMock.organizationSequence.findFirst.mockResolvedValue({
+        prefix: 'ACME',
+      });
+
+      const result = await service.find('org-1');
+
+      expect(prismaMock.organization.findUnique).toHaveBeenCalledWith({
+        where: { id: 'org-1' },
+        select: { name: true, logoUrl: true, settings: true, settingsVersion: true },
+      });
+      expect(prismaMock.organizationSequence.findFirst).toHaveBeenCalledWith({
+        where: { organizationId: 'org-1', type: 'SALE' },
+        orderBy: { year: 'desc' },
+        select: { prefix: true },
+      });
+      expect(result).toEqual({
+        organization: { name: 'Acme Corp', logoUrl: 'https://cdn/acme.png' },
+        invoicing: { printHeader: 'Acme - Comprobante', printFooter: 'Gracias por su compra' },
+        receipt: { prefix: 'ACME' },
+        locale: { currency: 'COP', locale: 'es-CO', timezone: 'America/Bogota' },
+        custom: { theme: 'dark', legacyKey: 'preserved' },
+      });
     });
-    expect(result).toEqual({ logoUrl: 'https://cloudinary.com/logo.png' });
+
+    it('falls back to defaults for invalid persisted values (no throw)', async () => {
+      prismaMock.organization.findUnique.mockResolvedValue({
+        name: 'Acme Corp',
+        logoUrl: null,
+        settings: { printHeader: 123, printFooter: null },
+        settingsVersion: 0,
+      });
+      prismaMock.organizationSequence.findFirst.mockResolvedValue(null);
+
+      const result = await service.find('org-1');
+
+      expect(result.invoicing).toEqual({ printHeader: '', printFooter: '' });
+      expect(result.receipt.prefix).toBeNull();
+    });
+
+    it('returns a default view when the organization is not found', async () => {
+      prismaMock.organization.findUnique.mockResolvedValue(null);
+
+      const result = await service.find('org-1');
+
+      expect(result).toEqual({
+        organization: { name: '', logoUrl: null },
+        invoicing: { printHeader: '', printFooter: '' },
+        receipt: { prefix: null },
+        locale: { currency: 'COP', locale: 'es-CO', timezone: 'America/Bogota' },
+        custom: {},
+      });
+    });
+
+    it('returns a default view without an organizationId and skips the query', async () => {
+      const result = await service.find(undefined);
+
+      expect(result.organization.name).toBe('');
+      expect(prismaMock.organization.findUnique).not.toHaveBeenCalled();
+    });
   });
 
-  it('uploadLogo throws BadRequestException when no file is provided', async () => {
-    await expect(
-      service.uploadLogo('org-1', undefined as never),
-    ).rejects.toBeInstanceOf(BadRequestException);
+  describe('update', () => {
+    it('merges typed params into existing settings without full-replace', async () => {
+      prismaMock.organization.findUnique.mockResolvedValue({
+        name: 'Acme Corp',
+        logoUrl: null,
+        settings: {
+          printHeader: 'Old Header',
+          downgradeFlags: { usersOverLimit: false },
+          custom: { theme: 'light' },
+          legacyKey: 'keep-me',
+        },
+        settingsVersion: 4,
+      });
+      prismaMock.organization.updateMany.mockResolvedValue({ count: 1 });
+      prismaMock.organizationSequence.findFirst.mockResolvedValue({
+        prefix: 'ACME',
+      });
+
+      const result = await service.update('org-1', {
+        printFooter: 'New Footer',
+      } as never);
+
+      expect(prismaMock.organization.updateMany).toHaveBeenCalledWith({
+        where: { id: 'org-1', settingsVersion: 4 },
+        data: {
+          settings: {
+            printHeader: 'Old Header',
+            downgradeFlags: { usersOverLimit: false },
+            printFooter: 'New Footer',
+            custom: { theme: 'light', legacyKey: 'keep-me' },
+          },
+          settingsVersion: { increment: 1 },
+        },
+      });
+      expect(result.invoicing.printFooter).toBe('New Footer');
+      expect(result.receipt.prefix).toBe('ACME');
+    });
+
+    it('overlays custom without dropping existing custom keys', async () => {
+      prismaMock.organization.findUnique.mockResolvedValue({
+        name: 'Acme Corp',
+        logoUrl: null,
+        settings: { custom: { theme: 'light' } },
+        settingsVersion: 1,
+      });
+      prismaMock.organization.updateMany.mockResolvedValue({ count: 1 });
+      prismaMock.organizationSequence.findFirst.mockResolvedValue(null);
+
+      await service.update('org-1', { custom: { lang: 'es' } } as never);
+
+      expect(prismaMock.organization.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            settings: expect.objectContaining({
+              custom: { theme: 'light', lang: 'es' },
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('rejects writes to the downgradeFlags system key', async () => {
+      await expect(
+        service.update('org-1', {
+          downgradeFlags: { usersOverLimit: true },
+        } as never),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(prismaMock.organization.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('throws ConflictException when the optimistic lock detects a concurrent write', async () => {
+      prismaMock.organization.findUnique.mockResolvedValue({
+        name: 'Acme Corp',
+        logoUrl: null,
+        settings: {},
+        settingsVersion: 2,
+      });
+      prismaMock.organization.updateMany.mockResolvedValue({ count: 0 });
+
+      await expect(
+        service.update('org-1', { printHeader: 'X' } as never),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('throws NotFoundException when the organization does not exist', async () => {
+      prismaMock.organization.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.update('org-1', { printHeader: 'X' } as never),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('throws BadRequestException without an organizationId', async () => {
+      await expect(
+        service.update(undefined, {} as never),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
   });
 
-  it('getDefaultSettings returns fallback values', () => {
-    const result = service.getDefaultSettings();
+  describe('uploadLogo', () => {
+    it('writes the URL to Organization.logoUrl (top-level)', async () => {
+      const file = { originalname: 'logo.png' } as Express.Multer.File;
+      cloudinaryMock.uploadImage.mockResolvedValue('https://cdn/logo.png');
+      prismaMock.organization.update.mockResolvedValue({
+        id: 'org-1',
+        logoUrl: 'https://cdn/logo.png',
+      });
 
-    expect(result).toEqual({
-      companyName: 'Mi Negocio',
-      currency: 'COP',
-      taxRate: 19,
-      receiptPrefix: 'REC-',
+      const result = await service.uploadLogo('org-1', file);
+
+      expect(cloudinaryMock.uploadImage).toHaveBeenCalledWith(file, 'logos');
+      expect(prismaMock.organization.update).toHaveBeenCalledWith({
+        where: { id: 'org-1' },
+        data: { logoUrl: 'https://cdn/logo.png' },
+      });
+      expect(result).toEqual({ logoUrl: 'https://cdn/logo.png' });
+    });
+
+    it('throws BadRequestException when no file is provided', async () => {
+      await expect(
+        service.uploadLogo('org-1', undefined as never),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws BadRequestException without an organizationId', async () => {
+      await expect(
+        service.uploadLogo(undefined, {} as never),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('getDefaultSettings', () => {
+    it('returns the defaults registry as a SettingsView', () => {
+      expect(service.getDefaultSettings()).toEqual({
+        organization: { name: '', logoUrl: null },
+        invoicing: { printHeader: '', printFooter: '' },
+        receipt: { prefix: null },
+        locale: { currency: 'COP', locale: 'es-CO', timezone: 'America/Bogota' },
+        custom: {},
+      });
     });
   });
 });

--- a/backend/src/settings/settings.service.ts
+++ b/backend/src/settings/settings.service.ts
@@ -1,17 +1,83 @@
-import { Injectable, BadRequestException } from '@nestjs/common';
+import {
+  Injectable,
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { UpdateSettingsDto } from './dto/settings.dto';
 import { CloudinaryService } from '../cloudinary/cloudinary.service';
+import {
+  CORE_KEY_SET,
+  SYSTEM_KEY_SET,
+  type SettingsView,
+} from './schema';
+import { DEFAULT_INVOICING, DEFAULT_LOCALE } from './defaults';
+import { validateInvoicing } from './validator';
 
-export interface OrganizationSettings {
-  companyName?: string;
-  currency?: string;
-  taxRate?: number;
-  receiptPrefix?: string;
-  printHeader?: string;
-  printFooter?: string;
-  logoUrl?: string;
-  [key: string]: unknown;
+/** Type guard for plain objects (Prisma `Json` values come back as objects). */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Surfaces the free-form `custom` section plus any unknown ad-hoc keys that
+ * still live at the root of the persisted blob.
+ */
+export function extractCustom(
+  settings: Record<string, unknown>,
+): Record<string, unknown> {
+  const custom: Record<string, unknown> = isRecord(settings.custom)
+    ? { ...settings.custom }
+    : {};
+
+  for (const [key, value] of Object.entries(settings)) {
+    if (CORE_KEY_SET.has(key) || SYSTEM_KEY_SET.has(key) || key === 'custom') {
+      continue;
+    }
+    custom[key] = value;
+  }
+
+  return custom;
+}
+
+/**
+ * Merge-on-write helper. Never full-replaces:
+ *
+ * - system keys (`downgradeFlags`) are copied through untouched;
+ * - typed core params (`printHeader`, `printFooter`) are overlaid from `incoming`;
+ * - `custom` is merged key-by-key;
+ * - unknown persisted root keys are normalized into `custom` (no data loss).
+ */
+export function mergeSettingsJson(
+  existing: Record<string, unknown>,
+  incoming: UpdateSettingsDto,
+): Record<string, unknown> {
+  const next: Record<string, unknown> = {};
+  const custom: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(existing)) {
+    if (SYSTEM_KEY_SET.has(key)) {
+      next[key] = value;
+    } else if (CORE_KEY_SET.has(key)) {
+      next[key] = value;
+    } else if (key === 'custom') {
+      if (isRecord(value)) Object.assign(custom, value);
+    } else {
+      custom[key] = value;
+    }
+  }
+
+  if (incoming.printHeader !== undefined) next.printHeader = incoming.printHeader;
+  if (incoming.printFooter !== undefined) next.printFooter = incoming.printFooter;
+  if (incoming.custom !== undefined && isRecord(incoming.custom)) {
+    Object.assign(custom, incoming.custom);
+  }
+
+  if (Object.keys(custom).length > 0) next.custom = custom;
+
+  return next;
 }
 
 @Injectable()
@@ -21,37 +87,85 @@ export class SettingsService {
     private cloudinaryService: CloudinaryService,
   ) {}
 
-  async find(organizationId: string | undefined): Promise<OrganizationSettings> {
+  /**
+   * Single read path for organization settings.
+   * Hydrates `Organization` (name/logoUrl/settings/version) + the SALE
+   * sequence prefix into a `SettingsView`, applying defaults on invalid values.
+   */
+  async find(organizationId?: string): Promise<SettingsView> {
     if (!organizationId) {
-      return {};
+      return this.buildDefaultView();
     }
+
     const org = await this.prisma.organization.findUnique({
       where: { id: organizationId },
-      select: { settings: true },
+      select: { name: true, logoUrl: true, settings: true, settingsVersion: true },
     });
-    return (org?.settings as OrganizationSettings) ?? {};
+
+    if (!org) {
+      return this.buildDefaultView();
+    }
+
+    const prefix = await this.readSalePrefix(organizationId);
+
+    return this.buildView(
+      org.name,
+      org.logoUrl,
+      isRecord(org.settings) ? org.settings : {},
+      prefix,
+    );
   }
 
+  /**
+   * Merge-on-write with optimistic locking.
+   *
+   * Reads the current `settingsVersion`, overlays typed params + `custom` onto
+   * the existing blob (never full-replace), then writes via `updateMany`
+   * guarded by that version. A concurrent write yields `count === 0` → 409.
+   */
   async update(
     organizationId: string | undefined,
     dto: UpdateSettingsDto,
-  ): Promise<unknown> {
+  ): Promise<SettingsView> {
     if (!organizationId) {
       throw new BadRequestException('Organization ID is required for this operation');
     }
-    return this.prisma.organization.update({
+
+    this.assertNoSystemKeyWrites(dto);
+
+    const org = await this.prisma.organization.findUnique({
       where: { id: organizationId },
-      data: { settings: dto as any },
+      select: { name: true, logoUrl: true, settings: true, settingsVersion: true },
     });
+
+    if (!org) {
+      throw new NotFoundException('Organization not found');
+    }
+
+    const existing = isRecord(org.settings) ? org.settings : {};
+    const merged = mergeSettingsJson(existing, dto);
+
+    const result = await this.prisma.organization.updateMany({
+      where: { id: organizationId, settingsVersion: org.settingsVersion },
+      data: {
+        settings: merged as Prisma.InputJsonValue,
+        settingsVersion: { increment: 1 },
+      },
+    });
+
+    if (result.count === 0) {
+      throw new ConflictException(
+        'Settings were modified concurrently. Please reload and try again.',
+      );
+    }
+
+    const prefix = await this.readSalePrefix(organizationId);
+
+    return this.buildView(org.name, org.logoUrl, merged, prefix);
   }
 
-  getDefaultSettings(): Partial<OrganizationSettings> {
-    return {
-      companyName: 'Mi Negocio',
-      currency: 'COP',
-      taxRate: 19,
-      receiptPrefix: 'REC-',
-    };
+  getDefaultSettings(): SettingsView {
+    return this.buildDefaultView();
   }
 
   async uploadLogo(
@@ -69,14 +183,54 @@ export class SettingsService {
 
     await this.prisma.organization.update({
       where: { id: organizationId },
-      data: {
-        settings: {
-          ...(await this.find(organizationId)),
-          logoUrl,
-        } as any,
-      },
+      data: { logoUrl },
     });
 
     return { logoUrl };
+  }
+
+  private async readSalePrefix(organizationId: string): Promise<string | null> {
+    const sequence = await this.prisma.organizationSequence.findFirst({
+      where: { organizationId, type: 'SALE' },
+      orderBy: { year: 'desc' },
+      select: { prefix: true },
+    });
+    return sequence?.prefix ?? null;
+  }
+
+  private assertNoSystemKeyWrites(dto: UpdateSettingsDto): void {
+    const payload = dto as Record<string, unknown>;
+    for (const key of SYSTEM_KEY_SET) {
+      if (key in payload && payload[key] !== undefined) {
+        throw new BadRequestException(
+          `Setting '${key}' is system-managed and cannot be updated`,
+        );
+      }
+    }
+  }
+
+  private buildView(
+    name: string,
+    logoUrl: string | null,
+    settings: Record<string, unknown>,
+    prefix: string | null,
+  ): SettingsView {
+    return {
+      organization: { name, logoUrl },
+      invoicing: validateInvoicing(settings),
+      receipt: { prefix },
+      locale: { ...DEFAULT_LOCALE },
+      custom: extractCustom(settings),
+    };
+  }
+
+  private buildDefaultView(): SettingsView {
+    return {
+      organization: { name: '', logoUrl: null },
+      invoicing: { ...DEFAULT_INVOICING },
+      receipt: { prefix: null },
+      locale: { ...DEFAULT_LOCALE },
+      custom: {},
+    };
   }
 }

--- a/backend/src/settings/validator.ts
+++ b/backend/src/settings/validator.ts
@@ -1,0 +1,23 @@
+import { DEFAULT_INVOICING } from './defaults';
+import type { InvoicingSettings } from './schema';
+
+/**
+ * Runtime validation for typed core params.
+ *
+ * Invalid values fall back to the registry default and NEVER throw — reads
+ * must be resilient to whatever was persisted in the JSON blob historically.
+ */
+export function validateInvoicing(
+  raw: Record<string, unknown>,
+): InvoicingSettings {
+  return {
+    printHeader:
+      typeof raw.printHeader === 'string'
+        ? raw.printHeader
+        : DEFAULT_INVOICING.printHeader,
+    printFooter:
+      typeof raw.printFooter === 'string'
+        ? raw.printFooter
+        : DEFAULT_INVOICING.printFooter,
+  };
+}


### PR DESCRIPTION
## Summary

Work unit 2 of the \settings-refactor\ change: the **typed settings engine**. Replaces the free-form \Organization.settings\ full-replace PUT with a code-defined schema, single defaults registry, runtime validation (invalid → default, never throw), merge-on-write semantics, and optimistic locking via \settingsVersion\.

## Chain context (feature-branch-chain)

- PR #1 (foundation + tax) → merged into tracker \settings-refactor\: target base is \settings-refactor-pr1-foundation-tax\
- 📍 **This PR** → targets \settings-refactor-pr1-foundation-tax\
- Next: PR3 (backend consumers products/sales/imports/billing/admin) → targets this branch
- Tracker \settings-refactor\ → \master\ (only the tracker merges to master)

## In scope

- \schema.ts\: typed core params, \SYSTEM_KEYS=['downgradeFlags']\, \SettingsView\
- \defaults.ts\ + \alidator.ts\: single defaults registry + runtime validation
- \settings.service.ts\: \ind()\ hydrates \SettingsView\; \update()\ merges + \updateMany\ optimistic lock (409 on conflict); rejects \downgradeFlags\ writes; logo → \Organization.logoUrl\
- \settings.dto.ts\: drops companyName/currency/taxRate/receiptPrefix; adds \custom\
- \migration.ts\: idempotent JSON normalize (companyName/logoUrl/receiptPrefix relocation, unknown → custom, preserve downgradeFlags)

## Out of scope (next PR)

- Backend consumers (products/sales/imports/billing/admin) still read the old flat shape — they will be migrated in PR3.
- Frontend.

## Verification

- \
pm run test -- --testPathPatterns=settings\ → 21/21 (settings.service 14 + migration 7)
- \
px prisma validate\ → valid
- \
px prisma generate\ (client regenerated to pick up \settingsVersion\)

## Rollback boundary

Revert \ackend/src/settings/\*\ (engine files + DTO). Consumers untouched.