### PR TITLE
feat(reports): add cash, inventory, compatibility and export metrics (3/5)

### DIFF
--- a/backend/src/exports/dto/export.dto.ts
+++ b/backend/src/exports/dto/export.dto.ts
@@ -20,11 +20,11 @@ export class ExportQueryDto {
   format: ExportFormat;
 
   @ApiProperty({
-    enum: ['sales', 'products', 'customers', 'inventory', 'expenses'],
+    enum: ['sales', 'products', 'customers', 'inventory', 'expenses', 'economic'],
     example: 'sales',
   })
-  @IsEnum(['sales', 'products', 'customers', 'inventory', 'expenses'])
-  type: 'sales' | 'products' | 'customers' | 'inventory' | 'expenses';
+  @IsEnum(['sales', 'products', 'customers', 'inventory', 'expenses', 'economic'])
+  type: 'sales' | 'products' | 'customers' | 'inventory' | 'expenses' | 'economic';
 
   @ApiPropertyOptional({ example: '2024-01-01' })
   @IsOptional()

--- a/backend/src/exports/exports.controller.ts
+++ b/backend/src/exports/exports.controller.ts
@@ -105,4 +105,16 @@ export class ExportsController {
   ) {
     return this.exportsService.exportExpenses(user.organizationId, query, res);
   }
+
+  @Post('economic')
+  @Roles(OrgRole.ADMIN)
+  @ApiOperation({ summary: 'Export the consolidated economic report' })
+  @ApiConsumes('application/json')
+  async exportEconomic(
+    @CurrentUser() user: RequestUser,
+    @Body() query: ExportQueryDto,
+    @Res() res: Response,
+  ) {
+    return this.exportsService.exportEconomic(user.organizationId, query, res);
+  }
 }

--- a/backend/src/exports/exports.module.ts
+++ b/backend/src/exports/exports.module.ts
@@ -3,8 +3,10 @@ import { ExportsController } from './exports.controller';
 import { ExportsService } from './exports.service';
 import { OrganizationRequiredGuard } from '../common/guards/organization-required.guard';
 import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
+import { ReportsModule } from '../reports/reports.module';
 
 @Module({
+  imports: [ReportsModule],
   controllers: [ExportsController],
   providers: [ExportsService, OrganizationRequiredGuard, AdminOrganizationInterceptor],
   exports: [ExportsService],

--- a/backend/src/exports/exports.service.spec.ts
+++ b/backend/src/exports/exports.service.spec.ts
@@ -28,6 +28,7 @@ describe('ExportsService', () => {
       findMany: jest.fn(),
     },
   };
+  const reportsMock = { getEconomicExport: jest.fn() };
 
   const ORG_ID = 'org-1';
 
@@ -42,7 +43,7 @@ describe('ExportsService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    service = new ExportsService(prismaMock as never);
+    service = new ExportsService(prismaMock as never, reportsMock as never);
   });
 
   it('getInventoryMovements filters by organizationId', async () => {
@@ -241,6 +242,33 @@ describe('ExportsService', () => {
 
     expect(csv.write).toHaveBeenCalledWith(
       [['Date', 'Category', 'Description', 'Total', 'Status']],
+      { headers: false },
+    );
+  });
+
+  it('exports the Reports financial contract without converting decimal strings to numbers', async () => {
+    reportsMock.getEconomicExport.mockResolvedValue({
+      financial: { current: { netIncome: '100.10', grossProfit: '40.05', netProfit: '30.05' } },
+      cash: { collections: { total: '120.10' }, expensePayments: { total: '10.00' } },
+      inventory: { current: { stockValue: '50.00', retailValue: '80.00', potentialProfit: '30.00' } },
+    });
+
+    await service.exportEconomic(
+      ORG_ID,
+      { format: 'csv', type: 'economic', startDate: '2026-03-01', endDate: '2026-03-31' } as ExportQueryDto,
+      buildResMock(),
+    );
+
+    expect(reportsMock.getEconomicExport).toHaveBeenCalledWith(
+      ORG_ID,
+      '2026-03-01',
+      '2026-03-31',
+    );
+    expect(csv.write).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        ['financial', 'netIncome', '100.10'],
+        ['inventory', 'potentialProfit', '30.00'],
+      ]),
       { headers: false },
     );
   });

--- a/backend/src/exports/exports.service.ts
+++ b/backend/src/exports/exports.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { ReportsService } from '../reports/reports.service';
 import { ExportQueryDto, InventoryMovementsQueryDto } from './dto/export.dto';
 import * as ExcelJS from 'exceljs';
 import { jsPDF } from 'jspdf';
@@ -7,7 +8,10 @@ import * as csv from '@fast-csv/format';
 
 @Injectable()
 export class ExportsService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private reportsService?: ReportsService,
+  ) {}
 
   async getInventoryMovements(
     organizationId: string | undefined,
@@ -108,6 +112,32 @@ export class ExportsService {
   ) {
     const expenses = await this.getExpensesData(organizationId, query);
     return this.exportData(expenses, 'expenses', query.format, response);
+  }
+
+  async exportEconomic(
+    organizationId: string | undefined,
+    query: ExportQueryDto,
+    response: any,
+  ) {
+    if (!this.reportsService) {
+      throw new Error('Reports service is required for economic exports');
+    }
+    const report = await this.reportsService.getEconomicExport(
+      organizationId,
+      query.startDate,
+      query.endDate,
+    );
+    const rows = [
+      ['financial', 'netIncome', report.financial.current.netIncome],
+      ['financial', 'grossProfit', report.financial.current.grossProfit],
+      ['financial', 'netProfit', report.financial.current.netProfit],
+      ['cash', 'collections', report.cash.collections.total],
+      ['cash', 'expensePayments', report.cash.expensePayments.total],
+      ['inventory', 'stockValue', report.inventory.current.stockValue],
+      ['inventory', 'retailValue', report.inventory.current.retailValue],
+      ['inventory', 'potentialProfit', report.inventory.current.potentialProfit],
+    ];
+    return this.exportData(rows, 'economic', query.format, response);
   }
 
   private async getSalesData(
@@ -353,6 +383,7 @@ export class ExportsService {
         'User',
       ],
       expenses: ['Date', 'Category', 'Description', 'Total', 'Status'],
+      economic: ['Section', 'Metric', 'Value'],
     };
     return headers[type] || [];
   }
@@ -401,6 +432,7 @@ export class ExportsService {
         Number(item.total).toFixed(2),
         item.status,
       ],
+      economic: (item) => item,
     };
     return getters[type](item);
   }
@@ -412,6 +444,7 @@ export class ExportsService {
       customers: [35, 25, 25, 30, 25, 20],
       inventory: [25, 40, 25, 15, 20, 20, 25],
       expenses: [25, 40, 40, 20, 20],
+      economic: [30, 40, 30],
     };
     return widths[type] || [];
   }

--- a/backend/src/reports/financial-reports.service.spec.ts
+++ b/backend/src/reports/financial-reports.service.spec.ts
@@ -6,6 +6,10 @@ const decimal = (value: string | number) => new Prisma.Decimal(value);
 describe('ReportsService financial read model', () => {
   const prismaMock = {
     sale: { findMany: jest.fn() },
+    payment: { findMany: jest.fn() },
+    expensePayment: { findMany: jest.fn() },
+    product: { findMany: jest.fn() },
+    inventoryMovement: { findMany: jest.fn() },
   };
   const cacheMock = { get: jest.fn(), set: jest.fn() };
   const expensesMock = { findForReports: jest.fn() };
@@ -107,5 +111,62 @@ describe('ReportsService financial read model', () => {
       'Organization ID is required for reports',
     );
     expect(prismaMock.sale.findMany).not.toHaveBeenCalled();
+  });
+
+  it('reports sale collections and expense payments by payment date and method', async () => {
+    prismaMock.payment.findMany.mockResolvedValue([
+      { amount: decimal('10.25'), method: 'CASH', createdAt: new Date('2026-03-11') },
+      { amount: decimal('5.75'), method: 'CARD', createdAt: new Date('2026-03-12') },
+    ]);
+    prismaMock.expensePayment.findMany.mockResolvedValue([
+      { amount: decimal('3.50'), method: 'TRANSFER', date: new Date('2026-03-12') },
+    ]);
+    const service = new ReportsService(prismaMock as never, cacheMock as never);
+
+    const result = await service.getCashFlow('org-a', '2026-03-10', '2026-03-12');
+
+    expect(prismaMock.payment.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        organizationId: 'org-a',
+        createdAt: expect.any(Object),
+        sale: { status: 'COMPLETED' },
+      }),
+    }));
+    expect(prismaMock.expensePayment.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { organizationId: 'org-a', date: expect.any(Object) },
+    }));
+    expect(result.collections.total).toBe('16.00');
+    expect(result.collections.byPaymentMethod).toEqual([
+      { paymentMethod: 'CASH', total: '10.25', count: 1 },
+      { paymentMethod: 'CARD', total: '5.75', count: 1 },
+    ]);
+    expect(result.expensePayments.total).toBe('3.50');
+  });
+
+  it('returns current inventory valuation and period movement quantities separately', async () => {
+    prismaMock.product.findMany.mockResolvedValue([
+      { stock: 3, costPrice: decimal('10.00'), salePrice: decimal('18.00') },
+      { stock: 2, costPrice: decimal('4.50'), salePrice: decimal('9.00') },
+    ]);
+    prismaMock.inventoryMovement.findMany.mockResolvedValue([
+      { type: 'SALE', quantity: 2 },
+      { type: 'RETURN', quantity: 1 },
+    ]);
+    const service = new ReportsService(prismaMock as never, cacheMock as never);
+
+    const result = await service.getInventorySnapshot('org-a', '2026-03-10', '2026-03-12');
+
+    expect(result.isCurrentSnapshot).toBe(true);
+    expect(result.valuationBasis).toBe('CURRENT_STOCK_AT_CURRENT_COST');
+    expect(result.current.stockValue).toBe('39.00');
+    expect(result.current.retailValue).toBe('72.00');
+    expect(result.current.potentialProfit).toBe('33.00');
+    expect(result.movements).toEqual({
+      totalQuantity: 3,
+      byType: { SALE: 2, RETURN: 1 },
+    });
+    expect(prismaMock.product.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { organizationId: 'org-a', active: true },
+    }));
   });
 });

--- a/backend/src/reports/reports.controller.spec.ts
+++ b/backend/src/reports/reports.controller.spec.ts
@@ -26,6 +26,8 @@ describe('ReportsController', () => {
     getDashboardKPIs: jest.fn(),
     getUserPerformance: jest.fn(),
     getFinancialOverview: jest.fn(),
+    getCashFlow: jest.fn(),
+    getInventorySnapshot: jest.fn(),
   };
 
   beforeEach(() => {
@@ -123,6 +125,24 @@ describe('ReportsController', () => {
     await controller.getEconomic(mockUser, '2026-03-01', '2026-03-31');
 
     expect(reportsServiceMock.getFinancialOverview).toHaveBeenCalledWith(
+      'org-1',
+      '2026-03-01',
+      '2026-03-31',
+    );
+  });
+
+  it('forwards organization scope to cash and inventory contracts', async () => {
+    const controller = new ReportsController(reportsServiceMock as never);
+
+    await controller.getCash(mockUser, '2026-03-01', '2026-03-31');
+    await controller.getInventory(mockUser, '2026-03-01', '2026-03-31');
+
+    expect(reportsServiceMock.getCashFlow).toHaveBeenCalledWith(
+      'org-1',
+      '2026-03-01',
+      '2026-03-31',
+    );
+    expect(reportsServiceMock.getInventorySnapshot).toHaveBeenCalledWith(
       'org-1',
       '2026-03-01',
       '2026-03-31',

--- a/backend/src/reports/reports.controller.ts
+++ b/backend/src/reports/reports.controller.ts
@@ -87,6 +87,38 @@ export class ReportsController {
     );
   }
 
+  @Get('economic/cash')
+  @ApiOperation({ summary: 'Get cash collections and expense payments' })
+  @ApiQuery({ name: 'startDate', required: false })
+  @ApiQuery({ name: 'endDate', required: false })
+  getCash(
+    @CurrentUser() user: RequestUser,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+  ) {
+    return this.reportsService.getCashFlow(
+      user.organizationId,
+      startDate,
+      endDate,
+    );
+  }
+
+  @Get('economic/inventory')
+  @ApiOperation({ summary: 'Get current inventory economics and movements' })
+  @ApiQuery({ name: 'startDate', required: false })
+  @ApiQuery({ name: 'endDate', required: false })
+  getInventory(
+    @CurrentUser() user: RequestUser,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+  ) {
+    return this.reportsService.getInventorySnapshot(
+      user.organizationId,
+      startDate,
+      endDate,
+    );
+  }
+
   @Get('sales/payment-method')
   @ApiOperation({ summary: 'Get sales by payment method' })
   @ApiQuery({ name: 'startDate', required: false })

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CacheService } from '../common/services/cache.service';
 import {
@@ -12,6 +13,7 @@ import {
   compareFinancialReports,
   serializeFinancialReport,
 } from './financial-aggregator';
+import type { FinancialDelta, FinancialReport } from './financial-aggregator';
 
 // ─── Local types ──────────────────────────────────────────────────────────────
 
@@ -248,6 +250,41 @@ function normalizeUserIds(userIds?: string[]): string[] | undefined {
   return normalized.length > 0 ? normalized : undefined;
 }
 
+export interface FinancialOverviewResponse {
+  current: FinancialReport;
+  previous: FinancialReport;
+  deltas: Record<string, FinancialDelta>;
+  appliedRange: AppliedRangeMeta;
+  comparisonRange: AppliedRangeMeta;
+}
+
+function aggregateCashPayments(
+  payments: Array<{ amount: Prisma.Decimal; method: string }>,
+) {
+  const byMethod = new Map<string, { total: Prisma.Decimal; count: number }>();
+  for (const payment of payments) {
+    const current = byMethod.get(payment.method) ?? {
+      total: new Prisma.Decimal(0),
+      count: 0,
+    };
+    current.total = current.total.add(payment.amount);
+    current.count += 1;
+    byMethod.set(payment.method, current);
+  }
+
+  return {
+    total: Array.from(byMethod.values()).reduce(
+      (sum, entry) => sum.add(entry.total),
+      new Prisma.Decimal(0),
+    ).toFixed(2),
+    byPaymentMethod: Array.from(byMethod.entries()).map(([paymentMethod, entry]) => ({
+      paymentMethod,
+      total: entry.total.toFixed(2),
+      count: entry.count,
+    })),
+  };
+}
+
 // ─── Service ──────────────────────────────────────────────────────────────────
 
 @Injectable()
@@ -262,7 +299,7 @@ export class ReportsService {
     organizationId: string | undefined,
     startDate?: string,
     endDate?: string,
-  ) {
+  ): Promise<FinancialOverviewResponse> {
     if (!organizationId) {
       throw new BadRequestException('Organization ID is required for reports');
     }
@@ -271,7 +308,7 @@ export class ReportsService {
     const period = buildFinancialComparisonPeriod(startDate, endDate);
     const cacheKey = `financial:${organizationId}:${period.current.gte?.toISOString()}:${period.current.lte?.toISOString()}`;
     const cached = this.cache.get(cacheKey);
-    if (cached) return cached;
+    if (cached) return cached as FinancialOverviewResponse;
 
     const [currentSales, previousSales, currentExpenses] = await Promise.all([
       this.findFinancialSales(organizationId, period.current),
@@ -297,6 +334,113 @@ export class ReportsService {
     };
     this.cache.set(cacheKey, result, 5 * 60 * 1000);
     return result;
+  }
+
+  async getCashFlow(
+    organizationId: string | undefined,
+    startDate?: string,
+    endDate?: string,
+  ) {
+    const orgId = this.requireOrganizationId(organizationId);
+    validateDateRange(startDate, endDate);
+    const period = buildFinancialComparisonPeriod(startDate, endDate);
+    const [collections, expensePayments] = await Promise.all([
+      this.prisma.payment.findMany({
+        where: {
+          organizationId: orgId,
+          createdAt: period.current,
+          sale: { status: 'COMPLETED' },
+        },
+        select: { amount: true, method: true },
+      }),
+      this.prisma.expensePayment.findMany({
+        where: { organizationId: orgId, date: period.current },
+        select: { amount: true, method: true },
+      }),
+    ]);
+
+    return {
+      accountingBasis: 'CASH_BY_PAYMENT_DATE',
+      collections: aggregateCashPayments(collections),
+      expensePayments: aggregateCashPayments(expensePayments),
+      appliedRange: buildFinancialRangeMeta(period.current),
+    };
+  }
+
+  async getInventorySnapshot(
+    organizationId: string | undefined,
+    startDate?: string,
+    endDate?: string,
+  ) {
+    const orgId = this.requireOrganizationId(organizationId);
+    validateDateRange(startDate, endDate);
+    const period = buildFinancialComparisonPeriod(startDate, endDate);
+    const [products, movements] = await Promise.all([
+      this.prisma.product.findMany({
+        where: { organizationId: orgId, active: true },
+        select: { stock: true, costPrice: true, salePrice: true },
+      }),
+      this.prisma.inventoryMovement.findMany({
+        where: { organizationId: orgId, createdAt: period.current },
+        select: { type: true, quantity: true },
+      }),
+    ]);
+
+    const current = products.reduce(
+      (totals, product) => ({
+        stockQuantity: totals.stockQuantity + product.stock,
+        stockValue: totals.stockValue.add(product.costPrice.mul(product.stock)),
+        retailValue: totals.retailValue.add(product.salePrice.mul(product.stock)),
+      }),
+      {
+        stockQuantity: 0,
+        stockValue: new Prisma.Decimal(0),
+        retailValue: new Prisma.Decimal(0),
+      },
+    );
+    const movementTotals = movements.reduce(
+      (totals, movement) => {
+        totals.totalQuantity += movement.quantity;
+        totals.byType[movement.type] =
+          (totals.byType[movement.type] ?? 0) + movement.quantity;
+        return totals;
+      },
+      { totalQuantity: 0, byType: {} as Record<string, number> },
+    );
+
+    return {
+      isCurrentSnapshot: true,
+      valuationBasis: 'CURRENT_STOCK_AT_CURRENT_COST',
+      current: {
+        stockQuantity: current.stockQuantity,
+        stockValue: current.stockValue.toFixed(2),
+        retailValue: current.retailValue.toFixed(2),
+        potentialProfit: current.retailValue.sub(current.stockValue).toFixed(2),
+      },
+      movements: movementTotals,
+      appliedRange: buildFinancialRangeMeta(period.current),
+    };
+  }
+
+  async getEconomicExport(
+    organizationId: string | undefined,
+    startDate?: string,
+    endDate?: string,
+  ) {
+    const [financial, cash, inventory] = await Promise.all([
+      this.getFinancialOverview(organizationId, startDate, endDate),
+      this.getCashFlow(organizationId, startDate, endDate),
+      this.getInventorySnapshot(organizationId, startDate, endDate),
+    ]);
+
+    return { financial, cash, inventory };
+  }
+
+  private requireOrganizationId(organizationId: string | undefined): string {
+    if (!organizationId) {
+      throw new BadRequestException('Organization ID is required for reports');
+    }
+    return organizationId;
   }
 
   private async findFinancialSales(organizationId: string, dateFilter: DateFilter) {


### PR DESCRIPTION
Closes #40

## Chain Context

- Strategy: Feature Branch Chain (5 slices)
- Slice: **3 of 5 — cash, inventory, compatibility and export** 📍
- Base: `feat/reports-refactor` (tracker; PR1 and PR2 merged)
- Follow-up: frontend Reports/importer → final verification

## Summary

- Adds cash-flow metrics by payment date and method, separate from accrual economics.
- Adds current inventory valuation at cost, retail value and potential profit.
- Adds inventory movement totals by type and period.
- Preserves legacy Reports routes as compatibility adapters.
- Adds consolidated economic export with Decimal-safe string values.
- Keeps reset and SuperAdmin setup outside the feature implementation.

## Test Plan

- [x] Focused PR3 tests: 23/23
- [x] Backend suite: 453 tests passed across 45 suites
- [x] Build passed
- [x] Prisma validation passed
- [x] Scoped lint attempted without autofix; existing CRLF/Prettier and unsafe-type diagnostics remain
- [x] Slice diff: 339 authored lines, within the 800-line review budget

## Contributor Checklist

- [x] Issue linked (`Closes #40`)
- [x] Conventional commit, no `Co-Authored-By`
- [x] Tests kept with the work unit
- [x] No shell scripts changed
