### PR TITLE
refactor(backend): migrate consumers to settings engine and unified tax

### DIFF
--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -16,6 +16,7 @@ import { OrgRole, OrgStatus, PlanType, Prisma } from '@prisma/client';
 import { PlanLimitService } from '../plan-limits/plan-limits.service';
 import { PLAN_LIMITS, LimitType } from '../plan-limits/plan-limits.constants';
 import { DEFAULT_EXPENSE_CATEGORY_NAMES } from '../expenses/default-expense-categories';
+import { isRecord, mergeSettingsJson } from '../settings/settings.service';
 
 @Injectable()
 export class AdminService {

--- a/backend/src/billing/billing.service.spec.ts
+++ b/backend/src/billing/billing.service.spec.ts
@@ -1,0 +1,62 @@
+import { BillingService } from './billing.service';
+
+describe('BillingService', () => {
+  let service: BillingService;
+
+  const prismaMock = {
+    organization: {
+      findUnique: jest.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new BillingService(prismaMock as never);
+  });
+
+  it('returns null when no organizationId is provided', async () => {
+    expect(await service.getStatus(undefined)).toBeNull();
+    expect(prismaMock.organization.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('exposes only the downgradeFlags system key (never other settings)', async () => {
+    prismaMock.organization.findUnique.mockResolvedValue({
+      id: 'org-1',
+      plan: 'PRO',
+      status: 'ACTIVE',
+      trialEndsAt: null,
+      billingStatus: 'PAID',
+      settings: {
+        printHeader: 'secret header',
+        downgradeFlags: { usersOverLimit: true },
+        custom: { theme: 'dark' },
+      },
+    });
+
+    const result = await service.getStatus('org-1');
+
+    expect(result).toEqual({
+      id: 'org-1',
+      plan: 'PRO',
+      status: 'ACTIVE',
+      trialEndsAt: null,
+      billingStatus: 'PAID',
+      settings: { downgradeFlags: { usersOverLimit: true } },
+    });
+  });
+
+  it('returns empty settings when no system keys are present', async () => {
+    prismaMock.organization.findUnique.mockResolvedValue({
+      id: 'org-1',
+      plan: 'BASIC',
+      status: 'ACTIVE',
+      trialEndsAt: null,
+      billingStatus: 'PENDING',
+      settings: { printHeader: 'h' },
+    });
+
+    const result = await service.getStatus('org-1');
+
+    expect(result?.settings).toEqual({});
+  });
+});

--- a/backend/src/billing/billing.service.ts
+++ b/backend/src/billing/billing.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { SYSTEM_KEY_SET } from '../settings/schema';
 
 @Injectable()
 export class BillingService {
@@ -9,7 +10,7 @@ export class BillingService {
     if (!organizationId) {
       return null;
     }
-    return this.prisma.organization.findUnique({
+    const org = await this.prisma.organization.findUnique({
       where: { id: organizationId },
       select: {
         id: true,
@@ -20,5 +21,30 @@ export class BillingService {
         settings: true,
       },
     });
+
+    if (!org) {
+      return null;
+    }
+
+    // Expose only system-managed keys (e.g. downgradeFlags). These are never
+    // user-writable — the settings engine rejects writes to them on PUT.
+    const raw = org.settings as Record<string, unknown> | null;
+    const settings: Record<string, unknown> = {};
+    if (raw && typeof raw === 'object') {
+      for (const key of SYSTEM_KEY_SET) {
+        if (key in raw && raw[key] !== undefined) {
+          settings[key] = raw[key];
+        }
+      }
+    }
+
+    return {
+      id: org.id,
+      plan: org.plan,
+      status: org.status,
+      trialEndsAt: org.trialEndsAt,
+      billingStatus: org.billingStatus,
+      settings,
+    };
   }
 }

--- a/backend/src/imports/imports.module.ts
+++ b/backend/src/imports/imports.module.ts
@@ -2,12 +2,11 @@ import { Module } from '@nestjs/common';
 import { ImportsController } from './imports.controller';
 import { ImportsService } from './imports.service';
 import { ProductsModule } from '../products/products.module';
-import { SettingsModule } from '../settings/settings.module';
 import { OrganizationRequiredGuard } from '../common/guards/organization-required.guard';
 import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
 
 @Module({
-  imports: [ProductsModule, SettingsModule],
+  imports: [ProductsModule],
   controllers: [ImportsController],
   providers: [ImportsService, OrganizationRequiredGuard, AdminOrganizationInterceptor],
 })

--- a/backend/src/imports/imports.service.ts
+++ b/backend/src/imports/imports.service.ts
@@ -11,7 +11,6 @@ import { Prisma, type Category } from '@prisma/client';
 import * as ExcelJS from 'exceljs';
 import { PrismaService } from '../prisma/prisma.service';
 import { ProductsService } from '../products/products.service';
-import { SettingsService } from '../settings/settings.service';
 import type { RetryImportRowDto } from './dto/import.dto';
 import {
   detectColumnMapping,
@@ -91,7 +90,6 @@ interface ImportJobInternal {
   seenSkusInFileLower: Set<string>;
   seenBarcodesInFileLower: Set<string>;
   categoriesByNormalizedName: Map<string, Category>;
-  settingsTaxRate: number;
 }
 
 const MAX_FILE_ROWS = 5000;
@@ -118,7 +116,6 @@ export class ImportsService implements OnModuleDestroy {
   constructor(
     private readonly prisma: PrismaService,
     private readonly productsService: ProductsService,
-    private readonly settingsService: SettingsService,
   ) {
     this.cleanupInterval = setInterval(
       () => {
@@ -166,13 +163,12 @@ export class ImportsService implements OnModuleDestroy {
       );
     }
 
-    const [products, categories, settings] = await Promise.all([
+    const [products, categories] = await Promise.all([
       this.prisma.product.findMany({
         where: { organizationId },
         select: { sku: true, barcode: true },
       }),
       this.prisma.category.findMany({ where: { organizationId } }),
-      this.settingsService.find(organizationId),
     ]);
 
     const job: ImportJobInternal = {
@@ -210,7 +206,6 @@ export class ImportsService implements OnModuleDestroy {
           category,
         ]),
       ),
-      settingsTaxRate: settings?.taxRate ? Number(settings.taxRate) : 0,
     };
 
     this.jobs.set(job.id, job);
@@ -272,12 +267,8 @@ export class ImportsService implements OnModuleDestroy {
         dto.rowIndex,
       );
 
-      const effectiveTaxRate = this.resolveEffectiveTaxRate(
-        parsed.data.taxRate,
-        parsed.data.taxRateProvided,
-        category,
-        job,
-      );
+      const taxable = parsed.data.taxRateProvided && parsed.data.taxRate > 0;
+      const taxRate = taxable ? parsed.data.taxRate : 0;
 
       await this.productsService.create(
         {
@@ -287,7 +278,8 @@ export class ImportsService implements OnModuleDestroy {
           description: parsed.data.description,
           costPrice: parsed.data.costPrice,
           salePrice: parsed.data.salePrice,
-          taxRate: effectiveTaxRate,
+          taxable,
+          taxRate,
           stock: parsed.data.stock,
           minStock: parsed.data.minStock,
           categoryId: category.id,
@@ -295,7 +287,6 @@ export class ImportsService implements OnModuleDestroy {
         userId,
         job.organizationId,
       );
-
       job.importedCount += 1;
       job.errorCount = Math.max(0, job.errorCount - 1);
       unresolvedError.retried = true;
@@ -507,12 +498,8 @@ export class ImportsService implements OnModuleDestroy {
         row.rowIndex,
       );
 
-      const effectiveTaxRate = this.resolveEffectiveTaxRate(
-        parsed.data.taxRate,
-        parsed.data.taxRateProvided,
-        category,
-        job,
-      );
+      const taxable = parsed.data.taxRateProvided && parsed.data.taxRate > 0;
+      const taxRate = taxable ? parsed.data.taxRate : 0;
 
       await this.productsService.create(
         {
@@ -522,7 +509,8 @@ export class ImportsService implements OnModuleDestroy {
           description: parsed.data.description,
           costPrice: parsed.data.costPrice,
           salePrice: parsed.data.salePrice,
-          taxRate: effectiveTaxRate,
+          taxable,
+          taxRate,
           stock: parsed.data.stock,
           minStock: parsed.data.minStock,
           categoryId: category.id,
@@ -1038,33 +1026,6 @@ export class ImportsService implements OnModuleDestroy {
 
       throw error;
     }
-  }
-
-  /**
-   * Resolves the effective tax rate for a product based on precedence:
-   * 1. Explicit value from CSV (taxRateProvided=true) → use as-is
-   * 2. Category's defaultTaxRate → if set
-   * 3. Global settings tax rate → fallback
-   * 4. 0 → last resort
-   */
-  private resolveEffectiveTaxRate(
-    parsedTaxRate: number,
-    taxRateProvided: boolean,
-    category: Category,
-    job: ImportJobInternal,
-  ): number {
-    if (taxRateProvided) {
-      return parsedTaxRate;
-    }
-
-    if (
-      category.defaultTaxRate !== null &&
-      category.defaultTaxRate !== undefined
-    ) {
-      return Number(category.defaultTaxRate);
-    }
-
-    return job.settingsTaxRate;
   }
 
   private mapProductCreationError(

--- a/backend/src/products/dto/product.dto.ts
+++ b/backend/src/products/dto/product.dto.ts
@@ -43,6 +43,11 @@ export class CreateProductDto {
   @IsOptional()
   taxRate?: number;
 
+  @ApiProperty({ example: false, required: false })
+  @IsBoolean()
+  @IsOptional()
+  taxable?: boolean;
+
   @ApiProperty({ example: 10 })
   @IsNumber()
   @Min(0)
@@ -101,6 +106,11 @@ export class UpdateProductDto {
   @Min(0)
   @IsOptional()
   taxRate?: number;
+
+  @ApiProperty({ example: false, required: false })
+  @IsBoolean()
+  @IsOptional()
+  taxable?: boolean;
 
   @ApiProperty({ example: 10, required: false })
   @IsNumber()

--- a/backend/src/products/products.module.ts
+++ b/backend/src/products/products.module.ts
@@ -2,13 +2,12 @@ import { Module } from '@nestjs/common';
 import { ProductsService } from './products.service';
 import { ProductsController } from './products.controller';
 import { CloudinaryModule } from '../cloudinary/cloudinary.module';
-import { SettingsModule } from '../settings/settings.module';
 import { PlanLimitsModule } from '../plan-limits/plan-limits.module';
 import { OrganizationRequiredGuard } from '../common/guards/organization-required.guard';
 import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
 
 @Module({
-  imports: [CloudinaryModule, SettingsModule, PlanLimitsModule],
+  imports: [CloudinaryModule, PlanLimitsModule],
   controllers: [ProductsController],
   providers: [ProductsService, OrganizationRequiredGuard, AdminOrganizationInterceptor],
   exports: [ProductsService],

--- a/backend/src/products/products.service.int.spec.ts
+++ b/backend/src/products/products.service.int.spec.ts
@@ -4,10 +4,6 @@ import { ProductsService } from './products.service';
 const prisma = new PrismaClient();
 
 // Minimal mocks for dependencies not under test
-const settingsServiceMock = {
-  find: jest.fn().mockResolvedValue({}),
-};
-
 const cloudinaryServiceMock = {};
 const planLimitServiceMock = {};
 
@@ -20,7 +16,6 @@ describe('ProductsService — Integration (Query Isolation)', () => {
   beforeAll(async () => {
     service = new ProductsService(
       prisma as never,
-      settingsServiceMock as never,
       cloudinaryServiceMock as never,
       planLimitServiceMock as never,
     );

--- a/backend/src/products/products.service.spec.ts
+++ b/backend/src/products/products.service.spec.ts
@@ -1,7 +1,11 @@
-import { NotFoundException, ConflictException } from '@nestjs/common';
+import {
+  NotFoundException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
 import { ProductsService } from './products.service';
 
-describe('ProductsService — Tax Precedence', () => {
+describe('ProductsService — Opt-in tax resolution', () => {
   let service: ProductsService;
 
   // ── Mocks ──────────────────────────────────────────────────────────
@@ -24,10 +28,6 @@ describe('ProductsService — Tax Precedence', () => {
     },
   };
 
-  const settingsServiceMock = {
-    find: jest.fn(),
-  };
-
   const cloudinaryServiceMock = {};
 
   const planLimitServiceMock = {
@@ -38,11 +38,15 @@ describe('ProductsService — Tax Precedence', () => {
   const ORG_ID = 'org-1';
 
   // ── Shared fixtures ────────────────────────────────────────────────
-  const categoryWithDefault = (defaultTaxRate: number | null) => ({
+  const categoryWithDefault = (
+    defaultTaxRate: number | null,
+    taxable = false,
+  ) => ({
     id: 'cat-1',
     name: 'Electrónica',
     description: null,
     defaultTaxRate,
+    taxable,
     active: true,
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -56,6 +60,7 @@ describe('ProductsService — Tax Precedence', () => {
     description: null,
     costPrice: 100,
     salePrice: 150,
+    taxable: overrides.taxable ?? false,
     taxRate: overrides.taxRate ?? 0,
     stock: 10,
     minStock: 5,
@@ -65,7 +70,7 @@ describe('ProductsService — Tax Precedence', () => {
     version: 1,
     createdAt: new Date(),
     updatedAt: new Date(),
-    category: overrides.category ?? categoryWithDefault(16),
+    category: overrides.category ?? categoryWithDefault(null, false),
     ...overrides,
   });
 
@@ -75,7 +80,6 @@ describe('ProductsService — Tax Precedence', () => {
     service = new ProductsService(
       prismaMock as never,
       cloudinaryServiceMock as never,
-      settingsServiceMock as never,
       planLimitServiceMock as never,
     );
   });
@@ -94,166 +98,124 @@ describe('ProductsService — Tax Precedence', () => {
       categoryId: 'cat-1',
     };
 
-    it('uses explicit taxRate when provided — ignores category default and settings', async () => {
-      prismaMock.category.findFirst.mockResolvedValue(categoryWithDefault(16));
-      prismaMock.product.findUnique.mockResolvedValue(null); // no SKU/barcode conflict
+    it('stores taxable=true with the provided rate', async () => {
+      prismaMock.category.findFirst.mockResolvedValue(
+        categoryWithDefault(null, false),
+      );
+      prismaMock.product.findUnique.mockResolvedValue(null);
       prismaMock.product.create.mockResolvedValue(
-        buildProduct({ taxRate: 8, category: categoryWithDefault(16) }),
+        buildProduct({
+          taxable: true,
+          taxRate: 8,
+          category: categoryWithDefault(null, false),
+        }),
       );
       prismaMock.inventoryMovement.create.mockResolvedValue({});
 
       const result = await service.create(
-        { ...baseDto, taxRate: 8 },
+        { ...baseDto, taxable: true, taxRate: 8 },
         USER_ID,
         ORG_ID,
       );
 
-      // The create call should receive the explicit taxRate, NOT the category default
       expect(prismaMock.product.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({ taxRate: 8 }),
+          data: expect.objectContaining({ taxable: true, taxRate: 8 }),
         }),
       );
-      // Settings should NOT be fetched when taxRate is explicit
-      expect(settingsServiceMock.find).not.toHaveBeenCalled();
-      expect(result.taxRate).toBe(8);
+      expect(result.taxable).toBe(true);
       expect(result.effectiveTaxRate).toBe(8);
     });
 
-    it('falls back to category defaultTaxRate when product has no override', async () => {
-      prismaMock.category.findFirst.mockResolvedValue(categoryWithDefault(16));
-      prismaMock.product.findUnique.mockResolvedValue(null);
-      prismaMock.product.create.mockResolvedValue(
-        buildProduct({ taxRate: 16, category: categoryWithDefault(16) }),
-      );
-      prismaMock.inventoryMovement.create.mockResolvedValue({});
-      settingsServiceMock.find.mockResolvedValue({ taxRate: 19 });
-
-      // No taxRate in the DTO
-      const result = await service.create(
-        {
-          name: 'Test',
-          sku: 'SKU-002',
-          costPrice: 100,
-          salePrice: 150,
-          stock: 10,
-          minStock: 5,
-          categoryId: 'cat-1',
-        },
-        USER_ID,
-        ORG_ID,
-      );
-
-      expect(prismaMock.product.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({ taxRate: 16 }),
-        }),
-      );
-      expect(settingsServiceMock.find).toHaveBeenCalled();
-      expect(result.taxRate).toBe(16);
-    });
-
-    it('falls back to settings taxRate when category has no defaultTaxRate', async () => {
+    it('forces taxRate to 0 when taxable is false even if a rate is supplied', async () => {
       prismaMock.category.findFirst.mockResolvedValue(
-        categoryWithDefault(null),
+        categoryWithDefault(null, false),
       );
       prismaMock.product.findUnique.mockResolvedValue(null);
       prismaMock.product.create.mockResolvedValue(
-        buildProduct({ taxRate: 19, category: categoryWithDefault(null) }),
-      );
-      prismaMock.inventoryMovement.create.mockResolvedValue({});
-      settingsServiceMock.find.mockResolvedValue({ taxRate: 19 });
-
-      const result = await service.create(
-        {
-          name: 'Test',
-          sku: 'SKU-003',
-          costPrice: 100,
-          salePrice: 150,
-          stock: 10,
-          minStock: 5,
-          categoryId: 'cat-1',
-        },
-        USER_ID,
-        ORG_ID,
-      );
-
-      expect(prismaMock.product.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({ taxRate: 19 }),
+        buildProduct({
+          taxable: false,
+          taxRate: 0,
+          category: categoryWithDefault(null, false),
         }),
       );
-      expect(result.taxRate).toBe(19);
-    });
-
-    it('falls back to settings when category defaultTaxRate is zero', async () => {
-      prismaMock.category.findFirst.mockResolvedValue(categoryWithDefault(0));
-      prismaMock.product.findUnique.mockResolvedValue(null);
-      prismaMock.product.create.mockResolvedValue(
-        buildProduct({ taxRate: 19, category: categoryWithDefault(0) }),
-      );
       prismaMock.inventoryMovement.create.mockResolvedValue({});
-      settingsServiceMock.find.mockResolvedValue({ taxRate: 19 });
 
       await service.create(
-        {
-          name: 'Test',
-          sku: 'SKU-004',
-          costPrice: 100,
-          salePrice: 150,
-          stock: 10,
-          minStock: 5,
-          categoryId: 'cat-1',
-        },
+        { ...baseDto, taxable: false, taxRate: 8 },
         USER_ID,
         ORG_ID,
       );
 
       expect(prismaMock.product.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({ taxRate: 19 }),
+          data: expect.objectContaining({ taxable: false, taxRate: 0 }),
         }),
       );
+    });
+
+    it('defaults to non-taxable (rate 0) when taxable is omitted', async () => {
+      prismaMock.category.findFirst.mockResolvedValue(
+        categoryWithDefault(null, false),
+      );
+      prismaMock.product.findUnique.mockResolvedValue(null);
+      prismaMock.product.create.mockResolvedValue(
+        buildProduct({
+          taxable: false,
+          taxRate: 0,
+          category: categoryWithDefault(null, false),
+        }),
+      );
+      prismaMock.inventoryMovement.create.mockResolvedValue({});
+
+      const result = await service.create(baseDto, USER_ID, ORG_ID);
+
+      expect(prismaMock.product.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ taxable: false, taxRate: 0 }),
+        }),
+      );
+      expect(result.effectiveTaxRate).toBe(0);
+    });
+
+    it('throws BadRequestException when taxable is true without a rate', async () => {
+      prismaMock.category.findFirst.mockResolvedValue(
+        categoryWithDefault(null, false),
+      );
+      prismaMock.product.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.create({ ...baseDto, taxable: true }, USER_ID, ORG_ID),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws BadRequestException when taxable is true with rate 0', async () => {
+      prismaMock.category.findFirst.mockResolvedValue(
+        categoryWithDefault(null, false),
+      );
+      prismaMock.product.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.create({ ...baseDto, taxable: true, taxRate: 0 }, USER_ID, ORG_ID),
+      ).rejects.toBeInstanceOf(BadRequestException);
     });
 
     it('throws NotFoundException when category does not exist', async () => {
       prismaMock.category.findFirst.mockResolvedValue(null);
 
       await expect(
-        service.create(
-          {
-            name: 'Test',
-            sku: 'SKU-005',
-            costPrice: 100,
-            salePrice: 150,
-            stock: 10,
-            minStock: 5,
-            categoryId: 'non-existent',
-          },
-          USER_ID,
-          ORG_ID,
-        ),
+        service.create({ ...baseDto, sku: 'SKU-005' }, USER_ID, ORG_ID),
       ).rejects.toThrow(NotFoundException);
     });
 
     it('throws ConflictException when SKU already exists', async () => {
-      prismaMock.category.findFirst.mockResolvedValue(categoryWithDefault(16));
+      prismaMock.category.findFirst.mockResolvedValue(
+        categoryWithDefault(null, false),
+      );
       prismaMock.product.findUnique.mockResolvedValue({ id: 'existing' });
 
       await expect(
-        service.create(
-          {
-            name: 'Test',
-            sku: 'DUPLICATE-SKU',
-            costPrice: 100,
-            salePrice: 150,
-            stock: 10,
-            minStock: 5,
-            categoryId: 'cat-1',
-          },
-          USER_ID,
-          ORG_ID,
-        ),
+        service.create({ ...baseDto, sku: 'DUPLICATE-SKU' }, USER_ID, ORG_ID),
       ).rejects.toThrow(ConflictException);
     });
   });
@@ -262,247 +224,134 @@ describe('ProductsService — Tax Precedence', () => {
   // Product Update — tax behavior
   // ════════════════════════════════════════════════════════════════════
   describe('Product Update', () => {
-    it('preserves explicit override when category changes — update does not recalculate tax', async () => {
-      const existing = buildProduct({
-        id: 'prod-1',
-        taxRate: 8,
-        categoryId: 'cat-1',
-        category: categoryWithDefault(16),
-        version: 1,
-      });
-      prismaMock.product.findFirst.mockResolvedValue(existing);
-      prismaMock.product.updateMany.mockResolvedValue({ count: 1 });
-
-      const newCategory = { ...categoryWithDefault(20), id: 'cat-2' };
-      const updated = buildProduct({
-        id: 'prod-1',
-        taxRate: 8, // explicit override preserved
-        categoryId: 'cat-2',
-        category: newCategory,
-        version: 2,
-      });
-      // After updateMany, the service does findFirst again
+    it('stores taxable + rate when explicitly provided', async () => {
+      const existing = buildProduct({ taxRate: 16, version: 1 });
       prismaMock.product.findFirst.mockResolvedValueOnce(existing);
-      prismaMock.product.findFirst.mockResolvedValueOnce(updated);
+      prismaMock.product.updateMany.mockResolvedValue({ count: 1 });
+      prismaMock.product.findFirst.mockResolvedValueOnce(
+        buildProduct({ taxable: true, taxRate: 5, version: 2 }),
+      );
       prismaMock.inventoryMovement.create.mockResolvedValue({});
 
       const result = await service.update(
         'prod-1',
-        { categoryId: 'cat-2' }, // changing category, no taxRate in DTO
-        USER_ID,
-        ORG_ID,
-      );
-
-      // The updateMany should NOT have changed the taxRate
-      expect(prismaMock.product.updateMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.not.objectContaining({ taxRate: expect.any(Number) }),
-        }),
-      );
-      expect(result.taxRate).toBe(8);
-      expect(result.effectiveTaxRate).toBe(8);
-    });
-
-    it('updates effective tax when explicitly providing a new taxRate', async () => {
-      const existing = buildProduct({
-        id: 'prod-1',
-        taxRate: 16,
-        version: 1,
-      });
-      prismaMock.product.findFirst.mockResolvedValueOnce(existing);
-      prismaMock.product.updateMany.mockResolvedValue({ count: 1 });
-
-      const updated = buildProduct({
-        id: 'prod-1',
-        taxRate: 5,
-        version: 2,
-      });
-      prismaMock.product.findFirst.mockResolvedValueOnce(updated);
-      prismaMock.inventoryMovement.create.mockResolvedValue({});
-
-      const result = await service.update(
-        'prod-1',
-        { taxRate: 5 },
+        { taxable: true, taxRate: 5 },
         USER_ID,
         ORG_ID,
       );
 
       expect(prismaMock.product.updateMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({ taxRate: 5 }),
+          data: expect.objectContaining({ taxable: true, taxRate: 5 }),
         }),
       );
-      expect(result.taxRate).toBe(5);
+      expect(result.taxable).toBe(true);
       expect(result.effectiveTaxRate).toBe(5);
     });
 
-    it('does not change taxRate when update has no taxRate or categoryId fields', async () => {
-      const existing = buildProduct({
-        id: 'prod-1',
-        taxRate: 16,
-        version: 1,
-      });
-      prismaMock.product.findFirst.mockResolvedValue(existing);
+    it('forces taxRate to 0 when taxable is set to false', async () => {
+      const existing = buildProduct({ taxable: true, taxRate: 8, version: 1 });
+      prismaMock.product.findFirst.mockResolvedValueOnce(existing);
       prismaMock.product.updateMany.mockResolvedValue({ count: 1 });
+      prismaMock.product.findFirst.mockResolvedValueOnce(
+        buildProduct({ taxable: false, taxRate: 0, version: 2 }),
+      );
       prismaMock.inventoryMovement.create.mockResolvedValue({});
 
-      await service.update(
-        'prod-1',
-        { name: 'Renamed Product' },
-        USER_ID,
-        ORG_ID,
-      );
+      await service.update('prod-1', { taxable: false }, USER_ID, ORG_ID);
 
-      // updateMany data should only contain the name, not taxRate
+      expect(prismaMock.product.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ taxable: false, taxRate: 0 }),
+        }),
+      );
+    });
+
+    it('throws BadRequestException when taxable=true without a valid rate', async () => {
+      const existing = buildProduct({ taxable: false, taxRate: 0, version: 1 });
+      prismaMock.product.findFirst.mockResolvedValueOnce(existing);
+
+      await expect(
+        service.update('prod-1', { taxable: true }, USER_ID, ORG_ID),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('does not change taxable/taxRate when both are omitted', async () => {
+      const existing = buildProduct({ taxable: true, taxRate: 16, version: 1 });
+      prismaMock.product.findFirst.mockResolvedValueOnce(existing);
+      prismaMock.product.updateMany.mockResolvedValue({ count: 1 });
+      prismaMock.product.findFirst.mockResolvedValueOnce(
+        buildProduct({ name: 'Renamed', version: 2 }),
+      );
+      prismaMock.inventoryMovement.create.mockResolvedValue({});
+
+      await service.update('prod-1', { name: 'Renamed Product' }, USER_ID, ORG_ID);
+
       const updateCall = prismaMock.product.updateMany.mock.calls[0][0];
       expect(updateCall.data.name).toBe('Renamed Product');
+      expect(updateCall.data.taxable).toBeUndefined();
       expect(updateCall.data.taxRate).toBeUndefined();
     });
   });
 
   // ════════════════════════════════════════════════════════════════════
-  // Category Reassignment
+  // Effective tax resolution (read path)
   // ════════════════════════════════════════════════════════════════════
-  describe('Category Reassignment', () => {
-    it('applies new category default when product has no override — via create', async () => {
-      // Product created without explicit taxRate in category with default 10
-      prismaMock.category.findFirst.mockResolvedValue(categoryWithDefault(10));
-      prismaMock.product.findUnique.mockResolvedValue(null);
-      prismaMock.product.create.mockResolvedValue(
-        buildProduct({ taxRate: 10, category: categoryWithDefault(10) }),
-      );
-      prismaMock.inventoryMovement.create.mockResolvedValue({});
-      settingsServiceMock.find.mockResolvedValue({ taxRate: 19 });
-
-      const result = await service.create(
-        {
-          name: 'Test',
-          sku: 'SKU-REASSIGN-1',
-          costPrice: 100,
-          salePrice: 150,
-          stock: 10,
-          minStock: 5,
-          categoryId: 'cat-1',
-        },
-        USER_ID,
-        ORG_ID,
-      );
-
-      expect(result.taxRate).toBe(10); // category default, not settings 19
-    });
-
-    it('preserves product override regardless of category during update', async () => {
-      // Product has explicit taxRate 5, moving to category with default 20
-      const existing = buildProduct({
-        taxRate: 5,
-        categoryId: 'cat-1',
-        category: categoryWithDefault(10),
-        version: 1,
-      });
-      prismaMock.product.findFirst.mockResolvedValueOnce(existing);
-      prismaMock.product.updateMany.mockResolvedValue({ count: 1 });
-
-      const newCategory = { ...categoryWithDefault(20), id: 'cat-2' };
-      const updated = buildProduct({
-        taxRate: 5, // override preserved
-        categoryId: 'cat-2',
-        category: newCategory,
-        version: 2,
-      });
-      prismaMock.product.findFirst.mockResolvedValueOnce(updated);
-      prismaMock.inventoryMovement.create.mockResolvedValue({});
-
-      const result = await service.update(
-        'prod-1',
-        { categoryId: 'cat-2' },
-        USER_ID,
-        ORG_ID,
-      );
-
-      expect(result.taxRate).toBe(5); // override, not new category's 20
-      expect(result.effectiveTaxRate).toBe(5);
-    });
-
-    it('drops override when explicitly setting taxRate to 0 on update', async () => {
-      const existing = buildProduct({
-        taxRate: 8,
-        version: 1,
-      });
-      prismaMock.product.findFirst.mockResolvedValueOnce(existing);
-      prismaMock.product.updateMany.mockResolvedValue({ count: 1 });
-
-      const updated = buildProduct({
+  describe('Effective tax resolution (read path)', () => {
+    it('falls back to the category rate when the product is not opted-in', async () => {
+      const product = buildProduct({
+        taxable: false,
         taxRate: 0,
-        version: 2,
+        category: categoryWithDefault(16, true),
       });
-      prismaMock.product.findFirst.mockResolvedValueOnce(updated);
-      prismaMock.inventoryMovement.create.mockResolvedValue({});
+      prismaMock.product.findFirst.mockResolvedValue(product);
 
-      const result = await service.update(
-        'prod-1',
-        { taxRate: 0 }, // explicitly clearing the override
-        USER_ID,
-        ORG_ID,
-      );
+      const result = await service.findOne('prod-1', ORG_ID);
 
-      expect(prismaMock.product.updateMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({ taxRate: 0 }),
-        }),
-      );
-      expect(result.taxRate).toBe(0);
-    });
-  });
-
-  // ════════════════════════════════════════════════════════════════════
-  // Precedence consistency — creation vs enrichment
-  // ════════════════════════════════════════════════════════════════════
-  describe('Precedence consistency', () => {
-    it('enrichWithEffectiveTax returns stored taxRate as effectiveTaxRate (create+read match)', async () => {
-      prismaMock.category.findFirst.mockResolvedValue(categoryWithDefault(16));
-      prismaMock.product.findUnique.mockResolvedValue(null);
-      prismaMock.product.create.mockResolvedValue(
-        buildProduct({ taxRate: 16, category: categoryWithDefault(16) }),
-      );
-      prismaMock.inventoryMovement.create.mockResolvedValue({});
-      settingsServiceMock.find.mockResolvedValue({ taxRate: 19 });
-
-      const created = await service.create(
-        {
-          name: 'Test',
-          sku: 'SKU-CONSISTENCY',
-          costPrice: 100,
-          salePrice: 150,
-          stock: 10,
-          minStock: 5,
-          categoryId: 'cat-1',
-        },
-        USER_ID,
-        ORG_ID,
-      );
-
-      // Now simulate a read (findOne)
-      prismaMock.product.findFirst.mockResolvedValue(
-        buildProduct({
-          id: 'prod-1',
-          taxRate: 16,
-          category: categoryWithDefault(16),
-          movements: [],
-        }),
-      );
-
-      const read = await service.findOne('prod-1', ORG_ID);
-
-      // The effectiveTaxRate from create and findOne must match
-      expect(created.effectiveTaxRate).toBe(read.effectiveTaxRate);
-      expect(created.taxRate).toBe(read.taxRate);
+      expect(result.effectiveTaxRate).toBe(16);
     });
 
-    it('findAll enriches all products with effectiveTaxRate', async () => {
+    it('uses the product rate when the product is opted-in (overrides category)', async () => {
+      const product = buildProduct({
+        taxable: true,
+        taxRate: 8,
+        category: categoryWithDefault(16, true),
+      });
+      prismaMock.product.findFirst.mockResolvedValue(product);
+
+      const result = await service.findOne('prod-1', ORG_ID);
+
+      expect(result.effectiveTaxRate).toBe(8);
+    });
+
+    it('returns 0 when neither product nor category is opted-in', async () => {
+      const product = buildProduct({
+        taxable: false,
+        taxRate: 0,
+        category: categoryWithDefault(null, false),
+      });
+      prismaMock.product.findFirst.mockResolvedValue(product);
+
+      const result = await service.findOne('prod-1', ORG_ID);
+
+      expect(result.effectiveTaxRate).toBe(0);
+    });
+
+    it('findAll enriches every product with effectiveTaxRate', async () => {
       prismaMock.product.findMany.mockResolvedValue([
-        buildProduct({ id: 'p1', taxRate: 8 }),
-        buildProduct({ id: 'p2', taxRate: 16 }),
-        buildProduct({ id: 'p3', taxRate: 19 }),
+        buildProduct({ id: 'p1', taxable: true, taxRate: 8 }),
+        buildProduct({
+          id: 'p2',
+          taxable: false,
+          taxRate: 0,
+          category: categoryWithDefault(16, true),
+        }),
+        buildProduct({
+          id: 'p3',
+          taxable: false,
+          taxRate: 0,
+          category: categoryWithDefault(null, false),
+        }),
       ]);
       prismaMock.product.count.mockResolvedValue(3);
 
@@ -510,7 +359,7 @@ describe('ProductsService — Tax Precedence', () => {
 
       expect(result.data[0].effectiveTaxRate).toBe(8);
       expect(result.data[1].effectiveTaxRate).toBe(16);
-      expect(result.data[2].effectiveTaxRate).toBe(19);
+      expect(result.data[2].effectiveTaxRate).toBe(0);
     });
   });
 
@@ -539,18 +388,8 @@ describe('ProductsService — Tax Precedence', () => {
             organizationId: ORG_ID,
             active: true,
             OR: [
-              {
-                barcode: {
-                  equals: '7701234567890',
-                  mode: 'insensitive',
-                },
-              },
-              {
-                sku: {
-                  equals: '7701234567890',
-                  mode: 'insensitive',
-                },
-              },
+              { barcode: { equals: '7701234567890', mode: 'insensitive' } },
+              { sku: { equals: '7701234567890', mode: 'insensitive' } },
             ],
           },
         }),

--- a/backend/src/products/products.service.ts
+++ b/backend/src/products/products.service.ts
@@ -8,7 +8,6 @@ import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateProductDto, UpdateProductDto } from './dto/product.dto';
 import { CloudinaryService } from '../cloudinary/cloudinary.service';
-import { SettingsService } from '../settings/settings.service';
 import { resolveEffectiveTaxRate } from '../common/utils/tax.util';
 import { PlanLimitService } from '../plan-limits/plan-limits.service';
 
@@ -17,7 +16,6 @@ export class ProductsService {
   constructor(
     private prisma: PrismaService,
     private cloudinaryService: CloudinaryService,
-    private settingsService: SettingsService,
     private planLimitService: PlanLimitService,
   ) {}
 
@@ -29,7 +27,8 @@ export class ProductsService {
     if (!organizationId) {
       throw new BadRequestException('Organization ID is required for this operation');
     }
-    const { sku, barcode: rawBarcode, categoryId, taxRate, ...rest } = createProductDto;
+    const { sku, barcode: rawBarcode, categoryId, taxRate, taxable, ...rest } =
+      createProductDto;
     // Normalize empty barcode to null so PostgreSQL unique constraint ignores it
     const barcode = rawBarcode?.trim() || null;
 
@@ -59,19 +58,20 @@ export class ProductsService {
       }
     }
 
-    // Resolve effective tax rate if not explicitly provided
+    // Tax is opt-in: a taxable product must carry a positive rate; otherwise
+    // the rate is forced to 0 and the effective rate is resolved at read time
+    // (product.taxable → category.taxable → 0).
+    const resolvedTaxable = taxable ?? false;
     let resolvedTaxRate: number;
-    if (taxRate != null) {
-      // Explicitly provided — use as-is
-      resolvedTaxRate = taxRate;
+    if (resolvedTaxable) {
+      if (taxRate == null || Number(taxRate) <= 0) {
+        throw new BadRequestException(
+          'Taxable products require a tax rate greater than 0',
+        );
+      }
+      resolvedTaxRate = Number(taxRate);
     } else {
-      // Not provided — resolve from category default → settings fallback
-      const settings = await this.settingsService.find(organizationId);
-      resolvedTaxRate = resolveEffectiveTaxRate(
-        null,
-        category.defaultTaxRate,
-        settings.taxRate ?? 19,
-      );
+      resolvedTaxRate = 0;
     }
 
     const product = await this.prisma.product.create({
@@ -81,6 +81,7 @@ export class ProductsService {
         barcode,
         categoryId,
         organizationId,
+        taxable: resolvedTaxable,
         taxRate: resolvedTaxRate,
       },
       include: { category: true },
@@ -222,10 +223,28 @@ export class ProductsService {
     const previousStock = existingProduct.stock;
     const newStock = updateProductDto.stock ?? previousStock;
 
+    // Apply the same opt-in tax invariant as create: `taxable=true` requires a
+    // positive rate; `taxable=false` forces the stored rate back to 0.
+    const taxData =
+      updateProductDto.taxable === true
+        ? (() => {
+            const rate = updateProductDto.taxRate ?? existingProduct.taxRate;
+            if (rate == null || Number(rate) <= 0) {
+              throw new BadRequestException(
+                'Taxable products require a tax rate greater than 0',
+              );
+            }
+            return { taxable: true, taxRate: Number(rate) };
+          })()
+        : updateProductDto.taxable === false
+          ? { taxable: false, taxRate: 0 }
+          : {};
+
     const updateResult = await this.prisma.product.updateMany({
       where: { id, version: existingProduct.version, active: true },
       data: {
         ...updateProductDto,
+        ...taxData,
         barcode: normalizedBarcode,
         version: { increment: 1 },
       },
@@ -353,12 +372,9 @@ export class ProductsService {
       barcode: p.barcode,
       salePrice: p.salePrice,
       stock: p.stock,
+      taxable: p.taxable,
       taxRate: p.taxRate,
-      effectiveTaxRate: resolveEffectiveTaxRate(
-        p.taxRate,
-        p.category?.defaultTaxRate ?? null,
-        0,
-      ),
+      effectiveTaxRate: resolveEffectiveTaxRate(p, p.category),
       minStock: p.minStock,
       isLowStock: p.stock <= p.minStock,
       category: p.category,
@@ -398,12 +414,9 @@ export class ProductsService {
       barcode: product.barcode,
       salePrice: product.salePrice,
       stock: product.stock,
+      taxable: product.taxable,
       taxRate: product.taxRate,
-      effectiveTaxRate: resolveEffectiveTaxRate(
-        product.taxRate,
-        product.category?.defaultTaxRate ?? null,
-        0,
-      ),
+      effectiveTaxRate: resolveEffectiveTaxRate(product, product.category),
       minStock: product.minStock,
       isLowStock: product.stock <= product.minStock,
       category: product.category,
@@ -414,23 +427,22 @@ export class ProductsService {
   /**
    * Enriches a product with effective tax rate information.
    *
-   * Uses resolveEffectiveTaxRate so that a product with taxRate === 0
-   * (the schema default, meaning "not explicitly set") falls back to
-   * the category's defaultTaxRate.
+   * Uses the shared `resolveEffectiveTaxRate(product, category)` so the
+   * read-time value agrees with sale-time resolution (opt-in precedence:
+   * product.taxable → category.taxable → 0).
    */
   private enrichWithEffectiveTax<
     T extends {
+      taxable: boolean;
       taxRate: Prisma.Decimal | number;
-      category?: { defaultTaxRate: Prisma.Decimal | null } | null;
+      category?:
+        | { taxable: boolean; defaultTaxRate: Prisma.Decimal | null }
+        | null;
     },
   >(product: T): T & { effectiveTaxRate: number } {
     return {
       ...product,
-      effectiveTaxRate: resolveEffectiveTaxRate(
-        product.taxRate,
-        product.category?.defaultTaxRate ?? null,
-        0,
-      ),
+      effectiveTaxRate: resolveEffectiveTaxRate(product, product.category),
     };
   }
 

--- a/backend/src/sales/sales.service.spec.ts
+++ b/backend/src/sales/sales.service.spec.ts
@@ -400,9 +400,10 @@ describe('SalesService', () => {
       name: 'Test Product',
       active: true,
       salePrice: 100,
+      taxable: true,
       taxRate: 19,
       stock: 10,
-      category: { defaultTaxRate: null },
+      category: { taxable: false, defaultTaxRate: null },
     });
     prismaMock.customer.findFirst.mockResolvedValue({ id: 'cust-1' });
     txMock.sale.create.mockResolvedValue({ id: 'sale-new', saleNumber: 42 });
@@ -454,6 +455,129 @@ describe('SalesService', () => {
     );
   });
 
+  it('create computes tax via the shared opt-in resolver (taxable product → product rate)', async () => {
+    const txMock = {
+      sale: { create: jest.fn() },
+      saleItem: { create: jest.fn() },
+      product: {
+        findFirst: jest.fn().mockResolvedValue({ stock: 10 }),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      inventoryMovement: { create: jest.fn() },
+      payment: { create: jest.fn() },
+    };
+
+    prismaMock.$transaction.mockImplementation(
+      async (callback: (tx: unknown) => unknown) => callback(txMock),
+    );
+    sequenceServiceMock.nextNumber.mockResolvedValue({
+      number: 42,
+      formatted: '42',
+    });
+    prismaMock.product.findFirst.mockResolvedValue({
+      id: 'prod-1',
+      name: 'Taxable Product',
+      active: true,
+      salePrice: 100,
+      taxable: true,
+      taxRate: 19,
+      stock: 10,
+      category: { taxable: false, defaultTaxRate: null },
+    });
+    prismaMock.customer.findFirst.mockResolvedValue({ id: 'cust-1' });
+    txMock.sale.create.mockResolvedValue({ id: 'sale-new', saleNumber: 42 });
+    prismaMock.sale.findFirst.mockResolvedValue({
+      id: 'sale-new',
+      saleNumber: 42,
+      userId: 'user-1',
+      user: { id: 'user-1', name: 'User', email: 'user@example.com' },
+      customer: null,
+      items: [],
+      payments: [],
+    });
+
+    await service.create(
+      {
+        customerId: 'cust-1',
+        items: [{ productId: 'prod-1', quantity: 1, discountAmount: 0 }],
+        discountAmount: 0,
+        payments: [{ method: 'CASH' as const, amount: 119 }],
+      },
+      'user-1',
+      'org-1',
+    );
+
+    expect(txMock.saleItem.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ taxRate: 19, total: 119 }),
+      }),
+    );
+    expect(txMock.sale.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ taxAmount: 19, total: 119 }),
+      }),
+    );
+  });
+
+  it('create falls back to the category rate when the product is not taxable', async () => {
+    const txMock = {
+      sale: { create: jest.fn() },
+      saleItem: { create: jest.fn() },
+      product: {
+        findFirst: jest.fn().mockResolvedValue({ stock: 10 }),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      inventoryMovement: { create: jest.fn() },
+      payment: { create: jest.fn() },
+    };
+
+    prismaMock.$transaction.mockImplementation(
+      async (callback: (tx: unknown) => unknown) => callback(txMock),
+    );
+    sequenceServiceMock.nextNumber.mockResolvedValue({
+      number: 43,
+      formatted: '43',
+    });
+    prismaMock.product.findFirst.mockResolvedValue({
+      id: 'prod-1',
+      name: 'Inherited Tax Product',
+      active: true,
+      salePrice: 100,
+      taxable: false,
+      taxRate: 0,
+      stock: 10,
+      category: { taxable: true, defaultTaxRate: 16 },
+    });
+    prismaMock.customer.findFirst.mockResolvedValue({ id: 'cust-1' });
+    txMock.sale.create.mockResolvedValue({ id: 'sale-new', saleNumber: 43 });
+    prismaMock.sale.findFirst.mockResolvedValue({
+      id: 'sale-new',
+      saleNumber: 43,
+      userId: 'user-1',
+      user: { id: 'user-1', name: 'User', email: 'user@example.com' },
+      customer: null,
+      items: [],
+      payments: [],
+    });
+
+    await service.create(
+      {
+        customerId: 'cust-1',
+        items: [{ productId: 'prod-1', quantity: 1, discountAmount: 0 }],
+        discountAmount: 0,
+        payments: [{ method: 'CASH' as const, amount: 116 }],
+      },
+      'user-1',
+      'org-1',
+    );
+
+    expect(txMock.saleItem.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ taxRate: 16, total: 116 }),
+      }),
+    );
+  });
+
   it('create throws ServiceUnavailableException on P2028 transaction timeout', async () => {
     const error = new Prisma.PrismaClientKnownRequestError(
       'Transaction timeout',
@@ -468,9 +592,10 @@ describe('SalesService', () => {
       name: 'Test Product',
       active: true,
       salePrice: 100,
+      taxable: true,
       taxRate: 19,
       stock: 10,
-      category: { defaultTaxRate: null },
+      category: { taxable: false, defaultTaxRate: null },
     });
     prismaMock.customer.findFirst.mockResolvedValue({ id: 'cust-1' });
 

--- a/backend/src/sales/sales.service.ts
+++ b/backend/src/sales/sales.service.ts
@@ -18,6 +18,7 @@ import {
 import { CacheService } from '../common/services/cache.service';
 import { SettingsService } from '../settings/settings.service';
 import { resolveEffectiveTaxRate } from '../common/utils/tax.util';
+import { CURRENCY, LOCALE, TIMEZONE } from '../common/constants/locale.constants';
 import type { RequestUser } from '../common/interfaces/request-user.interface';
 import { SequenceService } from '../common/sequences/sequence.service';
 import { PLAN_LIMITS } from '../plan-limits/plan-limits.constants';
@@ -117,11 +118,7 @@ export class SalesService {
       }
 
       const itemSubtotal = grossSubtotal - itemDiscount;
-      const effectiveTaxRate = resolveEffectiveTaxRate(
-        product.taxRate,
-        product.category?.defaultTaxRate ?? null,
-        0,
-      );
+      const effectiveTaxRate = resolveEffectiveTaxRate(product, product.category);
       const itemTax = itemSubtotal * (effectiveTaxRate / 100);
       const itemTotal = itemSubtotal + itemTax;
 
@@ -586,19 +583,20 @@ export class SalesService {
 
   async generateReceipt(id: string, response: Response, user?: RequestUser) {
     const sale = await this.findOne(id, user?.organizationId, user);
-    const settings = user
-      ? await this.settingsService.find(user.organizationId)
-      : {};
+    const settings = await this.settingsService.find(user?.organizationId);
 
     const doc = new jsPDF({
       orientation: 'portrait',
       unit: 'mm',
       format: [80, 300],
     });
-    const companyName = settings?.companyName || 'Mi Negocio';
-    const printHeader = settings?.printHeader || '';
-    const printFooter = settings?.printFooter || '';
-    const logoUrl = settings?.logoUrl;
+    const companyName = settings.organization.name || 'Mi Negocio';
+    const printHeader = settings.invoicing.printHeader || '';
+    const printFooter = settings.invoicing.printFooter || '';
+    const logoUrl = settings.organization.logoUrl;
+    const receiptNumber = settings.receipt.prefix
+      ? `${settings.receipt.prefix}-${sale.saleNumber}`
+      : String(sale.saleNumber);
 
     const margin = 4;
     const maxWidth = 80 - margin * 2;
@@ -644,13 +642,16 @@ export class SalesService {
 
     doc.setFontSize(8);
     doc.setFont('helvetica', 'normal');
-    const receiptDate = new Date(sale.createdAt).toLocaleDateString('es-CO');
-    const receiptTime = new Date(sale.createdAt).toLocaleTimeString('es-CO', {
+    const receiptDate = new Date(sale.createdAt).toLocaleDateString(LOCALE, {
+      timeZone: TIMEZONE,
+    });
+    const receiptTime = new Date(sale.createdAt).toLocaleTimeString(LOCALE, {
+      timeZone: TIMEZONE,
       hour: '2-digit',
       minute: '2-digit',
     });
     doc.text(
-      `No. ${sale.saleNumber}    ${receiptDate} ${receiptTime}`,
+      `No. ${receiptNumber}    ${receiptDate} ${receiptTime}`,
       margin,
       y,
     );
@@ -855,9 +856,9 @@ export class SalesService {
   }
 
   private formatCurrency(amount: number): string {
-    return new Intl.NumberFormat('es-CO', {
+    return new Intl.NumberFormat(LOCALE, {
       style: 'currency',
-      currency: 'COP',
+      currency: CURRENCY,
     }).format(amount);
   }
 }


### PR DESCRIPTION
PR3 of settings-refactor (chained PR, feature-branch-chain). Migrates backend consumers (products/sales/imports/billing/admin) to unified resolveEffectiveTaxRate(product, category) and SettingsView. Receipt name from Organization.name; downgradeFlags via system-key path; updatePlan merges (no full-replace). Tests 115/115. Scope SR-3/4/5/7/8. Targets PR2 branch.