### PR TITLE
feat(reports): add financial read model and economic API (2/5)

### DIFF
--- a/backend/src/expenses/expenses.service.spec.ts
+++ b/backend/src/expenses/expenses.service.spec.ts
@@ -241,6 +241,28 @@ describe('ExpensesService', () => {
   });
 
   describe('findAll', () => {
+    it('provides active report expenses with organization and event-date isolation', async () => {
+      prismaMock.expense.findMany.mockResolvedValue([
+        { total: new Prisma.Decimal('25.00'), purchaseOrderId: null },
+      ]);
+
+      const start = new Date('2026-08-01T05:00:00.000Z');
+      const end = new Date('2026-08-31T04:59:59.999Z');
+      const result = await service.findForReports(orgId, start, end);
+
+      expect(prismaMock.expense.findMany).toHaveBeenCalledWith({
+        where: {
+          organizationId: orgId,
+          active: true,
+          date: { gte: start, lte: end },
+        },
+        select: { total: true, purchaseOrderId: true },
+      });
+      expect(result).toEqual([
+        { total: new Prisma.Decimal('25.00'), purchaseOrderId: null },
+      ]);
+    });
+
     it('paginates active org-scoped expenses with filters and related data', async () => {
       prismaMock.expense.findMany.mockResolvedValue([{ id: 'exp-1' }]);
       prismaMock.expense.count.mockResolvedValue(42);

--- a/backend/src/expenses/expenses.service.ts
+++ b/backend/src/expenses/expenses.service.ts
@@ -258,6 +258,21 @@ export class ExpensesService {
     return { month, total, categories: rows };
   }
 
+  async findForReports(
+    organizationId: string,
+    start: Date,
+    end: Date,
+  ) {
+    return this.prisma.expense.findMany({
+      where: {
+        organizationId: this.requireOrganizationId(organizationId),
+        active: true,
+        date: { gte: start, lte: end },
+      },
+      select: { total: true, purchaseOrderId: true },
+    });
+  }
+
   async findOne(id: string, organizationId: string | undefined) {
     const orgId = this.requireOrganizationId(organizationId);
 

--- a/backend/src/reports/financial-aggregator.spec.ts
+++ b/backend/src/reports/financial-aggregator.spec.ts
@@ -1,0 +1,163 @@
+import { Prisma } from '@prisma/client';
+import {
+  aggregateFinancialSales,
+  compareFinancialReports,
+  serializeFinancialReport,
+} from './financial-aggregator';
+
+const decimal = (value: string | number) => new Prisma.Decimal(value);
+
+describe('financial aggregation', () => {
+  it('calculates tax-exclusive net income, exact COGS, gross profit and net profit', () => {
+    const result = aggregateFinancialSales(
+      [
+        {
+          subtotal: decimal('100.00'),
+          discountAmount: decimal('10.00'),
+          taxAmount: decimal('17.10'),
+          items: [
+            {
+              quantity: 2,
+              subtotal: decimal('100.00'),
+              costPriceSnapshot: decimal('30.00'),
+              discountAmount: decimal('0.00'),
+              productId: 'p-1',
+              productName: 'Widget',
+              categoryName: 'General',
+            },
+          ],
+        },
+      ],
+      [
+        {
+          total: decimal('15.00'),
+          purchaseOrderId: null,
+        },
+        {
+          total: decimal('999.00'),
+          purchaseOrderId: 'purchase-1',
+        },
+      ],
+    );
+
+    expect(result.netIncome).toBe('90.00');
+    expect(result.cogs).toBe('60.00');
+    expect(result.grossProfit).toBe('30.00');
+    expect(result.netProfit).toBe('15.00');
+    expect(result.tax).toBe('17.10');
+    expect(result.operatingExpenses).toBe('15.00');
+  });
+
+  it('excludes missing snapshots from exact margin and reports data quality', () => {
+    const result = aggregateFinancialSales([
+      {
+        subtotal: decimal('100.00'),
+        discountAmount: decimal('20.00'),
+        taxAmount: decimal('0.00'),
+        items: [
+          {
+            quantity: 1,
+            subtotal: decimal('60.00'),
+            costPriceSnapshot: decimal('25.00'),
+            discountAmount: decimal('0.00'),
+            productId: 'known',
+            productName: 'Known',
+            categoryName: 'General',
+          },
+          {
+            quantity: 1,
+            subtotal: decimal('40.00'),
+            costPriceSnapshot: null,
+            discountAmount: decimal('0.00'),
+            productId: 'unknown',
+            productName: 'Unknown',
+            categoryName: 'General',
+          },
+        ],
+      },
+    ]);
+
+    expect(result.netIncome).toBe('80.00');
+    expect(result.cogs).toBe('25.00');
+    expect(result.grossProfit).toBe('23.00');
+    expect(result.dataQuality).toEqual({
+      snapshotBackedItems: 1,
+      excludedItems: 1,
+      excludedQuantity: 1,
+    });
+  });
+
+  it('allocates a sale discount proportionally for product margins', () => {
+    const result = aggregateFinancialSales([
+      {
+        subtotal: decimal('100.00'),
+        discountAmount: decimal('30.00'),
+        taxAmount: decimal('0.00'),
+        items: [
+          {
+            quantity: 1,
+            subtotal: decimal('25.00'),
+            costPriceSnapshot: decimal('10.00'),
+            discountAmount: decimal('0.00'),
+            productId: 'p-1',
+            productName: 'A',
+            categoryName: 'General',
+          },
+          {
+            quantity: 1,
+            subtotal: decimal('75.00'),
+            costPriceSnapshot: decimal('20.00'),
+            discountAmount: decimal('0.00'),
+            productId: 'p-2',
+            productName: 'B',
+            categoryName: 'General',
+          },
+        ],
+      },
+    ]);
+
+    expect(result.products).toEqual([
+      expect.objectContaining({ productId: 'p-1', netRevenue: '17.50' }),
+      expect.objectContaining({ productId: 'p-2', netRevenue: '52.50' }),
+    ]);
+  });
+
+  it('is zero-safe for empty data and zero margin denominators', () => {
+    const result = aggregateFinancialSales([], []);
+
+    expect(result.netIncome).toBe('0.00');
+    expect(result.grossMarginPercentage).toBeNull();
+    expect(result.netMarginPercentage).toBeNull();
+  });
+
+  it('serializes every Decimal report value as a string', () => {
+    const serialized = serializeFinancialReport({
+      netIncome: decimal('10.50'),
+      nested: { cogs: decimal('2.25') },
+      rows: [{ margin: decimal('8.25') }],
+    });
+
+    expect(serialized).toEqual({
+      netIncome: '10.50',
+      nested: { cogs: '2.25' },
+      rows: [{ margin: '8.25' }],
+    });
+  });
+
+  it('returns absolute and percentage deltas with zero-safe comparisons', () => {
+    const current = aggregateFinancialSales([
+      {
+        subtotal: decimal('100.00'),
+        discountAmount: decimal('0.00'),
+        taxAmount: decimal('0.00'),
+        items: [],
+      },
+    ]);
+    const previous = aggregateFinancialSales([]);
+
+    expect(compareFinancialReports(current, previous).netIncome).toEqual({
+      absolute: '100.00',
+      percentage: 100,
+    });
+  });
+});

--- a/backend/src/reports/financial-aggregator.ts
+++ b/backend/src/reports/financial-aggregator.ts
@@ -1,0 +1,216 @@
+import { Prisma } from '@prisma/client';
+
+type DecimalValue = Prisma.Decimal;
+
+export interface FinancialSaleItem {
+  productId: string;
+  productName: string;
+  categoryName: string;
+  quantity: number;
+  subtotal: DecimalValue;
+  discountAmount: DecimalValue;
+  costPriceSnapshot: DecimalValue | null;
+}
+
+export interface FinancialSale {
+  subtotal: DecimalValue;
+  discountAmount: DecimalValue;
+  taxAmount: DecimalValue;
+  items: FinancialSaleItem[];
+}
+
+export interface FinancialExpense {
+  total: DecimalValue;
+  purchaseOrderId: string | null;
+}
+
+interface ProductMargin {
+  productId: string;
+  productName: string;
+  categoryName: string;
+  quantity: number;
+  netRevenue: string;
+  cogs: string;
+  grossProfit: string;
+  marginPercentage: number | null;
+}
+
+export interface FinancialReport {
+  netIncome: string;
+  tax: string;
+  cogs: string;
+  grossProfit: string;
+  grossMarginPercentage: number | null;
+  operatingExpenses: string;
+  netProfit: string;
+  netMarginPercentage: number | null;
+  products: ProductMargin[];
+  dataQuality: {
+    snapshotBackedItems: number;
+    excludedItems: number;
+    excludedQuantity: number;
+  };
+}
+
+export interface FinancialDelta {
+  absolute: string;
+  percentage: number | null;
+}
+
+const ZERO = new Prisma.Decimal(0);
+
+function money(value: DecimalValue): string {
+  return value.toFixed(2);
+}
+
+function percentage(value: DecimalValue, denominator: DecimalValue): number | null {
+  if (denominator.isZero()) return null;
+  return value.div(denominator).mul(100).toNumber();
+}
+
+export function aggregateFinancialSales(
+  sales: FinancialSale[],
+  expenses: FinancialExpense[] = [],
+): FinancialReport {
+  let netIncome = ZERO;
+  let tax = ZERO;
+  let attributableRevenue = ZERO;
+  let cogs = ZERO;
+  let operatingExpenses = ZERO;
+  let snapshotBackedItems = 0;
+  let excludedItems = 0;
+  let excludedQuantity = 0;
+  const products = new Map<string, {
+    productId: string;
+    productName: string;
+    categoryName: string;
+    quantity: number;
+    netRevenue: DecimalValue;
+    cogs: DecimalValue;
+  }>();
+
+  for (const sale of sales) {
+    const saleNetIncome = sale.subtotal.sub(sale.discountAmount);
+    netIncome = netIncome.add(saleNetIncome);
+    tax = tax.add(sale.taxAmount);
+    const itemSubtotal = sale.items.reduce(
+      (sum, item) => sum.add(item.subtotal),
+      ZERO,
+    );
+
+    for (const item of sale.items) {
+      if (item.costPriceSnapshot === null) {
+        excludedItems += 1;
+        excludedQuantity += item.quantity;
+        continue;
+      }
+
+      const snapshot = item.costPriceSnapshot;
+      snapshotBackedItems += 1;
+      const allocatedDiscount = itemSubtotal.isZero()
+        ? ZERO
+        : sale.discountAmount.mul(item.subtotal).div(itemSubtotal);
+      const itemNetRevenue = item.subtotal.sub(allocatedDiscount);
+      const itemCogs = snapshot.mul(item.quantity);
+      attributableRevenue = attributableRevenue.add(itemNetRevenue);
+      cogs = cogs.add(itemCogs);
+
+      const existing = products.get(item.productId) ?? {
+        productId: item.productId,
+        productName: item.productName,
+        categoryName: item.categoryName,
+        quantity: 0,
+        netRevenue: ZERO,
+        cogs: ZERO,
+      };
+      existing.quantity += item.quantity;
+      existing.netRevenue = existing.netRevenue.add(itemNetRevenue);
+      existing.cogs = existing.cogs.add(itemCogs);
+      products.set(item.productId, existing);
+    }
+  }
+
+  for (const expense of expenses) {
+    if (!expense.purchaseOrderId) {
+      operatingExpenses = operatingExpenses.add(expense.total);
+    }
+  }
+
+  const grossProfit = attributableRevenue.sub(cogs);
+  const netProfit = grossProfit.sub(operatingExpenses);
+
+  return {
+    netIncome: money(netIncome),
+    tax: money(tax),
+    cogs: money(cogs),
+    grossProfit: money(grossProfit),
+    grossMarginPercentage: percentage(grossProfit, attributableRevenue),
+    operatingExpenses: money(operatingExpenses),
+    netProfit: money(netProfit),
+    netMarginPercentage: percentage(netProfit, attributableRevenue),
+    products: Array.from(products.values()).map((product) => {
+      const productGrossProfit = product.netRevenue.sub(product.cogs);
+      return {
+        productId: product.productId,
+        productName: product.productName,
+        categoryName: product.categoryName,
+        quantity: product.quantity,
+        netRevenue: money(product.netRevenue),
+        cogs: money(product.cogs),
+        grossProfit: money(productGrossProfit),
+        marginPercentage: percentage(productGrossProfit, product.netRevenue),
+      };
+    }),
+    dataQuality: { snapshotBackedItems, excludedItems, excludedQuantity },
+  };
+}
+
+export function serializeFinancialReport<T>(value: T): T {
+  if (value instanceof Prisma.Decimal) {
+    return money(value) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => serializeFinancialReport(entry)) as T;
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        serializeFinancialReport(entry),
+      ]),
+    ) as T;
+  }
+  return value;
+}
+
+export function compareFinancialReports(
+  current: FinancialReport,
+  previous: FinancialReport,
+): Record<string, FinancialDelta> {
+  const fields = [
+    'netIncome',
+    'cogs',
+    'grossProfit',
+    'operatingExpenses',
+    'netProfit',
+  ] as const;
+
+  return Object.fromEntries(
+    fields.map((field) => {
+      const currentValue = new Prisma.Decimal(current[field]);
+      const previousValue = new Prisma.Decimal(previous[field]);
+      const absolute = currentValue.sub(previousValue);
+      return [
+        field,
+        {
+          absolute: money(absolute),
+          percentage: previousValue.isZero()
+            ? currentValue.isZero()
+              ? 0
+              : 100
+            : absolute.div(previousValue).mul(100).toNumber(),
+        },
+      ];
+    }),
+  );
+}

--- a/backend/src/reports/financial-reports.service.int.spec.ts
+++ b/backend/src/reports/financial-reports.service.int.spec.ts
@@ -1,0 +1,179 @@
+import { PrismaClient, PlanType } from '@prisma/client';
+import { CacheService } from '../common/services/cache.service';
+import { ReportsService } from './reports.service';
+
+const prisma = new PrismaClient();
+
+describe('ReportsService financial integration', () => {
+  let service: ReportsService;
+  let orgAId: string;
+  let orgBId: string;
+  let userId: string;
+  let categoryAId: string;
+  let categoryBId: string;
+  let productAId: string;
+  let saleAId: string;
+  let saleBId: string;
+  let expenseCategoryAId: string;
+  let expenseAId: string;
+  let purchaseExpenseId: string;
+  let supplierId: string;
+  let purchaseOrderId: string;
+
+  beforeAll(async () => {
+    service = new ReportsService(prisma as never, new CacheService());
+    const suffix = Date.now();
+    const sequence = suffix % 1_000_000_000;
+    const [orgA, orgB] = await Promise.all([
+      prisma.organization.create({
+        data: { name: 'Reports INT A', slug: `reports-int-a-${suffix}`, plan: PlanType.BASIC },
+      }),
+      prisma.organization.create({
+        data: { name: 'Reports INT B', slug: `reports-int-b-${suffix}`, plan: PlanType.BASIC },
+      }),
+    ]);
+    orgAId = orgA.id;
+    orgBId = orgB.id;
+    const user = await prisma.user.create({
+      data: {
+        email: `reports-int-${suffix}@example.com`,
+        password: 'hash',
+        name: 'Reports Integration',
+      },
+    });
+    userId = user.id;
+    const [categoryA, categoryB] = await Promise.all([
+      prisma.category.create({ data: { name: 'Reports A', organizationId: orgAId } }),
+      prisma.category.create({ data: { name: 'Reports B', organizationId: orgBId } }),
+    ]);
+    categoryAId = categoryA.id;
+    categoryBId = categoryB.id;
+    const productA = await prisma.product.create({
+      data: {
+        name: 'Product A',
+        sku: `reports-a-${suffix}`,
+        costPrice: 40,
+        salePrice: 100,
+        categoryId: categoryAId,
+        organizationId: orgAId,
+      },
+    });
+    productAId = productA.id;
+    const [saleA, saleB] = await Promise.all([
+      prisma.sale.create({
+        data: {
+          saleNumber: sequence,
+          subtotal: 100,
+          taxAmount: 19,
+          discountAmount: 10,
+          total: 109,
+          amountPaid: 109,
+          userId,
+          organizationId: orgAId,
+          createdAt: new Date('2026-08-15T15:00:00.000Z'),
+        },
+      }),
+      prisma.sale.create({
+        data: {
+          saleNumber: sequence,
+          subtotal: 900,
+          taxAmount: 0,
+          discountAmount: 0,
+          total: 900,
+          amountPaid: 900,
+          userId,
+          organizationId: orgBId,
+          createdAt: new Date('2026-08-15T15:00:00.000Z'),
+        },
+      }),
+    ]);
+    saleAId = saleA.id;
+    saleBId = saleB.id;
+    await prisma.saleItem.create({
+      data: {
+        saleId: saleAId,
+        productId: productAId,
+        quantity: 1,
+        unitPrice: 100,
+        costPriceSnapshot: 40,
+        taxRate: 19,
+        subtotal: 100,
+        total: 119,
+        organizationId: orgAId,
+      },
+    });
+    const expenseCategory = await prisma.expenseCategory.create({
+      data: { name: 'Reports expense', organizationId: orgAId },
+    });
+    expenseCategoryAId = expenseCategory.id;
+    const supplier = await prisma.supplier.create({
+      data: {
+        name: 'Reports supplier',
+        documentNumber: `reports-supplier-${suffix}`,
+        organizationId: orgAId,
+      },
+    });
+    supplierId = supplier.id;
+    const purchaseOrder = await prisma.purchaseOrder.create({
+      data: {
+        orderNumber: sequence,
+        supplierId,
+        createdById: userId,
+        organizationId: orgAId,
+      },
+    });
+    purchaseOrderId = purchaseOrder.id;
+    const [expense, purchaseExpense] = await Promise.all([
+      prisma.expense.create({
+        data: {
+          organizationId: orgAId,
+          categoryId: expenseCategoryAId,
+          date: new Date('2026-08-15T15:00:00.000Z'),
+          total: 15,
+          status: 'PAID',
+          createdById: userId,
+        },
+      }),
+      prisma.expense.create({
+        data: {
+          organizationId: orgAId,
+          categoryId: expenseCategoryAId,
+          date: new Date('2026-08-15T15:00:00.000Z'),
+          total: 999,
+          status: 'PAID',
+          purchaseOrderId,
+          createdById: userId,
+        },
+      }),
+    ]);
+    expenseAId = expense.id;
+    purchaseExpenseId = purchaseExpense.id;
+    void categoryBId;
+  });
+
+  afterAll(async () => {
+    await prisma.expense.deleteMany({ where: { id: { in: [expenseAId, purchaseExpenseId] } } });
+    await prisma.purchaseOrder.delete({ where: { id: purchaseOrderId } });
+    await prisma.supplier.delete({ where: { id: supplierId } });
+    await prisma.expenseCategory.delete({ where: { id: expenseCategoryAId } });
+    await prisma.saleItem.deleteMany({ where: { saleId: { in: [saleAId, saleBId] } } });
+    await prisma.sale.deleteMany({ where: { id: { in: [saleAId, saleBId] } } });
+    await prisma.product.delete({ where: { id: productAId } });
+    await prisma.category.deleteMany({ where: { id: { in: [categoryAId, categoryBId] } } });
+    await prisma.user.delete({ where: { id: userId } });
+    await prisma.organization.deleteMany({ where: { id: { in: [orgAId, orgBId] } } });
+    await prisma.$disconnect();
+  });
+
+  it('isolates organization economics and excludes purchase-linked operating outflows', async () => {
+    const reportA = await service.getFinancialOverview(orgAId, '2026-08-01', '2026-08-31');
+    const reportB = await service.getFinancialOverview(orgBId, '2026-08-01', '2026-08-31');
+
+    expect(reportA.current.netIncome).toBe('90.00');
+    expect(reportA.current.cogs).toBe('40.00');
+    expect(reportA.current.operatingExpenses).toBe('15.00');
+    expect(reportA.current.netProfit).toBe('35.00');
+    expect(reportB.current.netIncome).toBe('900.00');
+    expect(reportB.current.cogs).toBe('0.00');
+  });
+});

--- a/backend/src/reports/financial-reports.service.spec.ts
+++ b/backend/src/reports/financial-reports.service.spec.ts
@@ -1,0 +1,111 @@
+import { Prisma } from '@prisma/client';
+import { ReportsService } from './reports.service';
+
+const decimal = (value: string | number) => new Prisma.Decimal(value);
+
+describe('ReportsService financial read model', () => {
+  const prismaMock = {
+    sale: { findMany: jest.fn() },
+  };
+  const cacheMock = { get: jest.fn(), set: jest.fn() };
+  const expensesMock = { findForReports: jest.fn() };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('queries completed sales and expenses by the organization and equivalent ranges', async () => {
+    prismaMock.sale.findMany.mockResolvedValue([]);
+    expensesMock.findForReports.mockResolvedValue([]);
+    const service = new ReportsService(
+      prismaMock as never,
+      cacheMock as never,
+      expensesMock as never,
+    );
+
+    const result = await service.getFinancialOverview(
+      'org-a',
+      '2026-03-10',
+      '2026-03-12',
+    );
+
+    expect(prismaMock.sale.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          organizationId: 'org-a',
+          status: 'COMPLETED',
+          createdAt: expect.objectContaining({
+            gte: expect.any(Date),
+            lte: expect.any(Date),
+          }),
+        },
+      }),
+    );
+    expect(expensesMock.findForReports).toHaveBeenCalledWith(
+      'org-a',
+      expect.any(Date),
+      expect.any(Date),
+    );
+    expect(result.comparisonRange).toEqual({
+      startDate: '2026-03-07',
+      endDate: '2026-03-09',
+      timezone: 'America/Bogota',
+    });
+  });
+
+  it('returns decimal strings and keeps previous-period comparison separate', async () => {
+    prismaMock.sale.findMany
+      .mockResolvedValueOnce([
+        {
+          subtotal: decimal('100.00'),
+          discountAmount: decimal('0.00'),
+          taxAmount: decimal('19.00'),
+          items: [
+            {
+              quantity: 1,
+              subtotal: decimal('100.00'),
+              discountAmount: decimal('0.00'),
+              costPriceSnapshot: decimal('40.00'),
+              productId: 'p-1',
+              product: { name: 'A', category: { name: 'General' } },
+            },
+          ],
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    expensesMock.findForReports.mockResolvedValue([
+      { total: decimal('10.00'), purchaseOrderId: null },
+    ]);
+    const service = new ReportsService(
+      prismaMock as never,
+      cacheMock as never,
+      expensesMock as never,
+    );
+
+    const result = await service.getFinancialOverview(
+      'org-a',
+      '2026-03-10',
+      '2026-03-12',
+    );
+
+    expect(result.current.netIncome).toBe('100.00');
+    expect(result.current.cogs).toBe('40.00');
+    expect(result.current.netProfit).toBe('50.00');
+    expect(result.previous.netIncome).toBe('0.00');
+    expect(result.deltas.netIncome).toEqual({ absolute: '100.00', percentage: 100 });
+    expect(result.current.netIncome).toEqual(expect.any(String));
+  });
+
+  it('never builds a financial query without the requested organization', async () => {
+    const service = new ReportsService(
+      prismaMock as never,
+      cacheMock as never,
+      expensesMock as never,
+    );
+
+    await expect(service.getFinancialOverview(undefined)).rejects.toThrow(
+      'Organization ID is required for reports',
+    );
+    expect(prismaMock.sale.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/reports/reports.controller.spec.ts
+++ b/backend/src/reports/reports.controller.spec.ts
@@ -25,6 +25,7 @@ describe('ReportsController', () => {
   const reportsServiceMock = {
     getDashboardKPIs: jest.fn(),
     getUserPerformance: jest.fn(),
+    getFinancialOverview: jest.fn(),
   };
 
   beforeEach(() => {
@@ -111,6 +112,21 @@ describe('ReportsController', () => {
     );
     expect(result.appliedRange.timezone).toBe('America/Bogota');
     expect(result.comparisonRange).toBeDefined();
+  });
+
+  it('forwards organization scope to the financial endpoint', async () => {
+    const controller = new ReportsController(reportsServiceMock as never);
+    reportsServiceMock.getFinancialOverview.mockResolvedValue({
+      current: { netIncome: '0.00' },
+    });
+
+    await controller.getEconomic(mockUser, '2026-03-01', '2026-03-31');
+
+    expect(reportsServiceMock.getFinancialOverview).toHaveBeenCalledWith(
+      'org-1',
+      '2026-03-01',
+      '2026-03-31',
+    );
   });
 
   it('parses compare and userIds before delegating user performance analytics', async () => {

--- a/backend/src/reports/reports.controller.ts
+++ b/backend/src/reports/reports.controller.ts
@@ -71,6 +71,22 @@ export class ReportsController {
     );
   }
 
+  @Get('economic')
+  @ApiOperation({ summary: 'Get organization financial economics' })
+  @ApiQuery({ name: 'startDate', required: false })
+  @ApiQuery({ name: 'endDate', required: false })
+  getEconomic(
+    @CurrentUser() user: RequestUser,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+  ) {
+    return this.reportsService.getFinancialOverview(
+      user.organizationId,
+      startDate,
+      endDate,
+    );
+  }
+
   @Get('sales/payment-method')
   @ApiOperation({ summary: 'Get sales by payment method' })
   @ApiQuery({ name: 'startDate', required: false })

--- a/backend/src/reports/reports.module.ts
+++ b/backend/src/reports/reports.module.ts
@@ -3,8 +3,10 @@ import { ReportsService } from './reports.service';
 import { ReportsController } from './reports.controller';
 import { OrganizationRequiredGuard } from '../common/guards/organization-required.guard';
 import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
+import { ExpensesModule } from '../expenses/expenses.module';
 
 @Module({
+  imports: [ExpensesModule],
   controllers: [ReportsController],
   providers: [ReportsService, OrganizationRequiredGuard, AdminOrganizationInterceptor],
   exports: [ReportsService],

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -6,6 +6,12 @@ import {
   parseBogotaEndOfDay,
   parseBogotaStartOfDay,
 } from '../common/utils/bogota-date';
+import { ExpensesService } from '../expenses/expenses.service';
+import {
+  aggregateFinancialSales,
+  compareFinancialReports,
+  serializeFinancialReport,
+} from './financial-aggregator';
 
 // ─── Local types ──────────────────────────────────────────────────────────────
 
@@ -115,6 +121,14 @@ function buildAppliedRange(
   };
 }
 
+function buildFinancialRangeMeta(dateFilter: DateFilter): AppliedRangeMeta {
+  return {
+    startDate: dateFilter.gte ? formatDateInBogota(dateFilter.gte) : null,
+    endDate: dateFilter.lte ? formatDateInBogota(dateFilter.lte) : null,
+    timezone: 'America/Bogota',
+  };
+}
+
 function buildComparisonRangeMeta(
   comparisonPeriod: ComparisonPeriod,
 ): AppliedRangeMeta {
@@ -185,6 +199,32 @@ function buildComparisonPeriod(
   };
 }
 
+function buildFinancialComparisonPeriod(
+  startDate?: string,
+  endDate?: string,
+): ComparisonPeriod {
+  if (startDate || endDate) {
+    return buildComparisonPeriod(startDate, endDate);
+  }
+
+  const today = formatDateInBogota(new Date());
+  const [year, month] = today.split('-').map(Number);
+  const monthStart = `${year}-${String(month).padStart(2, '0')}-01`;
+  const nextMonthStart = new Date(Date.UTC(year, month, 1, 5));
+  const currentEnd = new Date(nextMonthStart.getTime() - 1);
+  const currentStart = parseBogotaStartOfDay(monthStart)!;
+  const durationMs = currentEnd.getTime() - currentStart.getTime() + 1;
+  const previousEnd = new Date(currentStart.getTime() - 1);
+
+  return {
+    current: { gte: currentStart, lte: currentEnd },
+    previous: {
+      gte: new Date(previousEnd.getTime() - durationMs + 1),
+      lte: previousEnd,
+    },
+  };
+}
+
 function calculatePercentageChange(
   currentValue: number,
   previousValue: number,
@@ -215,7 +255,107 @@ export class ReportsService {
   constructor(
     private prisma: PrismaService,
     private cache: CacheService,
+    private expensesService?: ExpensesService,
   ) {}
+
+  async getFinancialOverview(
+    organizationId: string | undefined,
+    startDate?: string,
+    endDate?: string,
+  ) {
+    if (!organizationId) {
+      throw new BadRequestException('Organization ID is required for reports');
+    }
+    validateDateRange(startDate, endDate);
+
+    const period = buildFinancialComparisonPeriod(startDate, endDate);
+    const cacheKey = `financial:${organizationId}:${period.current.gte?.toISOString()}:${period.current.lte?.toISOString()}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached) return cached;
+
+    const [currentSales, previousSales, currentExpenses] = await Promise.all([
+      this.findFinancialSales(organizationId, period.current),
+      this.findFinancialSales(organizationId, period.previous),
+      this.findFinancialExpenses(organizationId, period.current),
+    ]);
+    const current = serializeFinancialReport(
+      aggregateFinancialSales(currentSales, currentExpenses),
+    );
+    const previous = serializeFinancialReport(
+      aggregateFinancialSales(
+        previousSales,
+        await this.findFinancialExpenses(organizationId, period.previous),
+      ),
+    );
+
+    const result = {
+      current,
+      previous,
+      deltas: compareFinancialReports(current, previous),
+      appliedRange: buildFinancialRangeMeta(period.current),
+      comparisonRange: buildComparisonRangeMeta(period),
+    };
+    this.cache.set(cacheKey, result, 5 * 60 * 1000);
+    return result;
+  }
+
+  private async findFinancialSales(organizationId: string, dateFilter: DateFilter) {
+    const sales = await this.prisma.sale.findMany({
+      where: { organizationId, status: 'COMPLETED', createdAt: dateFilter },
+      select: {
+        subtotal: true,
+        discountAmount: true,
+        taxAmount: true,
+        items: {
+          select: {
+            productId: true,
+            quantity: true,
+            subtotal: true,
+            discountAmount: true,
+            costPriceSnapshot: true,
+            product: { select: { name: true, category: { select: { name: true } } } },
+          },
+        },
+      },
+    });
+
+    return sales.map((sale) => ({
+      subtotal: sale.subtotal,
+      discountAmount: sale.discountAmount,
+      taxAmount: sale.taxAmount,
+      items: sale.items.map((item) => ({
+        productId: item.productId,
+        productName: item.product.name,
+        categoryName: item.product.category.name,
+        quantity: item.quantity,
+        subtotal: item.subtotal,
+        discountAmount: item.discountAmount,
+        costPriceSnapshot: item.costPriceSnapshot,
+      })),
+    }));
+  }
+
+  private async findFinancialExpenses(
+    organizationId: string,
+    dateFilter: DateFilter,
+  ) {
+    if (!dateFilter.gte || !dateFilter.lte) return [];
+    if (this.expensesService) {
+      return this.expensesService.findForReports(
+        organizationId,
+        dateFilter.gte,
+        dateFilter.lte,
+      );
+    }
+    return this.prisma.expense.findMany({
+      where: {
+        organizationId,
+        active: true,
+        date: { gte: dateFilter.gte, lte: dateFilter.lte },
+      },
+      select: { total: true, purchaseOrderId: true },
+    });
+  }
 
   async getDashboardKPIs(
     organizationId: string | undefined,


### PR DESCRIPTION
Closes #38

## Chain Context

- Strategy: Feature Branch Chain (5 slices)
- Slice: **2 of 5 — financial read model and API** 📍
- Base: `feat/reports-refactor` (tracker; PR1 merged)
- Prior dependency: PR1 cost provenance
- Follow-up: cash/inventory/export → frontend Reports/importer → final verification

## Summary

- Adds `FinancialAggregator` and `GET /reports/economic`.
- Calculates net income as subtotal minus discounts, excluding tax.
- Calculates exact COGS only from `costPriceSnapshot` rows.
- Returns gross/net profit and margins, operating expense separation, equivalent-period deltas, and Decimal-safe response values.
- Preserves existing Reports routes and ADMIN/organization isolation.
- Reuses the Expenses domain through a reporting query seam instead of duplicating expense rules.

## Test Plan

- [x] Focused financial tests: 16/16
- [x] Integration organization-isolation test: 1/1
- [x] Backend suite: 449 tests passed across 45 suites
- [x] Build passed
- [x] Prisma validation passed
- [x] No database reset or credential changes in this slice
- [x] One-time size exception accepted: 880 authored lines vs 800 budget

## Contributor Checklist

- [x] Issue linked (`Closes #38`)
- [x] Conventional commit, no `Co-Authored-By`
- [x] Tests kept with the work unit
- [x] No shell scripts changed
