### PR TITLE
fix(sales): honor edited unit price in sale creation

### DIFF
--- a/backend/src/sales/sales.service.spec.ts
+++ b/backend/src/sales/sales.service.spec.ts
@@ -578,6 +578,72 @@ describe('SalesService', () => {
     );
   });
 
+  it('create honors an edited unit price (price override) instead of product salePrice', async () => {
+    const txMock = {
+      sale: { create: jest.fn() },
+      saleItem: { create: jest.fn() },
+      product: {
+        findFirst: jest.fn().mockResolvedValue({ stock: 10 }),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      inventoryMovement: { create: jest.fn() },
+      payment: { create: jest.fn() },
+    };
+
+    prismaMock.$transaction.mockImplementation(
+      async (callback: (tx: unknown) => unknown) => callback(txMock),
+    );
+    sequenceServiceMock.nextNumber.mockResolvedValue({
+      number: 44,
+      formatted: '44',
+    });
+    prismaMock.product.findFirst.mockResolvedValue({
+      id: 'prod-1',
+      name: 'Price Override Product',
+      active: true,
+      salePrice: 100,
+      taxable: false,
+      taxRate: 0,
+      stock: 10,
+      category: { taxable: false, defaultTaxRate: null },
+    });
+    prismaMock.customer.findFirst.mockResolvedValue({ id: 'cust-1' });
+    txMock.sale.create.mockResolvedValue({ id: 'sale-new', saleNumber: 44 });
+    prismaMock.sale.findFirst.mockResolvedValue({
+      id: 'sale-new',
+      saleNumber: 44,
+      userId: 'user-1',
+      user: { id: 'user-1', name: 'User', email: 'user@example.com' },
+      customer: null,
+      items: [],
+      payments: [],
+    });
+
+    await service.create(
+      {
+        customerId: 'cust-1',
+        items: [
+          { productId: 'prod-1', quantity: 1, unitPrice: 80, discountAmount: 0 },
+        ],
+        discountAmount: 0,
+        payments: [{ method: 'CASH' as const, amount: 80 }],
+      },
+      'user-1',
+      'org-1',
+    );
+
+    expect(txMock.saleItem.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ unitPrice: 80, subtotal: 80, total: 80 }),
+      }),
+    );
+    expect(txMock.sale.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ subtotal: 80, total: 80 }),
+      }),
+    );
+  });
+
   it('create throws ServiceUnavailableException on P2028 transaction timeout', async () => {
     const error = new Prisma.PrismaClientKnownRequestError(
       'Transaction timeout',

--- a/backend/src/sales/sales.service.ts
+++ b/backend/src/sales/sales.service.ts
@@ -107,7 +107,7 @@ export class SalesService {
         throw new BadRequestException(`Product ${product.name} is not active`);
       }
 
-      const unitPrice = Number(product.salePrice);
+      const unitPrice = Number(item.unitPrice ?? product.salePrice);
       const grossSubtotal = unitPrice * item.quantity;
       const itemDiscount = Math.max(0, item.discountAmount || 0);
 


### PR DESCRIPTION
## Bug

Editing a cart line's unit price ("Precio unitario" in the POS discount modal) sent `items[].unitPrice` to the backend, but `sales.service.ts` ignored it and always used `product.salePrice`. The frontend total (edited price) and backend total (catalog price) diverged, producing `Total paid (X) is less than total (Y)` on checkout.

## Fix

Use the client-supplied unit price when present:

```ts
const unitPrice = Number(item.unitPrice ?? product.salePrice);
```

The DTO already validates `unitPrice` with `@Min(0)`, so negative values are rejected by the global ValidationPipe.

## Test

Added `create honors an edited unit price (price override) instead of product salePrice` (RED → GREEN). Full backend suite: 435/435.
