### PR TITLE
feat(reports): persist immutable sale cost snapshots (1/5)

### DIFF
--- a/backend/prisma/migrations/20260820000000_add_sale_item_cost_price_snapshot/migration.sql
+++ b/backend/prisma/migrations/20260820000000_add_sale_item_cost_price_snapshot/migration.sql
@@ -1,0 +1,2 @@
+-- Preserve the product cost used by each sale item for exact historical COGS.
+ALTER TABLE "SaleItem" ADD COLUMN "costPriceSnapshot" DECIMAL(10,2);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -270,6 +270,7 @@ model SaleItem {
   productId      String
   quantity       Int
   unitPrice      Decimal      @db.Decimal(10, 2)
+  costPriceSnapshot Decimal?  @db.Decimal(10, 2)
   taxRate        Decimal      @db.Decimal(5, 2)
   discountAmount Decimal      @default(0) @db.Decimal(10, 2)
   subtotal       Decimal      @db.Decimal(10, 2)

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -188,9 +188,9 @@ async function createDemoProducts(
   orgId: string,
   categoryIds: string[],
   count: number,
-): Promise<{ id: string; salePrice: Prisma.Decimal }[]> {
+): Promise<{ id: string; costPrice: Prisma.Decimal; salePrice: Prisma.Decimal }[]> {
   const prefixes = ['BEB', 'ALI', 'LIM', 'ELEC', 'ROP', 'HOG', 'PAPEL', 'CUID', 'MASC', 'FARM'];
-  const products: { id: string; salePrice: Prisma.Decimal }[] = [];
+  const products: { id: string; costPrice: Prisma.Decimal; salePrice: Prisma.Decimal }[] = [];
 
   for (let i = 0; i < count; i++) {
     const prefix = prefixes[i % prefixes.length];
@@ -219,7 +219,11 @@ async function createDemoProducts(
       },
     });
 
-    products.push({ id: product.id, salePrice: d(salePrice) });
+    products.push({
+      id: product.id,
+      costPrice: d(costPrice),
+      salePrice: d(salePrice),
+    });
   }
 
   console.log(`  📦 ${count} productos creados`);
@@ -256,7 +260,7 @@ async function createDemoSales(
   orgId: string,
   userIds: string[],
   customerIds: string[],
-  products: { id: string; salePrice: Prisma.Decimal }[],
+  products: { id: string; costPrice: Prisma.Decimal; salePrice: Prisma.Decimal }[],
   count: number,
 ): Promise<void> {
   for (let i = 0; i < count; i++) {
@@ -268,6 +272,7 @@ async function createDemoSales(
       productId: string;
       quantity: number;
       unitPrice: Prisma.Decimal;
+      costPriceSnapshot: Prisma.Decimal;
       taxRate: Prisma.Decimal;
       subtotal: Prisma.Decimal;
       total: Prisma.Decimal;
@@ -284,6 +289,7 @@ async function createDemoSales(
         productId: product.id,
         quantity,
         unitPrice,
+        costPriceSnapshot: product.costPrice,
         taxRate,
         subtotal: itemSubtotal,
         total: itemTotal,
@@ -318,6 +324,7 @@ async function createDemoSales(
             productId: item.productId,
             quantity: item.quantity,
             unitPrice: item.unitPrice,
+            costPriceSnapshot: item.costPriceSnapshot,
             taxRate: item.taxRate,
             discountAmount: d(0),
             subtotal: item.subtotal,

--- a/backend/src/sales/sales.service.spec.ts
+++ b/backend/src/sales/sales.service.spec.ts
@@ -644,6 +644,122 @@ describe('SalesService', () => {
     );
   });
 
+  it('create persists the authoritative product cost and ignores a client cost snapshot', async () => {
+    const txMock = {
+      sale: { create: jest.fn() },
+      saleItem: { create: jest.fn() },
+      product: {
+        findFirst: jest.fn().mockResolvedValue({ stock: 10 }),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      inventoryMovement: { create: jest.fn() },
+      payment: { create: jest.fn() },
+    };
+
+    prismaMock.$transaction.mockImplementation(
+      async (callback: (tx: unknown) => unknown) => callback(txMock),
+    );
+    sequenceServiceMock.nextNumber.mockResolvedValue({ number: 45, formatted: '45' });
+    prismaMock.product.findFirst.mockResolvedValue({
+      id: 'prod-1',
+      name: 'Cost Provenance Product',
+      active: true,
+      costPrice: 37.25,
+      salePrice: 80,
+      taxable: false,
+      taxRate: 0,
+      stock: 10,
+      category: { taxable: false, defaultTaxRate: null },
+    });
+    txMock.sale.create.mockResolvedValue({ id: 'sale-new', saleNumber: 45 });
+    prismaMock.sale.findFirst.mockResolvedValue({
+      id: 'sale-new',
+      saleNumber: 45,
+      userId: 'user-1',
+      user: { id: 'user-1', name: 'User', email: 'user@example.com' },
+      customer: null,
+      items: [],
+      payments: [],
+    });
+
+    await service.create(
+      {
+        items: [
+          {
+            productId: 'prod-1',
+            quantity: 1,
+            unitPrice: 80,
+            discountAmount: 0,
+            costPriceSnapshot: 999,
+          },
+        ],
+        discountAmount: 0,
+        payments: [{ method: 'CASH' as const, amount: 80 }],
+      } as never,
+      'user-1',
+      'org-1',
+    );
+
+    expect(txMock.saleItem.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ costPriceSnapshot: 37.25 }),
+      }),
+    );
+    expect(txMock.saleItem.create.mock.calls[0][0].data.costPriceSnapshot).not.toBe(999);
+  });
+
+  it('keeps the sale cost snapshot independent from later product cost changes', async () => {
+    const txMock = {
+      sale: { create: jest.fn() },
+      saleItem: { create: jest.fn() },
+      product: {
+        findFirst: jest.fn().mockResolvedValue({ stock: 10 }),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      inventoryMovement: { create: jest.fn() },
+      payment: { create: jest.fn() },
+    };
+
+    prismaMock.$transaction.mockImplementation(
+      async (callback: (tx: unknown) => unknown) => callback(txMock),
+    );
+    sequenceServiceMock.nextNumber.mockResolvedValue({ number: 46, formatted: '46' });
+    prismaMock.product.findFirst.mockResolvedValue({
+      id: 'prod-1',
+      name: 'Immutable Cost Product',
+      active: true,
+      costPrice: 37.25,
+      salePrice: 80,
+      taxable: false,
+      taxRate: 0,
+      stock: 10,
+      category: { taxable: false, defaultTaxRate: null },
+    });
+    txMock.sale.create.mockResolvedValue({ id: 'sale-new', saleNumber: 46 });
+    prismaMock.sale.findFirst.mockResolvedValue({
+      id: 'sale-new',
+      saleNumber: 46,
+      userId: 'user-1',
+      user: { id: 'user-1', name: 'User', email: 'user@example.com' },
+      customer: null,
+      items: [{ productId: 'prod-1', costPriceSnapshot: 37.25 }],
+      payments: [],
+    });
+
+    await service.create(
+      {
+        items: [{ productId: 'prod-1', quantity: 1 }],
+        payments: [{ method: 'CASH' as const, amount: 80 }],
+      },
+      'user-1',
+      'org-1',
+    );
+
+    const persistedSnapshot = txMock.saleItem.create.mock.calls[0][0].data.costPriceSnapshot;
+    expect(persistedSnapshot).toBe(37.25);
+    expect(persistedSnapshot).not.toBe(80);
+  });
+
   it('create throws ServiceUnavailableException on P2028 transaction timeout', async () => {
     const error = new Prisma.PrismaClientKnownRequestError(
       'Transaction timeout',

--- a/backend/src/sales/sales.service.ts
+++ b/backend/src/sales/sales.service.ts
@@ -85,6 +85,7 @@ export class SalesService {
       productId: string;
       quantity: number;
       unitPrice: number;
+      costPriceSnapshot: Prisma.Decimal;
       taxRate: number;
       discountAmount: number;
       subtotal: number;
@@ -129,6 +130,7 @@ export class SalesService {
         productId: product.id,
         quantity: item.quantity,
         unitPrice,
+        costPriceSnapshot: product.costPrice,
         taxRate: effectiveTaxRate,
         discountAmount: itemDiscount,
         subtotal: itemSubtotal,
@@ -202,6 +204,7 @@ export class SalesService {
                 productId: saleItem.productId,
                 quantity: saleItem.quantity,
                 unitPrice: saleItem.unitPrice,
+                costPriceSnapshot: saleItem.costPriceSnapshot,
                 taxRate: saleItem.taxRate,
                 discountAmount: saleItem.discountAmount,
                 subtotal: saleItem.subtotal,


### PR DESCRIPTION
Closes #36

## Chain Context

- Strategy: Feature Branch Chain (5 slices)
- Slice: **1 of 5 — immutable sale cost provenance** 📍
- Base: `feat/reports-refactor` (tracker)
- Follow-up: financial read model/API → cash/inventory/export → frontend Reports/importer → final verification

```
master
  └─ feat/reports-refactor (tracker)
       └─ feat/reports-refactor-unit-1 📍
```

## Summary

- Adds nullable `SaleItem.costPriceSnapshot` with `Decimal(10,2)` precision.
- Captures the organization-scoped product cost server-side during sale creation; client input is ignored.
- Updates Prisma schema/migration, seed fixtures, and sales tests.

## Test Plan

- [x] Focused snapshot tests: 24/24
- [x] Integration test: 1/1
- [x] Backend suite: 437 tests passed
- [x] Prisma validation and generation passed
- [x] Backend build passed
- [ ] Database reset and SuperAdmin setup are separate operational runbook tasks

## Contributor Checklist

- [x] Issue linked (`Closes #36`)
- [x] Conventional commit, no `Co-Authored-By`
- [x] Tests kept with the work unit
- [x] No shell scripts changed
