### PR TITLE
refactor(admin): route updatePlan through shared applySystemKeys helper

### DIFF
--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -16,7 +16,7 @@ import { OrgRole, OrgStatus, PlanType, Prisma } from '@prisma/client';
 import { PlanLimitService } from '../plan-limits/plan-limits.service';
 import { PLAN_LIMITS, LimitType } from '../plan-limits/plan-limits.constants';
 import { DEFAULT_EXPENSE_CATEGORY_NAMES } from '../expenses/default-expense-categories';
-import { isRecord, mergeSettingsJson } from '../settings/settings.service';
+import { applySystemKeys } from '../settings/settings.service';
 
 @Injectable()
 export class AdminService {
@@ -215,10 +215,9 @@ export class AdminService {
 
     if (organization.plan === PlanType.PRO && dto.plan === PlanType.BASIC) {
       const downgradeFlags = await this.calculateDowngradeFlags(id);
-      data.settings = {
-        ...existingSettings,
+      data.settings = applySystemKeys(existingSettings, {
         downgradeFlags,
-      } as Prisma.InputJsonObject;
+      }) as Prisma.InputJsonObject;
     }
 
     return this.prisma.organization.update({

--- a/backend/src/settings/settings.service.spec.ts
+++ b/backend/src/settings/settings.service.spec.ts
@@ -3,7 +3,7 @@ import {
   ConflictException,
   NotFoundException,
 } from '@nestjs/common';
-import { SettingsService } from './settings.service';
+import { SettingsService, applySystemKeys } from './settings.service';
 
 describe('SettingsService', () => {
   let service: SettingsService;
@@ -388,5 +388,32 @@ describe('SettingsService', () => {
         custom: {},
       });
     });
+  });
+});
+
+describe('applySystemKeys', () => {
+  it('preserves user-owned keys and overlays system keys', () => {
+    const existing = {
+      printHeader: 'Mi Negocio',
+      printFooter: 'Gracias',
+      custom: { loyalty: 'true' },
+    };
+
+    const result = applySystemKeys(existing, { downgradeFlags: { users: 2 } });
+
+    expect(result).toEqual({
+      printHeader: 'Mi Negocio',
+      printFooter: 'Gracias',
+      custom: { loyalty: 'true' },
+      downgradeFlags: { users: 2 },
+    });
+  });
+
+  it('does not mutate the existing object', () => {
+    const existing = { printHeader: 'A' };
+    applySystemKeys(existing, { downgradeFlags: {} });
+
+    expect(existing).toEqual({ printHeader: 'A' });
+    expect(existing).not.toHaveProperty('downgradeFlags');
   });
 });

--- a/backend/src/settings/settings.service.ts
+++ b/backend/src/settings/settings.service.ts
@@ -80,6 +80,18 @@ export function mergeSettingsJson(
   return next;
 }
 
+/**
+ * Applies a system-key overlay (e.g. `downgradeFlags`) onto existing settings
+ * for write paths outside the user-facing settings PUT (e.g. `admin.updatePlan`).
+ * Preserves every user-owned key; only the given system keys are overlaid.
+ */
+export function applySystemKeys(
+  existing: Record<string, unknown>,
+  systemKeys: Record<string, unknown>,
+): Record<string, unknown> {
+  return { ...existing, ...systemKeys };
+}
+
 @Injectable()
 export class SettingsService {
   constructor(


### PR DESCRIPTION
PR6 of settings-refactor (chained PR, feature-branch-chain). Resolves verify warning 3: admin.updatePlan now routes the downgradeFlags write through the shared applySystemKeys helper (single merge discipline) instead of an ad-hoc spread; removes dead isRecord/mergeSettingsJson imports. Adds applySystemKeys unit spec. Tests 87/87 (settings+admin). Targets PR5 branch.