### PR TITLE
feat(settings): org-admin write endpoints for organization name and receipt prefix

### DIFF
--- a/backend/src/settings/dto/settings.dto.ts
+++ b/backend/src/settings/dto/settings.dto.ts
@@ -1,5 +1,19 @@
-import { IsString, IsOptional, IsObject } from 'class-validator';
-import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, IsOptional, IsObject, IsNotEmpty } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateOrganizationNameDto {
+  @ApiProperty({ example: 'Acme Corp' })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+}
+
+export class UpdateReceiptPrefixDto {
+  @ApiPropertyOptional({ example: 'REC-' })
+  @IsString()
+  @IsOptional()
+  prefix?: string;
+}
 
 export class UpdateSettingsDto {
   @ApiPropertyOptional({ example: 'Empresa ABC - Comprobante #' })

--- a/backend/src/settings/settings.controller.spec.ts
+++ b/backend/src/settings/settings.controller.spec.ts
@@ -1,0 +1,99 @@
+import { ForbiddenException, type ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { SettingsController } from './settings.controller';
+
+describe('SettingsController write endpoints', () => {
+  const settingsServiceMock = {
+    find: jest.fn(),
+    getDefaultSettings: jest.fn(),
+    update: jest.fn(),
+    uploadLogo: jest.fn(),
+    updateOrganizationName: jest.fn(),
+    updateSalePrefix: jest.fn(),
+  };
+
+  const createContext = (
+    handler: (...args: unknown[]) => unknown,
+    role: string,
+    isSuperAdmin = false,
+  ): ExecutionContext =>
+    ({
+      getHandler: () => handler,
+      getClass: () => SettingsController,
+      switchToHttp: () => ({
+        getRequest: () => ({ user: { role, isSuperAdmin } }),
+      }),
+    }) as unknown as ExecutionContext;
+
+  it('marks updateOrganizationName as org-ADMIN only', () => {
+    const controller = new SettingsController(settingsServiceMock as never);
+
+    expect(
+      Reflect.getMetadata(ROLES_KEY, controller.updateOrganizationName),
+    ).toEqual(['ADMIN']);
+  });
+
+  it('marks updateReceiptPrefix as org-ADMIN only', () => {
+    const controller = new SettingsController(settingsServiceMock as never);
+
+    expect(
+      Reflect.getMetadata(ROLES_KEY, controller.updateReceiptPrefix),
+    ).toEqual(['ADMIN']);
+  });
+
+  it('allows ADMIN access to updateOrganizationName', () => {
+    const controller = new SettingsController(settingsServiceMock as never);
+    const guard = new RolesGuard(new Reflector());
+
+    expect(
+      guard.canActivate(
+        createContext(controller.updateOrganizationName, 'ADMIN'),
+      ),
+    ).toBe(true);
+  });
+
+  it('denies CASHIER access to updateReceiptPrefix', () => {
+    const controller = new SettingsController(settingsServiceMock as never);
+    const guard = new RolesGuard(new Reflector());
+
+    expect(() =>
+      guard.canActivate(createContext(controller.updateReceiptPrefix, 'CASHIER')),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('delegates updateOrganizationName to the service', async () => {
+    const controller = new SettingsController(settingsServiceMock as never);
+    const dto = { name: 'Acme Corp' };
+    const user = { organizationId: 'org-1' } as never;
+    const expected = { organization: { name: 'Acme Corp' } };
+
+    settingsServiceMock.updateOrganizationName.mockResolvedValue(expected);
+
+    await expect(
+      controller.updateOrganizationName(dto, user),
+    ).resolves.toEqual(expected);
+    expect(settingsServiceMock.updateOrganizationName).toHaveBeenCalledWith(
+      'org-1',
+      'Acme Corp',
+    );
+  });
+
+  it('delegates updateReceiptPrefix to the service', async () => {
+    const controller = new SettingsController(settingsServiceMock as never);
+    const dto = { prefix: 'REC-' };
+    const user = { organizationId: 'org-1' } as never;
+    const expected = { receipt: { prefix: 'REC-' } };
+
+    settingsServiceMock.updateSalePrefix.mockResolvedValue(expected);
+
+    await expect(
+      controller.updateReceiptPrefix(dto, user),
+    ).resolves.toEqual(expected);
+    expect(settingsServiceMock.updateSalePrefix).toHaveBeenCalledWith(
+      'org-1',
+      'REC-',
+    );
+  });
+});

--- a/backend/src/settings/settings.controller.ts
+++ b/backend/src/settings/settings.controller.ts
@@ -3,6 +3,7 @@ import {
   Get,
   Put,
   Post,
+  Patch,
   Body,
   UseGuards,
   UseInterceptors,
@@ -16,7 +17,11 @@ import {
 } from '@nestjs/swagger';
 import { OrgRole } from '@prisma/client';
 import { SettingsService } from './settings.service';
-import { UpdateSettingsDto } from './dto/settings.dto';
+import {
+  UpdateSettingsDto,
+  UpdateOrganizationNameDto,
+  UpdateReceiptPrefixDto,
+} from './dto/settings.dto';
 import { JwtAuthGuard } from '../auth/jwt.strategy';
 import { Roles } from '../common/decorators/roles.decorator';
 import { RolesGuard } from '../common/guards/roles.guard';
@@ -68,5 +73,31 @@ export class SettingsController {
     @CurrentUser() user: RequestUser,
   ) {
     return this.settingsService.uploadLogo(user.organizationId, file);
+  }
+
+  @Patch('organization')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Update organization name' })
+  async updateOrganizationName(
+    @Body() updateOrganizationNameDto: UpdateOrganizationNameDto,
+    @CurrentUser() user: RequestUser,
+  ) {
+    return this.settingsService.updateOrganizationName(
+      user.organizationId,
+      updateOrganizationNameDto.name,
+    );
+  }
+
+  @Patch('receipt-prefix')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Update receipt prefix' })
+  async updateReceiptPrefix(
+    @Body() updateReceiptPrefixDto: UpdateReceiptPrefixDto,
+    @CurrentUser() user: RequestUser,
+  ) {
+    return this.settingsService.updateSalePrefix(
+      user.organizationId,
+      updateReceiptPrefixDto.prefix,
+    );
   }
 }

--- a/backend/src/settings/settings.service.spec.ts
+++ b/backend/src/settings/settings.service.spec.ts
@@ -16,6 +16,8 @@ describe('SettingsService', () => {
     },
     organizationSequence: {
       findFirst: jest.fn(),
+      update: jest.fn(),
+      create: jest.fn(),
     },
   };
 
@@ -232,6 +234,147 @@ describe('SettingsService', () => {
       await expect(
         service.uploadLogo(undefined, {} as never),
       ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('updateOrganizationName', () => {
+    it('trims and persists the name, returning the refreshed view', async () => {
+      prismaMock.organization.findUnique
+        .mockResolvedValueOnce({ id: 'org-1' })
+        .mockResolvedValue({
+          name: 'Acme Corp',
+          logoUrl: null,
+          settings: {},
+          settingsVersion: 0,
+        });
+      prismaMock.organization.update.mockResolvedValue({ id: 'org-1' });
+      prismaMock.organizationSequence.findFirst.mockResolvedValue(null);
+
+      const result = await service.updateOrganizationName('org-1', '  Acme Corp  ');
+
+      expect(prismaMock.organization.update).toHaveBeenCalledWith({
+        where: { id: 'org-1' },
+        data: { name: 'Acme Corp' },
+      });
+      expect(result.organization.name).toBe('Acme Corp');
+    });
+
+    it('throws BadRequestException for an empty or whitespace-only name', async () => {
+      await expect(
+        service.updateOrganizationName('org-1', '   '),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(prismaMock.organization.update).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException without an organizationId', async () => {
+      await expect(
+        service.updateOrganizationName(undefined, 'Acme'),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws NotFoundException when the organization does not exist', async () => {
+      prismaMock.organization.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.updateOrganizationName('missing', 'Acme'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('updateSalePrefix', () => {
+    it('updates the prefix of the latest SALE sequence (mirrors readSalePrefix)', async () => {
+      prismaMock.organization.findUnique
+        .mockResolvedValueOnce({ id: 'org-1' })
+        .mockResolvedValue({
+          name: 'Acme',
+          logoUrl: null,
+          settings: {},
+          settingsVersion: 0,
+        });
+      prismaMock.organizationSequence.findFirst
+        .mockResolvedValueOnce({ id: 'seq-1' })
+        .mockResolvedValue({ prefix: 'REC-' });
+      prismaMock.organizationSequence.update.mockResolvedValue({
+        id: 'seq-1',
+        prefix: 'REC-',
+      });
+
+      const result = await service.updateSalePrefix('org-1', ' REC- ');
+
+      expect(prismaMock.organizationSequence.findFirst).toHaveBeenCalledWith({
+        where: { organizationId: 'org-1', type: 'SALE' },
+        orderBy: { year: 'desc' },
+      });
+      expect(prismaMock.organizationSequence.update).toHaveBeenCalledWith({
+        where: { id: 'seq-1' },
+        data: { prefix: 'REC-' },
+      });
+      expect(result.receipt.prefix).toBe('REC-');
+    });
+
+    it('clears the prefix to null when the value is empty or whitespace', async () => {
+      prismaMock.organization.findUnique
+        .mockResolvedValueOnce({ id: 'org-1' })
+        .mockResolvedValue({
+          name: 'Acme',
+          logoUrl: null,
+          settings: {},
+          settingsVersion: 0,
+        });
+      prismaMock.organizationSequence.findFirst
+        .mockResolvedValueOnce({ id: 'seq-1' })
+        .mockResolvedValue({ prefix: null });
+      prismaMock.organizationSequence.update.mockResolvedValue({
+        id: 'seq-1',
+        prefix: null,
+      });
+
+      await service.updateSalePrefix('org-1', '   ');
+
+      expect(prismaMock.organizationSequence.update).toHaveBeenCalledWith({
+        where: { id: 'seq-1' },
+        data: { prefix: null },
+      });
+    });
+
+    it('creates a current-year SALE sequence when none exists yet', async () => {
+      prismaMock.organization.findUnique
+        .mockResolvedValueOnce({ id: 'org-1' })
+        .mockResolvedValue({
+          name: 'Acme',
+          logoUrl: null,
+          settings: {},
+          settingsVersion: 0,
+        });
+      prismaMock.organizationSequence.findFirst
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue({ prefix: 'REC-' });
+      prismaMock.organizationSequence.create.mockResolvedValue({ id: 'seq-2' });
+
+      await service.updateSalePrefix('org-1', 'REC-');
+
+      expect(prismaMock.organizationSequence.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          organizationId: 'org-1',
+          type: 'SALE',
+          currentNumber: 0,
+          prefix: 'REC-',
+        }),
+      });
+    });
+
+    it('throws BadRequestException without an organizationId', async () => {
+      await expect(
+        service.updateSalePrefix(undefined, 'REC-'),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws NotFoundException when the organization does not exist', async () => {
+      prismaMock.organization.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.updateSalePrefix('missing', 'REC-'),
+      ).rejects.toBeInstanceOf(NotFoundException);
     });
   });
 

--- a/backend/src/settings/settings.service.ts
+++ b/backend/src/settings/settings.service.ts
@@ -164,6 +164,79 @@ export class SettingsService {
     return this.buildView(org.name, org.logoUrl, merged, prefix);
   }
 
+  async updateOrganizationName(
+    organizationId: string | undefined,
+    name: string,
+  ): Promise<SettingsView> {
+    if (!organizationId) {
+      throw new BadRequestException('Organization ID is required for this operation');
+    }
+
+    const trimmed = typeof name === 'string' ? name.trim() : '';
+    if (!trimmed) {
+      throw new BadRequestException('Organization name cannot be empty');
+    }
+
+    const org = await this.prisma.organization.findUnique({
+      where: { id: organizationId },
+    });
+
+    if (!org) {
+      throw new NotFoundException('Organization not found');
+    }
+
+    await this.prisma.organization.update({
+      where: { id: organizationId },
+      data: { name: trimmed },
+    });
+
+    return this.find(organizationId);
+  }
+
+  async updateSalePrefix(
+    organizationId: string | undefined,
+    prefix: string | undefined,
+  ): Promise<SettingsView> {
+    if (!organizationId) {
+      throw new BadRequestException('Organization ID is required for this operation');
+    }
+
+    const trimmed = typeof prefix === 'string' ? prefix.trim() : '';
+    const value = trimmed.length > 0 ? trimmed : null;
+
+    const org = await this.prisma.organization.findUnique({
+      where: { id: organizationId },
+    });
+
+    if (!org) {
+      throw new NotFoundException('Organization not found');
+    }
+
+    const sequence = await this.prisma.organizationSequence.findFirst({
+      where: { organizationId, type: 'SALE' },
+      orderBy: { year: 'desc' },
+    });
+
+    if (sequence) {
+      await this.prisma.organizationSequence.update({
+        where: { id: sequence.id },
+        data: { prefix: value },
+      });
+    } else {
+      await this.prisma.organizationSequence.create({
+        data: {
+          organizationId,
+          type: 'SALE',
+          currentNumber: 0,
+          year: new Date().getFullYear(),
+          prefix: value,
+        },
+      });
+    }
+
+    return this.find(organizationId);
+  }
+
   getDefaultSettings(): SettingsView {
     return this.buildDefaultView();
   }

--- a/frontend/src/app/settings/(general)/general/page.behavior.test.tsx
+++ b/frontend/src/app/settings/(general)/general/page.behavior.test.tsx
@@ -4,10 +4,12 @@ import userEvent from "@testing-library/user-event";
 
 const {
   uploadLogoMutateAsyncMock,
+  updateOrganizationNameMutateAsyncMock,
   toastSuccessMock,
   settingsData,
 } = vi.hoisted(() => ({
   uploadLogoMutateAsyncMock: vi.fn(),
+  updateOrganizationNameMutateAsyncMock: vi.fn(),
   toastSuccessMock: vi.fn(),
   settingsData: {
     organization: { name: "Mi Empresa", logoUrl: null },
@@ -30,6 +32,10 @@ vi.mock("@/hooks/useSettings", () => ({
     mutateAsync: uploadLogoMutateAsyncMock,
     isPending: false,
   }),
+  useUpdateOrganizationName: () => ({
+    mutateAsync: updateOrganizationNameMutateAsyncMock,
+    isPending: false,
+  }),
 }));
 
 vi.mock("@/contexts/ToastContext", () => ({
@@ -46,15 +52,32 @@ describe("General settings page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     uploadLogoMutateAsyncMock.mockResolvedValue({ logoUrl: "https://cdn/logo.png" });
+    updateOrganizationNameMutateAsyncMock.mockResolvedValue(settingsData);
   });
 
   afterEach(() => {
     cleanup();
   });
 
-  it("shows the organization name from the settings view", () => {
+  it("shows the organization name as an editable input", () => {
     render(<GeneralSettingsPage />);
-    expect(screen.getByText("Mi Empresa")).toBeInTheDocument();
+    expect(screen.getByLabelText(/nombre de la organización/i)).toHaveValue(
+      "Mi Empresa"
+    );
+  });
+
+  it("saves the organization name through the organization endpoint", async () => {
+    const user = userEvent.setup();
+    render(<GeneralSettingsPage />);
+
+    const nameInput = screen.getByLabelText(/nombre de la organización/i);
+    await user.clear(nameInput);
+    await user.type(nameInput, "Nueva Empresa");
+    await user.click(screen.getByRole("button", { name: "Guardar" }));
+
+    expect(updateOrganizationNameMutateAsyncMock).toHaveBeenCalledWith(
+      "Nueva Empresa"
+    );
   });
 
   it("uploads a logo through the logo endpoint", async () => {

--- a/frontend/src/app/settings/(general)/general/page.tsx
+++ b/frontend/src/app/settings/(general)/general/page.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
-import { useSettings, useUploadLogo } from "@/hooks/useSettings";
+import {
+  useSettings,
+  useUploadLogo,
+  useUpdateOrganizationName,
+} from "@/hooks/useSettings";
 import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
 import { LoadingState } from "@/components/ui/LoadingState";
 import { SettingsCard } from "../../_components/SettingsCard";
 import { useToast } from "@/contexts/ToastContext";
@@ -14,7 +19,16 @@ export default function GeneralSettingsPage() {
   const toast = useToast();
   const { data: settings, isLoading } = useSettings();
   const uploadLogo = useUploadLogo();
+  const updateOrganizationName = useUpdateOrganizationName();
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [name, setName] = useState("");
+
+  useEffect(() => {
+    if (settings) {
+      setName(settings.organization.name ?? "");
+    }
+  }, [settings]);
 
   if (isLoading || !settings) {
     return (
@@ -38,6 +52,16 @@ export default function GeneralSettingsPage() {
     }
   };
 
+  const handleNameSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await updateOrganizationName.mutateAsync(name);
+      toast.success("Nombre actualizado correctamente");
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "Error al actualizar el nombre"));
+    }
+  };
+
   return (
     <div className="space-y-5">
       <div className="flex items-center gap-3 mb-5">
@@ -51,17 +75,23 @@ export default function GeneralSettingsPage() {
         icon={<Building2 className="w-4 h-4 text-primary" />}
       >
         <div className="space-y-6">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Nombre de la organización
-            </p>
-            <p className="text-base font-medium text-foreground mt-1">
-              {settings.organization.name || "Sin nombre"}
-            </p>
-            <p className="text-xs text-muted-foreground mt-1">
-              El nombre de la organización se gestiona desde tu cuenta.
-            </p>
-          </div>
+          <form onSubmit={handleNameSubmit} className="space-y-3">
+            <Input
+              label="Nombre de la organización"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Nombre de tu negocio"
+            />
+            <div className="flex justify-end">
+              <Button
+                type="submit"
+                size="sm"
+                loading={updateOrganizationName.isPending}
+              >
+                Guardar
+              </Button>
+            </div>
+          </form>
 
           <div className="pt-4 border-t border-black/5 dark:border-white/5">
             <p className="text-xs font-semibold uppercase tracking-wide text-foreground mb-3">

--- a/frontend/src/app/settings/(invoicing)/invoicing/page.behavior.test.tsx
+++ b/frontend/src/app/settings/(invoicing)/invoicing/page.behavior.test.tsx
@@ -4,10 +4,12 @@ import userEvent from "@testing-library/user-event";
 
 const {
   updateSettingsMutateAsyncMock,
+  updateReceiptPrefixMutateAsyncMock,
   toastSuccessMock,
   settingsData,
 } = vi.hoisted(() => ({
   updateSettingsMutateAsyncMock: vi.fn(),
+  updateReceiptPrefixMutateAsyncMock: vi.fn(),
   toastSuccessMock: vi.fn(),
   settingsData: {
     organization: { name: "Mi Empresa", logoUrl: null },
@@ -22,6 +24,10 @@ vi.mock("@/hooks/useSettings", () => ({
   useSettings: () => ({ data: settingsData, isLoading: false }),
   useUpdateSettings: () => ({
     mutateAsync: updateSettingsMutateAsyncMock,
+    isPending: false,
+  }),
+  useUpdateReceiptPrefix: () => ({
+    mutateAsync: updateReceiptPrefixMutateAsyncMock,
     isPending: false,
   }),
 }));
@@ -40,18 +46,19 @@ describe("Invoicing & Receipts settings page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     updateSettingsMutateAsyncMock.mockResolvedValue(settingsData);
+    updateReceiptPrefixMutateAsyncMock.mockResolvedValue(settingsData);
   });
 
   afterEach(() => {
     cleanup();
   });
 
-  it("shows print header/footer and the receipt prefix", () => {
+  it("shows print header/footer and the editable receipt prefix", () => {
     render(<InvoicingSettingsPage />);
 
     expect(screen.getByLabelText(/encabezado/i)).toHaveValue("Header actual");
     expect(screen.getByLabelText(/pie de página/i)).toHaveValue("Footer actual");
-    expect(screen.getByText("REC-")).toBeInTheDocument();
+    expect(screen.getByLabelText(/prefijo/i)).toHaveValue("REC-");
   });
 
   it("saves only printHeader and printFooter on submit", async () => {
@@ -61,11 +68,23 @@ describe("Invoicing & Receipts settings page", () => {
     const header = screen.getByLabelText(/encabezado/i);
     await user.clear(header);
     await user.type(header, "Nuevo encabezado");
-    await user.click(screen.getByRole("button", { name: /guardar/i }));
+    await user.click(screen.getByRole("button", { name: "Guardar" }));
 
     expect(updateSettingsMutateAsyncMock).toHaveBeenCalledWith({
       printHeader: "Nuevo encabezado",
       printFooter: "Footer actual",
     });
+  });
+
+  it("saves the receipt prefix through the receipt-prefix endpoint", async () => {
+    const user = userEvent.setup();
+    render(<InvoicingSettingsPage />);
+
+    const prefix = screen.getByLabelText(/prefijo/i);
+    await user.clear(prefix);
+    await user.type(prefix, "FAC-");
+    await user.click(screen.getByRole("button", { name: "Guardar prefijo" }));
+
+    expect(updateReceiptPrefixMutateAsyncMock).toHaveBeenCalledWith("FAC-");
   });
 });

--- a/frontend/src/app/settings/(invoicing)/invoicing/page.tsx
+++ b/frontend/src/app/settings/(invoicing)/invoicing/page.tsx
@@ -1,27 +1,34 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useSettings, useUpdateSettings } from "@/hooks/useSettings";
+import {
+  useSettings,
+  useUpdateSettings,
+  useUpdateReceiptPrefix,
+} from "@/hooks/useSettings";
 import { Input } from "@/components/ui/Input";
 import { Button } from "@/components/ui/Button";
 import { LoadingState } from "@/components/ui/LoadingState";
 import { SettingsCard } from "../../_components/SettingsCard";
 import { useToast } from "@/contexts/ToastContext";
 import { getApiErrorMessage } from "@/lib/api";
-import { Receipt } from "lucide-react";
+import { Receipt, Hash } from "lucide-react";
 
 export default function InvoicingSettingsPage() {
   const toast = useToast();
   const { data: settings, isLoading } = useSettings();
   const updateSettings = useUpdateSettings();
+  const updateReceiptPrefix = useUpdateReceiptPrefix();
 
   const [printHeader, setPrintHeader] = useState("");
   const [printFooter, setPrintFooter] = useState("");
+  const [prefix, setPrefix] = useState("");
 
   useEffect(() => {
     if (settings) {
       setPrintHeader(settings.invoicing.printHeader ?? "");
       setPrintFooter(settings.invoicing.printFooter ?? "");
+      setPrefix(settings.receipt.prefix ?? "");
     }
   }, [settings]);
 
@@ -41,6 +48,16 @@ export default function InvoicingSettingsPage() {
       toast.success("Configuración guardada correctamente");
     } catch (error) {
       toast.error(getApiErrorMessage(error, "Error al guardar la configuración"));
+    }
+  };
+
+  const handlePrefixSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await updateReceiptPrefix.mutateAsync(prefix);
+      toast.success("Prefijo guardado correctamente");
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "Error al guardar el prefijo"));
     }
   };
 
@@ -76,21 +93,30 @@ export default function InvoicingSettingsPage() {
             placeholder="Información que aparecerá al pie de los recibos"
           />
 
-          <div className="rounded-xl border border-border bg-card px-4 py-3">
-            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Prefijo de comprobante
-            </p>
-            <p className="text-sm font-mono text-foreground mt-1">
-              {settings.receipt.prefix ?? "—"}
-            </p>
-            <p className="text-xs text-muted-foreground mt-1">
-              Se toma de la secuencia de ventas configurada.
-            </p>
-          </div>
-
           <div className="flex justify-end pt-2">
             <Button type="submit" loading={updateSettings.isPending}>
               Guardar
+            </Button>
+          </div>
+        </form>
+      </SettingsCard>
+
+      <SettingsCard
+        title="Prefijo de comprobante"
+        description="Prefijo que antecede al número de cada recibo"
+        icon={<Hash className="w-4 h-4 text-primary" />}
+      >
+        <form onSubmit={handlePrefixSubmit} className="space-y-4">
+          <Input
+            label="Prefijo de comprobante"
+            value={prefix}
+            onChange={(e) => setPrefix(e.target.value)}
+            placeholder="Ej. REC-"
+          />
+
+          <div className="flex justify-end pt-2">
+            <Button type="submit" loading={updateReceiptPrefix.isPending}>
+              Guardar prefijo
             </Button>
           </div>
         </form>

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -47,6 +47,32 @@ export function useUploadLogo() {
   });
 }
 
+export function useUpdateOrganizationName() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (name: string) =>
+      api.patch<Settings>("/settings/organization", { name }).then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["settings"] });
+    },
+  });
+}
+
+export function useUpdateReceiptPrefix() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (prefix: string) =>
+      api
+        .patch<Settings>("/settings/receipt-prefix", { prefix })
+        .then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["settings"] });
+    },
+  });
+}
+
 export function useInventoryMovements(params?: {
   page?: number;
   limit?: number;


### PR DESCRIPTION
## Chain context

Feature branch chain for `settings-refactor` (tracker `settings-refactor`).

```
settings-refactor (tracker, no-merge)
  └─ settings-refactor-pr1-foundation-tax (#22)
       └─ settings-refactor-pr2-settings-engine (#23)
            └─ settings-refactor-pr3-backend-consumers (#24)
                 └─ settings-refactor-pr4-frontend-subsidebar (#25)
                      └─ settings-refactor-pr5-settings-write-endpoints (#26) 📍
```

## What

General (organization name) and Invoicing (receipt prefix) were read-only in PR4 because no org-ADMIN write endpoint existed. This slice adds them.

### Backend (`backend/src/settings/`)
- `PATCH /settings/organization` — `@Roles(OrgRole.ADMIN)`, updates `Organization.name`.
- `PATCH /settings/receipt-prefix` — `@Roles(OrgRole.ADMIN)`, writes the SALE `OrganizationSequence.prefix` (same selection as `readSalePrefix`: latest-year SALE sequence; creates one if none exists).
- `SettingsService.updateOrganizationName` (validate non-empty, trim) + `updateSalePrefix` (trim, empty→null).
- DTOs `UpdateOrganizationNameDto` / `UpdateReceiptPrefixDto` (class-validator).
- Service + controller specs (RED→GREEN).

### Frontend (`frontend/src/`)
- `useUpdateOrganizationName` / `useUpdateReceiptPrefix` hooks (TanStack Query, invalidate `["settings"]`).
- `(general)` page: editable org name + save.
- `(invoicing)` page: editable receipt prefix + save (separate card from print header/footer).
- Behavior tests updated/extended (RED→GREEN).

## Verification
- Backend `npm run test -- --testPathPatterns=settings`: 36/36 green.
- Backend full `npm run test`: 432/432 green.
- Frontend `npm run test -- settings/`: 16/16 green.
- Frontend full `npm run test`: 166 passed / 5 pre-existing failures (pos scanner, sales deep-link, admin spinner — identical to baseline).
- `npx tsc --noEmit`: clean for this slice's files (only pre-existing `expenses` / `AuthContext.switch.test.tsx` errors).

## Out of scope
- No migration; writes reuse existing `Organization.name` and `OrganizationSequence.prefix` columns.
- Receipt PDF/sequence consumers already read these fields (PR3), no consumer change needed.
