### PR TITLE
feat(reports): refactor frontend around economics and move importer (4/5)

### DIFF
--- a/frontend/src/app/inventory/page.tsx
+++ b/frontend/src/app/inventory/page.tsx
@@ -24,11 +24,13 @@ import { LoadingState } from "@/components/ui/LoadingState";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { FilterBar } from "@/components/ui/FilterBar";
 import { ProductCard } from "@/components/products/ProductCard";
+import { ImportSection } from "@/components/reports/ImportSection";
 import {
   Plus,
   AlertTriangle,
   Package,
   SlidersHorizontal,
+  Upload,
 } from "lucide-react";
 import type { Product } from "@/types";
 import { useToast } from "@/contexts/ToastContext";
@@ -52,6 +54,7 @@ export default function InventoryPage() {
   const [showDeactivateModal, setShowDeactivateModal] = useState(false);
   const [showReactivateModal, setShowReactivateModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showImporter, setShowImporter] = useState(false);
   const [productToDeactivate, setProductToDeactivate] = useState<string | null>(
     null,
   );
@@ -308,13 +311,16 @@ export default function InventoryPage() {
             </p>
           </div>
           {canManageInventory && (
-            <Button
-              onClick={handleCreate}
-              className="w-full sm:w-auto shrink-0"
-            >
-              <Plus className="w-4 h-4" />
-              Nuevo Producto
-            </Button>
+            <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
+              <Button variant="ghost" onClick={() => setShowImporter((current) => !current)} className="w-full sm:w-auto shrink-0">
+                <Upload className="w-4 h-4" />
+                {showImporter ? "Ocultar importador" : "Importar productos"}
+              </Button>
+              <Button onClick={handleCreate} className="w-full sm:w-auto shrink-0">
+                <Plus className="w-4 h-4" />
+                Nuevo Producto
+              </Button>
+            </div>
           )}
         </div>
 
@@ -437,6 +443,8 @@ export default function InventoryPage() {
             ) : undefined
           }
         />
+
+        {canManageInventory && showImporter && <ImportSection />}
 
         {/* Low stock alert */}
         {/* {lowStockProducts.length > 0 &&

--- a/frontend/src/app/reports/page.evidence.test.tsx
+++ b/frontend/src/app/reports/page.evidence.test.tsx
@@ -1,22 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 
-const useDashboardMock = vi.fn();
+const useEconomicOverviewMock = vi.fn();
+const useCashFlowMock = vi.fn();
+const useInventorySnapshotMock = vi.fn();
 const useSalesByPaymentMethodMock = vi.fn();
 const useSalesByCategoryMock = vi.fn();
 const useTopSellingProductsMock = vi.fn();
 const useCustomerStatisticsMock = vi.fn();
-const useUserPerformanceMock = vi.fn();
-const useUsersMock = vi.fn();
 
 vi.mock("@/components/layout/DashboardLayout", () => ({
   DashboardLayout: ({ children }: { children: ReactNode }) => <>{children}</>,
-}));
-
-vi.mock("@/components/reports/ImportSection", () => ({
-  ImportSection: () => <section>ImportSection</section>,
 }));
 
 vi.mock("@/components/ui/Button", () => ({
@@ -43,8 +38,12 @@ vi.mock("@/lib/api", () => ({
 }));
 
 vi.mock("@/hooks/useReports", () => ({
-  useDashboard: (startDate?: string, endDate?: string) =>
-    useDashboardMock(startDate, endDate),
+  useEconomicOverview: (startDate?: string, endDate?: string) =>
+    useEconomicOverviewMock(startDate, endDate),
+  useCashFlow: (startDate?: string, endDate?: string) =>
+    useCashFlowMock(startDate, endDate),
+  useInventorySnapshot: (startDate?: string, endDate?: string) =>
+    useInventorySnapshotMock(startDate, endDate),
   useSalesByPaymentMethod: (startDate?: string, endDate?: string) =>
     useSalesByPaymentMethodMock(startDate, endDate),
   useSalesByCategory: (startDate?: string, endDate?: string) =>
@@ -53,49 +52,60 @@ vi.mock("@/hooks/useReports", () => ({
     useTopSellingProductsMock(startDate, endDate, limit),
   useCustomerStatistics: (startDate?: string, endDate?: string) =>
     useCustomerStatisticsMock(startDate, endDate),
-  useUserPerformance: (
-    startDate?: string,
-    endDate?: string,
-    compare?: boolean,
-    userIds?: string[],
-  ) => useUserPerformanceMock(startDate, endDate, compare, userIds),
-}));
-
-vi.mock("@/hooks/useUsers", () => ({
-  useUsers: () => useUsersMock(),
 }));
 
 import ReportsPage from "./page";
 
-describe("Reports range label semantics evidence (#16)", () => {
+const range = {
+  startDate: "2026-01-10",
+  endDate: "2026-01-12",
+  timezone: "America/Bogota",
+};
+
+describe("Reports economics-first evidence", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    useDashboardMock.mockReturnValue({
+    useEconomicOverviewMock.mockReturnValue({
       data: {
-        totalSales: 3,
-        totalRevenue: 100000,
-        totalProducts: 20,
-        totalCustomers: 6,
-        lowStockProducts: 2,
-        trends: { totalSales: 1, totalRevenue: 2, totalCustomers: 1 },
-        recentSales: [],
-        appliedRange: {
-          startDate: "2026-01-10",
-          endDate: "2026-01-12",
-          timezone: "America/Bogota",
+        current: {
+          netIncome: "100000.25",
+          tax: "19000.05",
+          cogs: "40000.00",
+          grossProfit: "60000.25",
+          grossMarginPercentage: 60.0001,
+          operatingExpenses: "10000.00",
+          netProfit: "50000.25",
+          netMarginPercentage: 50.0001,
+          products: [],
+          dataQuality: { snapshotBackedItems: 3, excludedItems: 1, excludedQuantity: 2 },
         },
+        previous: {
+          netIncome: "80000.00",
+          tax: "15000.00",
+          cogs: "30000.00",
+          grossProfit: "50000.00",
+          grossMarginPercentage: 62.5,
+          operatingExpenses: "10000.00",
+          netProfit: "40000.00",
+          netMarginPercentage: 50,
+          products: [],
+          dataQuality: { snapshotBackedItems: 2, excludedItems: 0, excludedQuantity: 0 },
+        },
+        deltas: { netIncome: { absolute: "20000.25", percentage: 25.31 } },
+        appliedRange: range,
+        comparisonRange: { ...range, startDate: "2026-01-07", endDate: "2026-01-09" },
       },
+      isLoading: false,
+      error: null,
     });
 
+    useCashFlowMock.mockReturnValue({ data: { collections: { total: "70000.00", byPaymentMethod: [] }, expensePayments: { total: "5000.00", byPaymentMethod: [] }, appliedRange: range }, isLoading: false, error: null });
+    useInventorySnapshotMock.mockReturnValue({ data: { isCurrentSnapshot: true, valuationBasis: "CURRENT_STOCK_AT_CURRENT_COST", current: { stockQuantity: 10, stockValue: "50000.00", retailValue: "90000.00", potentialProfit: "40000.00" }, movements: { totalQuantity: 4, byType: {} }, appliedRange: range }, isLoading: false, error: null });
     useSalesByPaymentMethodMock.mockReturnValue({
       data: {
         data: [{ paymentMethod: "CASH", total: 100000, subtotal: 90000, count: 3 }],
-        appliedRange: {
-          startDate: "2026-01-10",
-          endDate: "2026-01-12",
-          timezone: "America/Bogota",
-        },
+        appliedRange: range,
       },
       isLoading: false,
     });
@@ -103,11 +113,7 @@ describe("Reports range label semantics evidence (#16)", () => {
     useSalesByCategoryMock.mockReturnValue({
       data: {
         data: [{ category: "Repuestos", total: 100000, quantity: 4 }],
-        appliedRange: {
-          startDate: "2026-01-10",
-          endDate: "2026-01-12",
-          timezone: "America/Bogota",
-        },
+        appliedRange: range,
       },
       isLoading: false,
     });
@@ -115,11 +121,7 @@ describe("Reports range label semantics evidence (#16)", () => {
     useTopSellingProductsMock.mockReturnValue({
       data: {
         data: [{ productId: "p-1", productName: "Casco", quantity: 4, total: 100000, stock: 8 }],
-        appliedRange: {
-          startDate: "2026-01-10",
-          endDate: "2026-01-12",
-          timezone: "America/Bogota",
-        },
+        appliedRange: range,
       },
       isLoading: false,
     });
@@ -136,94 +138,53 @@ describe("Reports range label semantics evidence (#16)", () => {
             totalRevenue: 50000,
           },
         ],
-        appliedRange: {
-          startDate: "2026-01-10",
-          endDate: "2026-01-12",
-          timezone: "America/Bogota",
-        },
+        appliedRange: range,
       },
       isLoading: false,
     });
 
-    useUserPerformanceMock.mockReturnValue({
-      data: {
-        data: [],
-        appliedRange: {
-          startDate: "2026-01-10",
-          endDate: "2026-01-12",
-          timezone: "America/Bogota",
-        },
-        comparisonRange: {
-          startDate: "2026-01-07",
-          endDate: "2026-01-09",
-          timezone: "America/Bogota",
-        },
-      },
-      isLoading: false,
-      error: null,
-    });
-
-    useUsersMock.mockReturnValue({
-      data: [
-        {
-          id: "user-1",
-          name: "Ana Admin",
-          email: "ana@example.com",
-          role: "ADMIN",
-          active: true,
-          createdAt: "2026-01-01T00:00:00.000Z",
-          updatedAt: "2026-01-01T00:00:00.000Z",
-        },
-        {
-          id: "user-2",
-          name: "Carlos Caja",
-          email: "carlos@example.com",
-          role: "CASHIER",
-          active: true,
-          createdAt: "2026-01-01T00:00:00.000Z",
-          updatedAt: "2026-01-01T00:00:00.000Z",
-        },
-      ],
-      isLoading: false,
-    });
   });
 
   afterEach(() => {
     cleanup();
   });
 
-  it("shows appliedRange labels consistently in key report sections", async () => {
+  it("puts economics first and renders Decimal strings as presentation values", () => {
     render(<ReportsPage />);
 
-    const rangeChips = screen.getAllByText(
-      /10\s+de\s+ene\s+de\s+2026\s+-\s+12\s+de\s+ene\s+de\s+2026/i,
-    );
-    expect(rangeChips.length).toBeGreaterThanOrEqual(5);
-
-    expect(screen.getByText("Composición por Categoría")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Economía" })).toBeTruthy();
+    expect(screen.getAllByText(/100\.000/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Comparación con período anterior/)).toBeTruthy();
     expect(screen.getByText("Productos Más Vendidos")).toBeTruthy();
     expect(screen.getByText("Top Clientes")).toBeTruthy();
     expect(screen.getByText("Métodos de Pago")).toBeTruthy();
-    expect(
-      screen.getAllByText(/10\s+de\s+ene\s+de\s+2026\s+-\s+12\s+de\s+ene\s+de\s+2026/i)
-        .length,
-    ).toBeGreaterThanOrEqual(6);
-    expect(screen.getByText(/vs\.?\s*07\s+de\s+ene\s+de\s+2026\s+-\s+09\s+de\s+ene\s+de\s+2026/i)).toBeTruthy();
+    expect(screen.queryByText("Rendimiento por vendedor")).toBeNull();
+    expect(screen.queryByText("Importar Inventario")).toBeNull();
   });
 
-  it("passes a selected user subset to the performance hook", async () => {
+  it("exposes the financial data-quality warning instead of estimating costs", () => {
     render(<ReportsPage />);
 
-    expect(useUserPerformanceMock).toHaveBeenCalledWith("", "", true, undefined);
+    expect(screen.getByRole("status")).toHaveTextContent(/1 registro/);
+    expect(screen.getByText(/registros con costo exacto/)).toBeTruthy();
+  });
 
-    await userEvent.click(screen.getByRole("button", { name: "Carlos Caja" }));
+  it("announces the economic loading state", () => {
+    useEconomicOverviewMock.mockReturnValueOnce({ data: undefined, isLoading: true, error: null });
+    render(<ReportsPage />);
+    expect(screen.getByText("Cargando economía...")).toBeTruthy();
+    expect(document.querySelector("[aria-busy='true']")).toBeTruthy();
+  });
 
-    expect(useUserPerformanceMock).toHaveBeenLastCalledWith(
-      "",
-      "",
-      true,
-      ["user-2"],
-    );
-    expect(screen.getByText("1 seleccionado")).toBeTruthy();
+  it("announces an economic request error", () => {
+    useEconomicOverviewMock.mockReturnValueOnce({ data: undefined, isLoading: false, error: new Error("network") });
+    render(<ReportsPage />);
+    expect(screen.getAllByRole("alert").length).toBeGreaterThan(0);
+  });
+
+  it("renders an intentional empty state when economics has no data", () => {
+    useEconomicOverviewMock.mockReturnValueOnce({ data: undefined, isLoading: false, error: null });
+    render(<ReportsPage />);
+    expect(screen.getByText("Sin datos de economía")).toBeTruthy();
   });
 });

--- a/frontend/src/app/reports/page.tsx
+++ b/frontend/src/app/reports/page.tsx
@@ -1,1039 +1,163 @@
-﻿"use client";
+"use client";
 
 import { useMemo, useState } from "react";
 import { DashboardLayout } from "@/components/layout/DashboardLayout";
 import {
-  useDashboard,
-  useSalesByPaymentMethod,
-  useSalesByCategory,
-  useTopSellingProducts,
+  useCashFlow,
   useCustomerStatistics,
-  useUserPerformance,
+  useEconomicOverview,
+  useInventorySnapshot,
+  useSalesByCategory,
+  useSalesByPaymentMethod,
+  useTopSellingProducts,
 } from "@/hooks/useReports";
-import { useUsers } from "@/hooks/useUsers";
 import { api, getApiErrorMessage } from "@/lib/api";
+import { adaptiveReportGranularity, formatReportMoney, safeDecimalNumber } from "@/lib/reportPresentation";
+import { formatCurrency, getBogotaDateInputValue, shiftDateInputValue } from "@/lib/utils";
+import { useToast } from "@/contexts/ToastContext";
 import { Button } from "@/components/ui/Button";
+import { LoadingState } from "@/components/ui/LoadingState";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Table, TableCell, TableHeader, TableRow } from "@/components/ui/Table";
 import {
-  DollarSign,
-  ShoppingCart,
-  Users,
-  Package,
-  TrendingUp,
-  Download,
+  ArrowDownRight,
+  ArrowUpRight,
   BarChart3,
   Calendar,
-  ArrowUpRight,
-  ArrowDownRight,
-  X,
-  Info,
+  CircleDollarSign,
+  Download,
+  Package,
+  Receipt,
+  TrendingUp,
+  Users,
 } from "lucide-react";
-import {
-  formatCurrency,
-  getBogotaDateInputValue,
-  shiftDateInputValue,
-} from "@/lib/utils";
-import { chipStyles } from "@/lib/chipStyles";
-import { useToast } from "@/contexts/ToastContext";
-import { ImportSection } from "@/components/reports/ImportSection";
-import { LoadingState } from "@/components/ui/LoadingState";
-import { Table, TableHeader, TableRow, TableCell } from "@/components/ui/Table";
-import type { AppliedRange } from "@/types";
+import type { AppliedRange, FinancialDelta, FinancialReport } from "@/types";
 
-type CategoryArcSegment = {
-  category: string;
-  total: number;
-  quantity: number;
-  color: string;
-  pct: number;
-  startAngle: number;
-  endAngle: number;
-  midAngle: number;
-};
-
-const DONUT_CENTER = 120;
-const DONUT_OUTER_RADIUS = 96;
-const DONUT_INNER_RADIUS = 58;
-
-function polarToCartesian(cx: number, cy: number, radius: number, angle: number) {
-  const radians = (angle * Math.PI) / 180;
-  return {
-    x: cx + radius * Math.cos(radians),
-    y: cy + radius * Math.sin(radians),
+function rangeLabel(range?: AppliedRange) {
+  if (!range?.startDate && !range?.endDate) return "Período completo";
+  const format = (value: string | null) => {
+    if (!value) return null;
+    const [year, month, day] = value.split("-").map(Number);
+    return new Intl.DateTimeFormat("es-CO", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+      timeZone: "America/Bogota",
+    }).format(new Date(Date.UTC(year, month - 1, day, 12)));
   };
+  const start = format(range.startDate);
+  const end = format(range.endDate);
+  return start && end ? `${start} - ${end}` : start ? `Desde ${start}` : `Hasta ${end}`;
 }
 
-function buildDonutPath(startAngle: number, endAngle: number) {
-  const sweep = Math.max(0, endAngle - startAngle);
-  const largeArcFlag = sweep > 180 ? 1 : 0;
-
-  const outerStart = polarToCartesian(
-    DONUT_CENTER,
-    DONUT_CENTER,
-    DONUT_OUTER_RADIUS,
-    startAngle,
-  );
-  const outerEnd = polarToCartesian(
-    DONUT_CENTER,
-    DONUT_CENTER,
-    DONUT_OUTER_RADIUS,
-    endAngle,
-  );
-  const innerEnd = polarToCartesian(
-    DONUT_CENTER,
-    DONUT_CENTER,
-    DONUT_INNER_RADIUS,
-    endAngle,
-  );
-  const innerStart = polarToCartesian(
-    DONUT_CENTER,
-    DONUT_CENTER,
-    DONUT_INNER_RADIUS,
-    startAngle,
-  );
-
-  return [
-    `M ${outerStart.x} ${outerStart.y}`,
-    `A ${DONUT_OUTER_RADIUS} ${DONUT_OUTER_RADIUS} 0 ${largeArcFlag} 1 ${outerEnd.x} ${outerEnd.y}`,
-    `L ${innerEnd.x} ${innerEnd.y}`,
-    `A ${DONUT_INNER_RADIUS} ${DONUT_INNER_RADIUS} 0 ${largeArcFlag} 0 ${innerStart.x} ${innerStart.y}`,
-    "Z",
-  ].join(" ");
+function ErrorState({ message }: { message: string }) {
+  return <p role="alert" className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-700 dark:text-rose-300">{message}</p>;
 }
 
-function formatRangeDateLabel(value: string | null) {
-  if (!value) {
-    return null;
-  }
-
-  const [year, month, day] = value.split("-").map(Number);
-  if (!year || !month || !day) {
-    return value;
-  }
-
-  return new Intl.DateTimeFormat("es-CO", {
-    day: "2-digit",
-    month: "short",
-    year: "numeric",
-    timeZone: "America/Bogota",
-  }).format(new Date(Date.UTC(year, month - 1, day, 12, 0, 0)));
+function SectionShell({ title, icon: Icon, children, tone = "primary" }: { title: string; icon: typeof BarChart3; children: React.ReactNode; tone?: "primary" | "accent" }) {
+  return (
+    <section className={`overflow-hidden rounded-3xl border ${tone === "primary" ? "border-primary/30 bg-primary/10" : "border-accent/30 bg-accent/10"}`}>
+      <div className={`flex items-center gap-2 border-b px-5 py-4 ${tone === "primary" ? "border-primary/20" : "border-accent/20"}`}>
+        <div className={`rounded-lg p-1.5 ${tone === "primary" ? "bg-primary/20 text-primary" : "bg-accent/20 text-accent"}`}><Icon className="h-4 w-4" aria-hidden="true" /></div>
+        <h2 className="text-sm font-semibold text-foreground">{title}</h2>
+      </div>
+      <div className="p-5">{children}</div>
+    </section>
+  );
 }
 
-function formatAppliedRangeLabel(appliedRange?: AppliedRange) {
-  if (!appliedRange) {
-    return "Período completo";
-  }
+function MetricCard({ label, value, helper, delta }: { label: string; value: string; helper: string; delta?: FinancialDelta }) {
+  const positive = (delta?.percentage ?? 0) >= 0;
+  return (
+    <div className="rounded-3xl border border-primary/30 bg-primary/10 p-5">
+      <p className="text-xs font-bold uppercase tracking-[0.16em] text-muted-foreground">{label}</p>
+      <p className="mt-3 text-2xl font-bold text-primary">{value}</p>
+      <div className="mt-4 flex items-center justify-between gap-2 text-xs">
+        {delta ? <span className={`inline-flex items-center gap-1 rounded-full px-2 py-1 font-semibold ${positive ? "bg-emerald-500/15 text-emerald-600" : "bg-rose-500/15 text-rose-600"}`}><span aria-hidden="true">{positive ? <ArrowUpRight className="h-3.5 w-3.5" /> : <ArrowDownRight className="h-3.5 w-3.5" />}</span>{delta.percentage === null ? "Sin base" : `${positive ? "+" : ""}${delta.percentage.toFixed(1)}%`}</span> : <span />}
+        <span className="text-right text-muted-foreground">{helper}</span>
+      </div>
+    </div>
+  );
+}
 
-  const startLabel = formatRangeDateLabel(appliedRange.startDate);
-  const endLabel = formatRangeDateLabel(appliedRange.endDate);
+function ComparisonChart({ current, previous, range }: { current: FinancialReport; previous: FinancialReport; range: AppliedRange }) {
+  const granularity = adaptiveReportGranularity(range.startDate, range.endDate);
+  const currentValue = safeDecimalNumber(current.netIncome);
+  const previousValue = safeDecimalNumber(previous.netIncome);
+  const scale = Math.max(Math.abs(currentValue), Math.abs(previousValue), 1);
+  return (
+    <div className="space-y-4" aria-label={`Comparación económica por ${granularity === "day" ? "día" : "mes"}`} role="img">
+      <div className="flex items-center justify-between gap-3"><div><p className="text-sm font-semibold text-foreground">Comparación con período anterior</p><p className="text-xs text-muted-foreground">Ingreso neto provisto por el contrato económico</p></div><span className="rounded-full border border-primary/30 bg-background/60 px-2.5 py-1 text-[11px] font-semibold text-primary">Granularidad: {granularity === "day" ? "día" : "mes"}</span></div>
+      {[{ label: "Actual", value: currentValue, color: "bg-primary" }, { label: "Anterior", value: previousValue, color: "bg-accent" }].map((item) => (
+        <div key={item.label} className="grid grid-cols-[70px_minmax(0,1fr)_auto] items-center gap-3 text-xs">
+          <span className="font-semibold text-muted-foreground">{item.label}</span>
+          <div className="h-3 overflow-hidden rounded-full bg-muted"><div className={`h-full rounded-full ${item.color}`} style={{ width: `${Math.max(2, (Math.abs(item.value) / scale) * 100)}%` }} /></div>
+          <span className="font-semibold text-foreground">{formatReportMoney(item.value)}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
 
-  if (startLabel && endLabel) {
-    return `${startLabel} - ${endLabel}`;
-  }
-  if (startLabel) {
-    return `Desde ${startLabel}`;
-  }
-  if (endLabel) {
-    return `Hasta ${endLabel}`;
-  }
-
-  return "Período completo";
+function OperationalEmpty({ label }: { label: string }) {
+  return <EmptyState icon={<BarChart3 className="h-6 w-6 text-muted-foreground/30" />} title={`Sin datos de ${label}`} subtitle="Prueba otro período o espera nuevas operaciones." className="min-h-[160px]" />;
 }
 
 export default function ReportsPage() {
   const toast = useToast();
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
-  const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
-  const [hoveredCategory, setHoveredCategory] =
-    useState<CategoryArcSegment | null>(null);
+  const [showExporting, setShowExporting] = useState(false);
 
-  const setToday = () => {
-    const today = getBogotaDateInputValue();
-    setStartDate(today);
-    setEndDate(today);
+  const economic = useEconomicOverview(startDate, endDate);
+  const cash = useCashFlow(startDate, endDate);
+  const inventory = useInventorySnapshot(startDate, endDate);
+  const paymentMethods = useSalesByPaymentMethod(startDate, endDate);
+  const categories = useSalesByCategory(startDate, endDate);
+  const topProducts = useTopSellingProducts(startDate, endDate, 5);
+  const customers = useCustomerStatistics(startDate, endDate);
+  const overview = economic.data;
+  const current = overview?.current;
+
+  const setToday = () => { const today = getBogotaDateInputValue(); setStartDate(today); setEndDate(today); };
+  const setLast30Days = () => { const today = getBogotaDateInputValue(); setStartDate(shiftDateInputValue(today, -29)); setEndDate(today); };
+  const handleEconomicExport = async () => {
+    setShowExporting(true);
+    try { await api.exportData("/exports/economic", { format: "excel", type: "economic", startDate, endDate }); toast.success("Exportación económica generada correctamente"); }
+    catch (error) { toast.error(getApiErrorMessage(error, "No se pudo generar la exportación")); }
+    finally { setShowExporting(false); }
   };
 
-  const setThisWeek = () => {
-    const today = getBogotaDateInputValue();
-    setStartDate(shiftDateInputValue(today, -6));
-    setEndDate(today);
-  };
-
-  const { data: dashboard } = useDashboard(startDate, endDate);
-  const { data: paymentMethodsResponse, isLoading: paymentLoading } =
-    useSalesByPaymentMethod(startDate, endDate);
-  const { data: salesByCategoryResponse, isLoading: categoryLoading } =
-    useSalesByCategory(startDate, endDate);
-  const { data: topProductsResponse, isLoading: topProductsLoading } =
-    useTopSellingProducts(startDate, endDate, 5);
-  const { data: customerStats, isLoading: customerLoading } =
-    useCustomerStatistics(startDate, endDate);
-  const { data: users = [], isLoading: usersLoading } = useUsers();
-  const {
-    data: userPerformanceResponse,
-    isLoading: userPerformanceLoading,
-    error: userPerformanceError,
-  } = useUserPerformance(
-    startDate,
-    endDate,
-    true,
-    selectedUserIds.length > 0 ? selectedUserIds : undefined,
-  );
-
-  const paymentMethods = useMemo(
-    () => paymentMethodsResponse?.data ?? [],
-    [paymentMethodsResponse?.data],
-  );
-  const salesByCategory = useMemo(
-    () => salesByCategoryResponse?.data ?? [],
-    [salesByCategoryResponse?.data],
-  );
-  const topProducts = useMemo(
-    () => topProductsResponse?.data ?? [],
-    [topProductsResponse?.data],
-  );
-
-  const handleExport = async (
-    type: "sales" | "products" | "customers" | "inventory",
-    format: "pdf" | "excel" | "csv",
-  ) => {
-    try {
-      await api.exportData(`/exports/${type}`, {
-        format,
-        type,
-        startDate,
-        endDate,
-      });
-      toast.success(
-        `Exportación ${format.toUpperCase()} generada correctamente`,
-      );
-    } catch (error) {
-      toast.error(getApiErrorMessage(error, "Error al exportar datos"));
-    }
-  };
-
-  const stats = dashboard || {
-    totalSales: 0,
-    totalRevenue: 0,
-    totalProducts: 0,
-    totalCustomers: 0,
-    lowStockProducts: 0,
-    trends: {
-      totalSales: 0,
-      totalRevenue: 0,
-      totalCustomers: 0,
-    },
-    recentSales: [],
-  };
-
-  const avgTicket =
-    stats.totalSales > 0 ? stats.totalRevenue / stats.totalSales : 0;
-
-  const dashboardRangeLabel = useMemo(
-    () => formatAppliedRangeLabel(dashboard?.appliedRange),
-    [dashboard?.appliedRange],
-  );
-  const paymentRangeLabel = useMemo(
-    () => formatAppliedRangeLabel(paymentMethodsResponse?.appliedRange),
-    [paymentMethodsResponse?.appliedRange],
-  );
-  const categoryRangeLabel = useMemo(
-    () => formatAppliedRangeLabel(salesByCategoryResponse?.appliedRange),
-    [salesByCategoryResponse?.appliedRange],
-  );
-  const topProductsRangeLabel = useMemo(
-    () => formatAppliedRangeLabel(topProductsResponse?.appliedRange),
-    [topProductsResponse?.appliedRange],
-  );
-  const customerRangeLabel = useMemo(
-    () => formatAppliedRangeLabel(customerStats?.appliedRange),
-    [customerStats?.appliedRange],
-  );
-  const userPerformance = useMemo(
-    () => userPerformanceResponse?.data ?? [],
-    [userPerformanceResponse?.data],
-  );
-  const userPerformanceRangeLabel = useMemo(
-    () => formatAppliedRangeLabel(userPerformanceResponse?.appliedRange),
-    [userPerformanceResponse?.appliedRange],
-  );
-  const userPerformanceComparisonRangeLabel = useMemo(
-    () => formatAppliedRangeLabel(userPerformanceResponse?.comparisonRange),
-    [userPerformanceResponse?.comparisonRange],
-  );
-  const selectableUsers = useMemo(
-    () => users.toSorted((a, b) => a.name.localeCompare(b.name, "es")),
-    [users],
-  );
-
-  const selectedUsersLabel = useMemo(() => {
-    if (selectedUserIds.length === 0) {
-      return "Todos los usuarios";
-    }
-
-    return `${selectedUserIds.length} seleccionado${selectedUserIds.length === 1 ? "" : "s"}`;
-  }, [selectedUserIds.length]);
-
-  const toggleSelectedUser = (userId: string) => {
-    setSelectedUserIds((current) =>
-      current.includes(userId)
-        ? current.filter((id) => id !== userId)
-        : [...current, userId],
-    );
-  };
-
-  const formatTrendLabel = (value: number | null | undefined) => {
-    const safeValue = value ?? 0;
-    const rounded = Math.abs(safeValue) < 0.05 ? 0 : safeValue;
-    const sign = rounded > 0 ? "+" : "";
-    return `${sign}${rounded.toFixed(1)}%`;
-  };
-
-  const statCards = [
-    {
-      label: "Ingresos netos",
-      value: formatCurrency(stats.totalRevenue),
-      helper: "vs. periodo anterior",
-      trend: stats.trends?.totalRevenue ?? 0,
-      icon: DollarSign,
-    },
-    {
-      label: "Pedidos",
-      value: stats.totalSales.toLocaleString("es-CO"),
-      helper: `ticket promedio ${formatCurrency(avgTicket)}`,
-      trend: stats.trends?.totalSales ?? 0,
-      icon: ShoppingCart,
-    },
-    {
-      label: "Clientes activos",
-      value: (customerStats?.activeCustomers ?? stats.totalCustomers).toLocaleString(
-        "es-CO",
-      ),
-      helper: `${customerStats?.totalCustomers ?? stats.totalCustomers} clientes registrados`,
-      trend: stats.trends?.totalCustomers ?? 0,
-      icon: Users,
-    },
-    {
-      label: "Rotación inventario",
-      value:
-        stats.totalProducts > 0
-          ? `${(
-              ((stats.totalProducts - stats.lowStockProducts) / stats.totalProducts) *
-              100
-            ).toFixed(1)}%`
-          : "0.0%",
-      helper: `${stats.lowStockProducts} con stock bajo`,
-      trend: stats.lowStockProducts > 0 ? -Math.min(100, stats.lowStockProducts * 2) : 0,
-      icon: Package,
-    },
-  ] as const;
-
-  const paymentMethodItems = useMemo(() => {
-    const map = {
-      CASH: { label: "Efectivo", dot: "#10b981" },
-      CARD: { label: "Tarjeta", dot: "#0ea5e9" },
-      TRANSFER: { label: "Transferencia", dot: "#f59e0b" },
-    } as const;
-
-    const totalCount = paymentMethods.reduce((sum, item) => sum + item.count, 0);
-    const totalAmount = paymentMethods.reduce((sum, item) => sum + item.total, 0);
-
-    return {
-      totalCount,
-      totalAmount,
-      avgTicket: totalCount > 0 ? totalAmount / totalCount : 0,
-      items: paymentMethods
-        .map((item) => ({
-          ...item,
-          label: map[item.paymentMethod as keyof typeof map]?.label ?? item.paymentMethod,
-          dot: map[item.paymentMethod as keyof typeof map]?.dot ?? "#64748b",
-          pct: totalCount > 0 ? (item.count / totalCount) * 100 : 0,
-        }))
-        .toSorted((a, b) => b.total - a.total),
-    };
-  }, [paymentMethods]);
-
-  const categoryChart = useMemo(() => {
-    const palette = ["#14b8a6", "#f97316", "#0ea5e9", "#84cc16", "#f43f5e", "#8b5cf6", "#f59e0b"];
-    const totalQuantity = salesByCategory.reduce((sum, item) => sum + item.quantity, 0);
-    const totalAmount = salesByCategory.reduce((sum, item) => sum + item.total, 0);
-
-    const baseSegments = salesByCategory
-      .map((item, index) => ({
-        ...item,
-        color: palette[index % palette.length],
-        pct: totalQuantity > 0 ? (item.quantity / totalQuantity) * 100 : 0,
-      }))
-      .toSorted((a, b) => b.quantity - a.quantity);
-
-    const segments = baseSegments.reduce<{
-      cursor: number;
-      segments: CategoryArcSegment[];
-    }>(
-      (acc, segment) => {
-        const rawSweep = (segment.pct / 100) * 360;
-        const gap = rawSweep > 6 ? 1.4 : 0;
-        const startAngle = acc.cursor + gap / 2;
-        const endAngle = acc.cursor + rawSweep - gap / 2;
-        const midAngle = (startAngle + endAngle) / 2;
-
-        return {
-          cursor: acc.cursor + rawSweep,
-          segments: [
-            ...acc.segments,
-            {
-              ...segment,
-              startAngle,
-              endAngle: Math.max(endAngle, startAngle),
-              midAngle,
-            },
-          ],
-        };
-      },
-      {
-        cursor: -90,
-        segments: [],
-      },
-    ).segments;
-
-    return {
-      segments,
-      totalQuantity,
-      totalAmount,
-    };
-  }, [salesByCategory]);
-
-  const getClientSegment = (salesCount: number) => {
-    if (salesCount >= 12) return "VIP";
-    if (salesCount >= 6) return "Frecuente";
-    if (salesCount >= 3) return "Recurrente";
-    return "Potencial";
-  };
-
-  // LoadingSpinner hoisted to module level as <LoadingState icon={<BarChart3 className="w-4 h-4 text-primary/50" />} message="Cargando..." />
+  const operationalPaymentMethods = useMemo(() => paymentMethods.data?.data ?? [], [paymentMethods.data?.data]);
+  const operationalCategories = useMemo(() => categories.data?.data ?? [], [categories.data?.data]);
+  const operationalProducts = useMemo(() => topProducts.data?.data ?? [], [topProducts.data?.data]);
+  const operationalCustomers = customers.data?.topCustomers ?? [];
 
   return (
     <DashboardLayout>
       <div className="space-y-5 lg:space-y-7">
-        {/* Page Header */}
-        <div className="animate-fade-in-up">
-          <div className="flex items-center gap-3 mb-1">
-            <div className="w-1 h-7 rounded-full bg-primary shrink-0" />
-            <h1 className="text-2xl lg:text-3xl font-bold text-foreground">
-              Reportes
-            </h1>
-          </div>
-          <p className="text-sm text-muted-foreground ml-4">
-            Analiza el rendimiento de tu negocio
-          </p>
-        </div>
+        <header>
+          <div className="flex items-center gap-3"><div className="h-7 w-1 rounded-full bg-primary" /><h1 className="text-2xl font-bold text-foreground lg:text-3xl">Reportes</h1></div>
+          <p className="ml-4 mt-1 text-sm text-muted-foreground">Economía primero, operación después</p>
+        </header>
 
-        {/* Date Filter */}
-        <div className="rounded-3xl border border-primary/30 bg-primary/10 overflow-hidden">
-          {/* Quick selects */}
-          <div className="flex items-center gap-2 px-4 py-2.5 border-b border-primary/20 bg-primary/5">
-            <Calendar className="w-3.5 h-3.5 text-primary shrink-0" />
-            <span className="text-xs font-bold uppercase tracking-[0.2em] text-muted-foreground mr-0.5">
-              Período
-            </span>
-            <button
-              onClick={setToday}
-              className="h-7 px-3 rounded-full text-xs font-semibold bg-background/60 border border-primary/30 text-muted-foreground hover:text-primary hover:bg-primary/15 transition-all"
-            >
-              Hoy
-            </button>
-            <button
-              onClick={setThisWeek}
-              className="h-7 px-3 rounded-full text-xs font-semibold bg-background/60 border border-primary/30 text-muted-foreground hover:text-primary hover:bg-primary/15 transition-all whitespace-nowrap"
-            >
-              Esta semana
-            </button>
-            {(startDate || endDate) && (
-              <button
-                onClick={() => {
-                  setStartDate("");
-                  setEndDate("");
-                }}
-                className="ml-auto flex items-center gap-1.5 h-7 px-2.5 rounded-full text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-background/80 border border-primary/20 transition-colors"
-              >
-                <X className="w-3 h-3" /> Limpiar
-              </button>
-            )}
-            <span className="rounded-full border border-primary/30 bg-background/60 px-2.5 py-1 text-[11px] font-semibold text-primary">
-              {dashboardRangeLabel}
-            </span>
-          </div>
-          {/* Custom date range */}
-          <div className="flex items-center gap-2 px-4 py-3 flex-wrap sm:flex-nowrap">
-            <span className="text-xs font-semibold text-muted-foreground whitespace-nowrap">
-              Desde
-            </span>
-            <input
-              type="date"
-              value={startDate}
-              onChange={(e) => setStartDate(e.target.value)}
-              className="flex-1 min-w-[130px] h-9 px-3 rounded-xl border border-primary/20 bg-background/60 text-foreground text-sm focus:outline-none focus:ring-1 focus:ring-primary/40 focus:border-primary/40 transition-colors cursor-pointer"
-            />
-            <span className="text-muted-foreground/40 font-mono hidden sm:block">
-              →
-            </span>
-            <span className="text-xs font-semibold text-muted-foreground whitespace-nowrap">
-              Hasta
-            </span>
-            <input
-              type="date"
-              value={endDate}
-              onChange={(e) => setEndDate(e.target.value)}
-              className="flex-1 min-w-[130px] h-9 px-3 rounded-xl border border-primary/20 bg-background/60 text-foreground text-sm focus:outline-none focus:ring-1 focus:ring-primary/40 focus:border-primary/40 transition-colors cursor-pointer"
-            />
-            {startDate && endDate && (
-              <div className="shrink-0 h-9 flex items-center px-3 rounded-xl bg-primary/15 border border-primary/30">
-                <span className="text-xs font-bold text-primary font-mono">
-                  {Math.max(
-                    1,
-                    Math.round(
-                      (new Date(endDate).getTime() -
-                        new Date(startDate).getTime()) /
-                        (1000 * 60 * 60 * 24) +
-                        1,
-                    ),
-                  )}
-                  d
-                </span>
-              </div>
-            )}
-          </div>
-        </div>
+        <section className="overflow-hidden rounded-3xl border border-primary/30 bg-primary/10" aria-label="Filtros de período">
+          <div className="flex flex-wrap items-center gap-2 border-b border-primary/20 bg-primary/5 px-4 py-3"><Calendar className="h-4 w-4 text-primary" aria-hidden="true" /><span className="text-xs font-bold uppercase tracking-[0.16em] text-muted-foreground">Período</span><Button variant="secondary" size="sm" onClick={setToday}>Hoy</Button><Button variant="secondary" size="sm" onClick={setLast30Days}>Últimos 30 días</Button>{(startDate || endDate) && <Button variant="ghost" size="sm" onClick={() => { setStartDate(""); setEndDate(""); }}>Limpiar</Button>}</div>
+          <div className="flex flex-wrap items-center gap-3 px-4 py-3"><label className="text-xs font-semibold text-muted-foreground" htmlFor="reports-start">Desde</label><input id="reports-start" type="date" value={startDate} onChange={(event) => setStartDate(event.target.value)} className="h-9 rounded-xl border border-primary/20 bg-background/60 px-3 text-sm" /><label className="text-xs font-semibold text-muted-foreground" htmlFor="reports-end">Hasta</label><input id="reports-end" type="date" value={endDate} onChange={(event) => setEndDate(event.target.value)} className="h-9 rounded-xl border border-primary/20 bg-background/60 px-3 text-sm" /><span className="rounded-full border border-primary/30 bg-background/60 px-2.5 py-1 text-[11px] font-semibold text-primary">{rangeLabel(economic.data?.appliedRange)}</span></div>
+        </section>
 
-        {/* Stat Cards */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 stagger-children">
-          {statCards.map((card, index) => {
-            const Icon = card.icon;
-            const isPrimary = index % 2 === 0;
-            const trendUp = card.trend >= 0;
-            return (
-              <div
-                key={card.label}
-                className={`relative overflow-hidden rounded-3xl border p-5 transition-all duration-200 ${
-                  isPrimary
-                    ? "border-primary/30 bg-primary/10 hover:border-primary/50"
-                    : "border-accent/30 bg-accent/10 hover:border-accent/50"
-                }`}
-              >
-                <div className="flex items-start justify-between gap-4 mb-4">
-                  <div className="min-w-0">
-                    <p className="text-xs font-bold text-muted-foreground uppercase tracking-[0.2em] truncate">
-                      {card.label}
-                    </p>
-                    <p
-                      className={`stat-number mt-2 text-2xl lg:text-3xl font-bold leading-none ${
-                        isPrimary ? "text-primary" : "text-accent"
-                      }`}
-                    >
-                      {card.value}
-                    </p>
-                  </div>
-                  <div
-                    className={`w-10 h-10 rounded-xl flex items-center justify-center shrink-0 ${
-                      isPrimary ? "bg-primary/20 text-primary" : "bg-accent/20 text-accent"
-                    }`}
-                  >
-                    <Icon className="w-5 h-5" />
-                  </div>
-                </div>
+        <SectionShell title="Economía" icon={CircleDollarSign}>
+          {economic.isLoading ? <div aria-busy="true"><LoadingState icon={<CircleDollarSign className="h-4 w-4 text-primary/50" />} message="Cargando economía..." /></div> : economic.error ? <ErrorState message={getApiErrorMessage(economic.error, "No se pudo cargar el resumen económico")} /> : !current ? <OperationalEmpty label="economía" /> : <>
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4"><MetricCard label="Ingreso neto" value={formatReportMoney(current.netIncome)} helper="Ventas completadas menos descuentos, sin impuestos" delta={overview!.deltas.netIncome} /><MetricCard label="Utilidad bruta" value={formatReportMoney(current.grossProfit)} helper={`${current.grossMarginPercentage?.toFixed(1) ?? "-"}% de margen`} delta={overview!.deltas.grossProfit} /><MetricCard label="Utilidad neta" value={formatReportMoney(current.netProfit)} helper={`${current.netMarginPercentage?.toFixed(1) ?? "-"}% de margen`} delta={overview!.deltas.netProfit} /><MetricCard label="Gastos operativos" value={formatReportMoney(current.operatingExpenses)} helper="Compras excluidas del gasto operativo" delta={overview!.deltas.operatingExpenses} /></div>
+            <div className="mt-5 grid gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)]"><div className="rounded-2xl border border-primary/20 bg-background/40 p-4"><ComparisonChart current={current} previous={overview!.previous} range={overview!.appliedRange} /></div><div className="rounded-2xl border border-amber-500/30 bg-amber-500/10 p-4"><p className="text-sm font-semibold text-foreground">Calidad de datos</p><p className="mt-1 text-xs text-muted-foreground">Sólo los ítems con costo histórico respaldado participan en COGS y margen exactos.</p><p className="mt-4 text-lg font-bold text-foreground">{current.dataQuality.snapshotBackedItems} registros con costo exacto</p><p role="status" className="mt-1 text-xs text-amber-700 dark:text-amber-300">{current.dataQuality.excludedItems} registro{current.dataQuality.excludedItems === 1 ? "" : "s"} excluido{current.dataQuality.excludedItems === 1 ? "" : "s"}; no se estimó su costo actual.</p></div></div>
+          </>}
+        </SectionShell>
 
-                <div className="flex items-center justify-between gap-2">
-                  <span
-                    className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-bold ${
-                      trendUp
-                        ? "bg-accent/20 text-accent"
-                        : "bg-rose-500/20 text-rose-500"
-                    }`}
-                  >
-                    {trendUp ? (
-                      <ArrowUpRight className="w-3.5 h-3.5" />
-                    ) : (
-                      <ArrowDownRight className="w-3.5 h-3.5" />
-                    )}
-                    {formatTrendLabel(card.trend)}
-                  </span>
-                  <span
-                    className={`text-[11px] text-right ${
-                      isPrimary ? "text-primary/70" : "text-accent/70"
-                    }`}
-                  >
-                    {card.helper}
-                  </span>
-                </div>
-              </div>
-            );
-          })}
-        </div>
+        <div className="grid gap-5 xl:grid-cols-2"><SectionShell title="Caja y pagos" icon={Receipt} tone="accent">{cash.isLoading ? <div aria-busy="true"><LoadingState icon={<Receipt className="h-4 w-4 text-primary/50" />} message="Cargando caja..." /></div> : cash.error ? <ErrorState message={getApiErrorMessage(cash.error, "No se pudo cargar caja")} /> : cash.data ? <div className="grid gap-3 sm:grid-cols-2"><div className="rounded-2xl border border-accent/20 bg-background/40 p-4"><p className="text-xs text-muted-foreground">Cobros por fecha de pago</p><p className="mt-2 text-xl font-bold text-accent">{formatReportMoney(cash.data.collections.total)}</p></div><div className="rounded-2xl border border-accent/20 bg-background/40 p-4"><p className="text-xs text-muted-foreground">Pagos de gastos</p><p className="mt-2 text-xl font-bold text-accent">{formatReportMoney(cash.data.expensePayments.total)}</p></div></div> : <OperationalEmpty label="caja" />}</SectionShell><SectionShell title="Inventario actual" icon={Package}>{inventory.isLoading ? <div aria-busy="true"><LoadingState icon={<Package className="h-4 w-4 text-primary/50" />} message="Cargando inventario..." /></div> : inventory.error ? <ErrorState message={getApiErrorMessage(inventory.error, "No se pudo cargar inventario")} /> : inventory.data ? <div className="grid gap-3 sm:grid-cols-2"><div><p className="text-xs text-muted-foreground">Valor a costo actual</p><p className="mt-1 font-bold text-foreground">{formatReportMoney(inventory.data.current.stockValue)}</p></div><div><p className="text-xs text-muted-foreground">Valor de venta actual</p><p className="mt-1 font-bold text-foreground">{formatReportMoney(inventory.data.current.retailValue)}</p></div><div><p className="text-xs text-muted-foreground">Utilidad potencial</p><p className="mt-1 font-bold text-primary">{formatReportMoney(inventory.data.current.potentialProfit)}</p></div><div><p className="text-xs text-muted-foreground">Unidades en stock</p><p className="mt-1 font-bold text-foreground">{inventory.data.current.stockQuantity.toLocaleString("es-CO")}</p></div></div> : <OperationalEmpty label="inventario" />}</SectionShell></div>
 
-        <div className="overflow-hidden rounded-3xl border border-primary/30 bg-primary/10">
-          <div className="border-b border-primary/20 px-5 py-4">
-            <div className="flex flex-wrap items-center gap-2">
-              <div className="p-1.5 bg-primary/20 rounded-lg">
-                <Users className="h-4 w-4 text-primary" />
-              </div>
-              <h3 className="text-sm font-semibold text-foreground">Rendimiento por vendedor</h3>
-              <span className="ml-auto rounded-full border border-primary/30 bg-background/60 px-2 py-0.5 text-[10px] font-semibold text-primary">
-                {userPerformanceRangeLabel}
-              </span>
-            </div>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Comparación de KPIs por usuario usando el mismo rango de fechas.
-              {userPerformanceComparisonRangeLabel
-                ? ` vs. ${userPerformanceComparisonRangeLabel}`
-                : ""}
-            </p>
-          </div>
+        <div><p className="mb-3 text-xs font-bold uppercase tracking-[0.2em] text-muted-foreground">Análisis operativo</p><div className="grid gap-5 xl:grid-cols-2"><SectionShell title="Productos Más Vendidos" icon={TrendingUp}>{topProducts.isLoading ? <div aria-busy="true"><LoadingState icon={<TrendingUp className="h-4 w-4 text-primary/50" />} message="Cargando productos..." /></div> : topProducts.error ? <ErrorState message={getApiErrorMessage(topProducts.error, "No se pudieron cargar productos")} /> : operationalProducts.length === 0 ? <OperationalEmpty label="productos" /> : <div className="space-y-2">{operationalProducts.map((product, index) => <div key={product.productId} className="flex items-center justify-between gap-3 rounded-2xl border border-primary/20 bg-background/40 p-3"><div className="flex min-w-0 items-center gap-3"><span className="font-bold text-primary">#{index + 1}</span><span className="truncate text-sm font-semibold text-foreground">{product.productName}</span></div><span className="shrink-0 text-xs text-muted-foreground">{product.quantity} vendidos</span></div>)}</div>}</SectionShell><SectionShell title="Categorías" icon={BarChart3} tone="accent">{categories.isLoading ? <div aria-busy="true"><LoadingState icon={<BarChart3 className="h-4 w-4 text-primary/50" />} message="Cargando categorías..." /></div> : categories.error ? <ErrorState message={getApiErrorMessage(categories.error, "No se pudieron cargar categorías")} /> : operationalCategories.length === 0 ? <OperationalEmpty label="categorías" /> : <div className="space-y-3">{operationalCategories.map((category) => <div key={category.category} className="flex items-center justify-between gap-3"><span className="text-sm text-foreground">{category.category}</span><span className="text-sm font-semibold text-accent">{category.quantity} unidades</span></div>)}</div>}</SectionShell><SectionShell title="Top Clientes" icon={Users} tone="accent">{customers.isLoading ? <div aria-busy="true"><LoadingState icon={<Users className="h-4 w-4 text-primary/50" />} message="Cargando clientes..." /></div> : customers.error ? <ErrorState message={getApiErrorMessage(customers.error, "No se pudieron cargar clientes")} /> : operationalCustomers.length === 0 ? <OperationalEmpty label="clientes" /> : <Table variant="primary"><TableHeader><TableRow><TableCell as="th">Cliente</TableCell><TableCell as="th" className="text-right">Compras</TableCell><TableCell as="th" className="text-right">Total</TableCell></TableRow></TableHeader><tbody>{operationalCustomers.map((customer) => <TableRow key={customer.customerId}><TableCell>{customer.customerName}</TableCell><TableCell className="text-right">{customer.totalSales}</TableCell><TableCell className="text-right">{formatCurrency(customer.totalRevenue)}</TableCell></TableRow>)}</tbody></Table>}</SectionShell><SectionShell title="Métodos de Pago" icon={Receipt}>{paymentMethods.isLoading ? <div aria-busy="true"><LoadingState icon={<Receipt className="h-4 w-4 text-primary/50" />} message="Cargando pagos..." /></div> : paymentMethods.error ? <ErrorState message={getApiErrorMessage(paymentMethods.error, "No se pudieron cargar pagos")} /> : operationalPaymentMethods.length === 0 ? <OperationalEmpty label="métodos de pago" /> : <div className="space-y-3">{operationalPaymentMethods.map((method) => <div key={method.paymentMethod} className="flex items-center justify-between"><span className="text-sm text-foreground">{method.paymentMethod}</span><span className="text-sm font-semibold text-primary">{formatCurrency(method.total)}</span></div>)}</div>}</SectionShell></div></div>
 
-          <div className="border-b border-primary/20 bg-primary/5 px-5 py-3">
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="text-[11px] font-bold uppercase tracking-[0.2em] text-muted-foreground">
-                Subconjunto
-              </span>
-              <button
-                type="button"
-                onClick={() => setSelectedUserIds([])}
-                className={`rounded-full border px-3 py-1 text-[11px] font-semibold transition ${
-                  selectedUserIds.length === 0
-                    ? "border-primary/40 bg-primary/20 text-primary"
-                    : "border-primary/20 bg-background/60 text-muted-foreground hover:border-primary/40 hover:text-primary"
-                }`}
-              >
-                Todos
-              </button>
-              {usersLoading ? (
-                <span className="text-[11px] text-muted-foreground">Cargando usuarios...</span>
-              ) : (
-                selectableUsers.map((user) => {
-                  const selected = selectedUserIds.includes(user.id);
-
-                  return (
-                    <button
-                      key={user.id}
-                      type="button"
-                      onClick={() => toggleSelectedUser(user.id)}
-                      className={`rounded-full border px-3 py-1 text-[11px] font-semibold transition ${
-                        selected
-                          ? "border-primary/40 bg-primary/20 text-primary"
-                          : "border-primary/20 bg-background/60 text-muted-foreground hover:border-primary/40 hover:text-primary"
-                      }`}
-                      aria-pressed={selected}
-                    >
-                      {user.name}
-                    </button>
-                  );
-                })
-              )}
-              <span className="ml-auto rounded-full border border-primary/30 bg-background/60 px-2.5 py-1 text-[10px] font-semibold text-primary">
-                {selectedUsersLabel}
-              </span>
-            </div>
-          </div>
-
-          <div className="border-b border-primary/20 bg-primary/5 px-5 py-3">
-            <div className="flex items-start gap-2">
-              <Info className="mt-0.5 h-3.5 w-3.5 text-primary" />
-              <p className="text-[11px] text-muted-foreground">
-                KPI: <strong>Ventas</strong> = cantidad de ventas completadas, <strong>Ingresos</strong> = suma total vendida, <strong>Ticket</strong> = ingresos/ventas, <strong>Clientes</strong> = clientes unicos atendidos.
-              </p>
-            </div>
-          </div>
-
-          <div className="p-5">
-            {userPerformanceLoading ? (
-              <LoadingState icon={<BarChart3 className="w-4 h-4 text-primary/50" />} message="Cargando..." />
-            ) : userPerformanceError ? (
-              <p className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
-                {getApiErrorMessage(userPerformanceError, "No se pudo cargar la comparación de vendedores")}
-              </p>
-            ) : userPerformance.length === 0 ? (
-              <p className="py-6 text-center text-sm text-muted-foreground">Sin datos para este período.</p>
-            ) : (
-              <div className="overflow-x-auto rounded-2xl border border-primary/20 bg-background/40">
-                <Table variant="primary" className="min-w-[700px]">
-                  <TableHeader>
-                    <TableRow>
-                      <TableCell as="th" className="px-4 py-2 text-left text-[11px] font-bold uppercase tracking-[0.15em] text-muted-foreground">Usuario</TableCell>
-                      <TableCell as="th" className="px-4 py-2 text-right text-[11px] font-bold uppercase tracking-[0.15em] text-muted-foreground">Ventas</TableCell>
-                      <TableCell as="th" className="px-4 py-2 text-right text-[11px] font-bold uppercase tracking-[0.15em] text-muted-foreground">Ingresos</TableCell>
-                      <TableCell as="th" className="px-4 py-2 text-right text-[11px] font-bold uppercase tracking-[0.15em] text-muted-foreground">Ticket</TableCell>
-                      <TableCell as="th" className="px-4 py-2 text-right text-[11px] font-bold uppercase tracking-[0.15em] text-muted-foreground">Clientes</TableCell>
-                      <TableCell as="th" className="px-4 py-2 text-right text-[11px] font-bold uppercase tracking-[0.15em] text-muted-foreground">Comparación</TableCell>
-                    </TableRow>
-                  </TableHeader>
-                  <tbody>
-                    {userPerformance.map((row) => (
-                      <TableRow key={row.userId}>
-                        <TableCell className="px-4 py-3">
-                          <p className="text-sm font-semibold text-foreground">{row.userName}</p>
-                          <p className="text-xs text-muted-foreground">{row.role}</p>
-                        </TableCell>
-                        <TableCell className="px-4 py-3 text-right text-sm text-foreground">{row.salesCount.toLocaleString("es-CO")}</TableCell>
-                        <TableCell className="px-4 py-3 text-right text-sm font-bold text-primary">{formatCurrency(row.revenue)}</TableCell>
-                        <TableCell className="px-4 py-3 text-right text-sm text-muted-foreground">{formatCurrency(row.avgTicket)}</TableCell>
-                        <TableCell className="px-4 py-3 text-right text-sm text-muted-foreground">{row.uniqueCustomers.toLocaleString("es-CO")}</TableCell>
-                        <TableCell className="px-4 py-3 text-right text-xs text-muted-foreground">
-                          {row.comparison
-                            ? `${formatTrendLabel(row.comparison.revenuePct)} ingresos / ${formatTrendLabel(row.comparison.salesPct)} ventas`
-                            : "Sin comparación"}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </tbody>
-                </Table>
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* Main Analytics */}
-        <div className="grid grid-cols-1 gap-4 lg:gap-5 xl:grid-cols-2">
-          {/* Category Distribution */}
-          <div className="rounded-3xl border border-accent/30 bg-accent/10 overflow-hidden">
-            <div className="px-5 py-4 border-b border-accent/20">
-              <h3 className="text-sm font-semibold text-foreground">
-                Composición por Categoría
-              </h3>
-              <div className="mt-0.5 flex items-center gap-2">
-                <p className="text-xs text-muted-foreground">
-                  Participación por cantidad y aporte en ingresos
-                </p>
-                <span className="rounded-full border border-accent/30 bg-background/60 px-2 py-0.5 text-[10px] font-semibold text-accent">
-                  {categoryRangeLabel}
-                </span>
-              </div>
-            </div>
-            <div className="p-5">
-              {categoryLoading ? <LoadingState icon={<BarChart3 className="w-4 h-4 text-primary/50" />} message="Cargando..." /> : categoryChart.segments.length > 0 ? (
-                <div className="grid gap-5 md:grid-cols-[250px_minmax(0,1fr)] md:items-center">
-                  <div className="flex justify-center">
-                    <div className="relative w-[240px] h-[240px]">
-                      <svg viewBox="0 0 240 240" className="w-full h-full">
-                        <circle
-                          cx={DONUT_CENTER}
-                          cy={DONUT_CENTER}
-                          r={DONUT_OUTER_RADIUS}
-                          fill="none"
-                          stroke="rgba(148,163,184,0.20)"
-                          strokeWidth={1}
-                        />
-                        {categoryChart.segments.map((segment) => (
-                          <path
-                            key={segment.category}
-                            d={buildDonutPath(segment.startAngle, segment.endAngle)}
-                            fill={segment.color}
-                            opacity={hoveredCategory && hoveredCategory.category !== segment.category ? 0.45 : 1}
-                            className="transition-opacity duration-150 cursor-pointer"
-                            onMouseEnter={() => setHoveredCategory(segment)}
-                            onMouseLeave={() => setHoveredCategory(null)}
-                          />
-                        ))}
-                        <circle
-                          cx={DONUT_CENTER}
-                          cy={DONUT_CENTER}
-                          r={DONUT_INNER_RADIUS}
-                          fill="var(--card)"
-                          stroke="var(--border)"
-                        />
-                      </svg>
-
-                      <div className="absolute inset-0 flex flex-col items-center justify-center text-center pointer-events-none">
-                        <span className="text-[11px] uppercase tracking-wide text-muted-foreground">Items</span>
-                        <span className="stat-number text-xl font-bold text-foreground mt-0.5">
-                          {categoryChart.totalQuantity.toLocaleString("es-CO")}
-                        </span>
-                        <span className="text-[11px] text-muted-foreground mt-0.5">vendidos</span>
-                      </div>
-
-                      {hoveredCategory && (
-                        <div className="absolute left-1/2 -translate-x-1/2 -bottom-4 z-10 rounded-xl border border-accent/30 bg-card px-3 py-2 shadow-lg">
-                          <p className="text-xs font-semibold text-foreground">
-                            {hoveredCategory.category}
-                          </p>
-                          <div className="mt-1 flex items-center justify-between gap-5 text-[11px] text-muted-foreground">
-                            <span>{hoveredCategory.pct.toFixed(1)}%</span>
-                            <span>{hoveredCategory.quantity} prod.</span>
-                            <span className="font-semibold text-accent">
-                              {formatCurrency(hoveredCategory.total)}
-                            </span>
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  </div>
-
-                  <div className="space-y-2.5">
-                    <div className="max-h-[352px] overflow-y-auto pr-1 space-y-3 scrollbar-app">
-                      {categoryChart.segments.map((item) => (
-                        <div key={item.category} className="rounded-2xl border border-accent/20 bg-background/40 p-3">
-                          <div className="flex items-center justify-between gap-3">
-                            <div className="flex items-center gap-2 min-w-0">
-                              <span className="h-2.5 w-2.5 rounded-full shrink-0" style={{ backgroundColor: item.color }} />
-                              <span className="text-sm font-medium text-foreground truncate">{item.category}</span>
-                            </div>
-                            <span className="text-xs font-semibold text-muted-foreground">{item.pct.toFixed(1)}%</span>
-                          </div>
-                          <div className="mt-2 h-1.5 rounded-full bg-accent/10 overflow-hidden">
-                            <div className="h-full rounded-full" style={{ width: `${item.pct}%`, backgroundColor: item.color }} />
-                          </div>
-                          <div className="mt-2 flex items-center justify-between text-[11px] text-muted-foreground">
-                            <span>{item.quantity} productos</span>
-                            <span className="stat-number font-bold text-foreground">{formatCurrency(item.total)}</span>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              ) : (
-                <div className="text-center py-8">
-                  <p className="text-sm text-muted-foreground">Sin datos para este período</p>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* Top Products */}
-          <div className="rounded-3xl border border-primary/30 bg-primary/10 overflow-hidden">
-            <div className="px-5 py-4 border-b border-primary/20 flex items-center gap-2">
-              <div className="p-1.5 bg-primary/20 rounded-lg">
-                <TrendingUp className="w-4 h-4 text-primary" />
-              </div>
-              <h3 className="text-sm font-semibold text-foreground">
-                Productos Más Vendidos
-              </h3>
-              <span className="ml-auto rounded-full border border-primary/30 bg-background/60 px-2 py-0.5 text-[10px] font-semibold text-primary">
-                {topProductsRangeLabel}
-              </span>
-            </div>
-            <div className="p-5">
-              {topProductsLoading ? <LoadingState icon={<BarChart3 className="w-4 h-4 text-primary/50" />} message="Cargando..." /> : topProducts.length > 0 ? (
-                <div className="space-y-3">
-                  {topProducts.map((product, index) => (
-                    <div
-                      key={product.productId}
-                      className="flex flex-col gap-3 p-3.5 rounded-2xl bg-background/40 border border-primary/20 hover:bg-primary/5 transition-colors md:flex-row md:items-center md:justify-between"
-                    >
-                      <div className="flex items-start gap-3 min-w-0">
-                        <div className="w-9 h-9 rounded-xl bg-primary/20 flex items-center justify-center shrink-0">
-                          <span className="text-xs font-bold text-primary">#{index + 1}</span>
-                        </div>
-                        <div className="min-w-0">
-                          <p className="text-sm font-semibold text-foreground truncate">
-                            {product.productName}
-                          </p>
-                          <div className="mt-1 flex items-center flex-wrap gap-2 text-xs text-muted-foreground">
-                            <span>{product.quantity} vendidos</span>
-                            <span
-                              className={`inline-flex items-center rounded-full px-2 py-0.5 font-semibold ${
-                                product.stock <= 10
-                                  ? chipStyles.danger
-                                  : chipStyles.success
-                              }`}
-                            >
-                              stock {product.stock}
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                      <div className="text-left md:text-right shrink-0">
-                        <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Total Vendido</p>
-                        <p className="stat-number text-sm font-bold text-accent shrink-0">
-                          {formatCurrency(product.total)}
-                        </p>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="text-center py-8">
-                  <p className="text-sm text-muted-foreground">
-                    Sin datos para este período
-                  </p>
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-
-        {/* Secondary Analytics */}
-        <div className="grid grid-cols-1 gap-5 xl:grid-cols-[minmax(0,1.15fr)_360px]">
-          {/* Top Customers */}
-          <div className="rounded-3xl border border-accent/30 bg-accent/10 overflow-hidden">
-            <div className="px-5 py-4 border-b border-accent/20 flex items-center gap-2">
-              <div className="p-1.5 bg-accent/20 rounded-lg">
-                <Users className="w-4 h-4 text-accent" />
-              </div>
-              <h3 className="text-sm font-semibold text-foreground">
-                Top Clientes
-              </h3>
-              <span className="ml-auto rounded-full border border-accent/30 bg-background/60 px-2 py-0.5 text-[10px] font-semibold text-accent">
-                {customerRangeLabel}
-              </span>
-            </div>
-            <div className="p-5">
-              {customerLoading ? <LoadingState icon={<BarChart3 className="w-4 h-4 text-primary/50" />} message="Cargando..." /> : customerStats?.topCustomers &&
-                customerStats.topCustomers.length > 0 ? (
-                <div className="space-y-3">
-                  {customerStats.topCustomers.map((customer, index) => (
-                    <div
-                      key={customer.customerId}
-                      className="flex flex-col gap-3 p-3.5 rounded-2xl bg-background/40 border border-accent/20 hover:bg-accent/5 transition-colors md:flex-row md:items-center md:justify-between"
-                    >
-                      <div className="flex items-center gap-3 min-w-0">
-                        <div className="w-9 h-9 rounded-xl bg-accent/20 flex items-center justify-center shrink-0">
-                          <span className="text-xs font-bold text-accent">#{index + 1}</span>
-                        </div>
-                        <div className="min-w-0">
-                          <p className="text-sm font-semibold text-foreground truncate">
-                            {customer.customerName}
-                          </p>
-                          <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
-                            <span>{customer.totalSales} compras</span>
-                            <span className="text-muted-foreground/40">-</span>
-                            <span className="font-semibold text-muted-foreground">
-                              {getClientSegment(customer.totalSales)}
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                      <div className="text-left md:text-right">
-                        <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Total comprado</p>
-                        <span className="stat-number text-sm font-bold text-primary shrink-0">
-                          {formatCurrency(customer.totalRevenue)}
-                        </span>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="text-center py-8">
-                  <p className="text-sm text-muted-foreground">
-                    Sin datos para este período
-                  </p>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* Payment Methods Summary */}
-          <div className="rounded-3xl border border-primary/30 bg-primary/10 overflow-hidden">
-            <div className="px-5 py-4 border-b border-primary/20">
-              <h3 className="text-sm font-semibold text-foreground">Métodos de Pago</h3>
-              <div className="mt-0.5 flex items-center gap-2">
-                <p className="text-xs text-muted-foreground">Resumen compacto del período</p>
-                <span className="rounded-full border border-primary/30 bg-background/60 px-2 py-0.5 text-[10px] font-semibold text-primary">
-                  {paymentRangeLabel}
-                </span>
-              </div>
-            </div>
-            <div className="p-5">
-              {paymentLoading ? <LoadingState icon={<BarChart3 className="w-4 h-4 text-primary/50" />} message="Cargando..." /> : paymentMethodItems.items.length > 0 ? (
-                <div className="space-y-3.5">
-                  <div className="grid grid-cols-2 gap-2.5">
-                    <div className="rounded-xl border border-primary/20 bg-background/40 px-3 py-2">
-                      <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Ventas</p>
-                      <p className="stat-number text-sm font-bold text-foreground">
-                        {paymentMethodItems.totalCount.toLocaleString("es-CO")}
-                      </p>
-                    </div>
-                    <div className="rounded-xl border border-primary/20 bg-background/40 px-3 py-2">
-                      <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Ticket prom.</p>
-                      <p className="stat-number text-sm font-bold text-foreground">
-                        {formatCurrency(paymentMethodItems.avgTicket)}
-                      </p>
-                    </div>
-                  </div>
-
-                  {paymentMethodItems.items.map((item) => (
-                    <div key={item.paymentMethod} className="space-y-1.5">
-                      <div className="flex items-center justify-between text-xs">
-                        <div className="flex items-center gap-2">
-                          <span className="w-2 h-2 rounded-full" style={{ backgroundColor: item.dot }} />
-                          <span className="font-medium text-foreground">{item.label}</span>
-                        </div>
-                        <span className="text-muted-foreground">{item.pct.toFixed(1)}%</span>
-                      </div>
-                      <div className="h-1.5 w-full rounded-full bg-primary/10 overflow-hidden">
-                        <div className="h-full rounded-full" style={{ width: `${item.pct}%`, backgroundColor: item.dot }} />
-                      </div>
-                    </div>
-                  ))}
-
-                  <div className="pt-2 border-t border-primary/20 flex items-center justify-between text-xs">
-                    <span className="text-muted-foreground">Ingresos por pagos</span>
-                    <span className="stat-number font-bold text-primary">{formatCurrency(paymentMethodItems.totalAmount)}</span>
-                  </div>
-                </div>
-              ) : (
-                <div className="text-center py-8">
-                  <p className="text-sm text-muted-foreground">Sin datos para este período</p>
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-1 xl:grid-cols-2 gap-4 lg:gap-5 items-start">
-          {/* Export */}
-          <div className="rounded-3xl border border-primary/30 bg-primary/10 overflow-hidden transition-all duration-300 hover:border-primary/50">
-            <div className="px-5 py-4 border-b border-primary/20 flex items-center gap-2">
-              <div className="p-1.5 bg-primary/20 rounded-lg">
-                <Download className="w-4 h-4 text-primary" />
-              </div>
-              <h3 className="text-sm font-semibold text-foreground">
-                Exportar Datos
-              </h3>
-            </div>
-            <div className="p-5">
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {[
-                  { key: "sales", label: "Ventas" },
-                  { key: "products", label: "Productos" },
-                  { key: "customers", label: "Clientes" },
-                  { key: "inventory", label: "Inventario" },
-                ].map(({ key, label }) => (
-                  <div
-                    key={key}
-                    className="p-4 rounded-2xl bg-background/40 border border-primary/20"
-                  >
-                    <p className="text-xs font-semibold uppercase tracking-wide text-foreground mb-3">
-                      {label}
-                    </p>
-                    <div className="flex gap-1.5">
-                      {["pdf", "excel", "csv"].map((format) => (
-                        <Button
-                          key={format}
-                          variant="secondary"
-                          size="sm"
-                          onClick={() =>
-                            handleExport(
-                              key as
-                                | "sales"
-                                | "products"
-                                | "customers"
-                                | "inventory",
-                              format as "pdf" | "excel" | "csv",
-                            )
-                          }
-                          className="flex-1 text-xs font-mono"
-                        >
-                          {format.toUpperCase()}
-                        </Button>
-                      ))}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-
-          <ImportSection />
-        </div>
+        <SectionShell title="Exportación económica" icon={Download}><div className="flex flex-wrap items-center justify-between gap-3"><p className="max-w-xl text-sm text-muted-foreground">Descarga un único paquete con economía, caja e inventario actual para el período seleccionado.</p><Button onClick={handleEconomicExport} loading={showExporting}><Download className="h-4 w-4" aria-hidden="true" /> Exportar economía</Button></div></SectionShell>
       </div>
     </DashboardLayout>
   );

--- a/frontend/src/hooks/useReports.ts
+++ b/frontend/src/hooks/useReports.ts
@@ -11,28 +11,15 @@ import type {
   CustomerStatistics,
   DailySale,
   ReportEnvelope,
-  UserPerformance,
+  FinancialOverview,
+  CashFlowReport,
+  InventorySnapshotReport,
 } from "@/types";
 
 type DashboardResponse = DashboardData & {
   appliedRange: AppliedRange;
   comparisonRange?: AppliedRange;
 };
-
-type UserPerformanceResponse = ReportEnvelope<UserPerformance[]>;
-
-function buildUserPerformanceParams(
-  startDate?: string,
-  endDate?: string,
-  compare?: boolean,
-  userIds?: string[],
-) {
-  return {
-    ...buildDateRangeParams(startDate, endDate),
-    ...(typeof compare === "boolean" ? { compare } : {}),
-    ...(userIds && userIds.length > 0 ? { userIds: userIds.join(",") } : {}),
-  };
-}
 
 function buildDateRangeParams(startDate?: string, endDate?: string) {
   const params: Record<string, string> = {};
@@ -57,6 +44,36 @@ export function useDashboard(startDate?: string, endDate?: string) {
           "/reports/dashboard",
           buildDateRangeParams(startDate, endDate),
         )
+        .then((res) => res.data),
+  });
+}
+
+export function useEconomicOverview(startDate?: string, endDate?: string) {
+  return useQuery({
+    queryKey: ["reports", "economic", startDate, endDate],
+    queryFn: () =>
+      api
+        .get<FinancialOverview>("/reports/economic", buildDateRangeParams(startDate, endDate))
+        .then((res) => res.data),
+  });
+}
+
+export function useCashFlow(startDate?: string, endDate?: string) {
+  return useQuery({
+    queryKey: ["reports", "economic", "cash", startDate, endDate],
+    queryFn: () =>
+      api
+        .get<CashFlowReport>("/reports/economic/cash", buildDateRangeParams(startDate, endDate))
+        .then((res) => res.data),
+  });
+}
+
+export function useInventorySnapshot(startDate?: string, endDate?: string) {
+  return useQuery({
+    queryKey: ["reports", "economic", "inventory", startDate, endDate],
+    queryFn: () =>
+      api
+        .get<InventorySnapshotReport>("/reports/economic/inventory", buildDateRangeParams(startDate, endDate))
         .then((res) => res.data),
   });
 }
@@ -137,39 +154,6 @@ export function useDailySales(startDate: string, endDate: string) {
         })
         .then((res) => res.data),
     enabled: !!startDate && !!endDate,
-  });
-}
-
-export function useUserPerformance(
-  startDate?: string,
-  endDate?: string,
-  compare = true,
-  userIds?: string[],
-) {
-  const normalizedUserIds = userIds?.filter(Boolean) ?? [];
-
-  return useQuery({
-    queryKey: [
-      "reports",
-      "users",
-      "performance",
-      startDate,
-      endDate,
-      compare,
-      normalizedUserIds.join(","),
-    ],
-    queryFn: () =>
-      api
-        .get<UserPerformanceResponse>(
-          "/reports/users/performance",
-          buildUserPerformanceParams(
-            startDate,
-            endDate,
-            compare,
-            normalizedUserIds,
-          ),
-        )
-        .then((res) => res.data),
   });
 }
 

--- a/frontend/src/lib/reportPresentation.test.ts
+++ b/frontend/src/lib/reportPresentation.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { adaptiveReportGranularity, safeDecimalNumber } from "./reportPresentation";
+
+describe("report presentation contract", () => {
+  it("converts valid Decimal strings only for display", () => {
+    expect(safeDecimalNumber("100000.25")).toBe(100000.25);
+    expect(safeDecimalNumber("not-a-decimal")).toBe(0);
+  });
+
+  it("uses daily buckets for short ranges and monthly buckets for long ranges", () => {
+    expect(adaptiveReportGranularity("2026-01-01", "2026-01-12")).toBe("day");
+    expect(adaptiveReportGranularity("2026-01-01", "2026-06-30")).toBe("month");
+  });
+});

--- a/frontend/src/lib/reportPresentation.ts
+++ b/frontend/src/lib/reportPresentation.ts
@@ -1,0 +1,23 @@
+import { formatCurrency } from "@/lib/utils";
+
+export type ReportGranularity = "day" | "month";
+
+export function safeDecimalNumber(value: string | number | null | undefined) {
+  const parsed = typeof value === "number" ? value : Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function formatReportMoney(value: string | number | null | undefined) {
+  return formatCurrency(safeDecimalNumber(value));
+}
+
+export function adaptiveReportGranularity(
+  startDate: string | null | undefined,
+  endDate: string | null | undefined,
+): ReportGranularity {
+  if (!startDate || !endDate) return "month";
+  const start = Date.parse(`${startDate}T12:00:00Z`);
+  const end = Date.parse(`${endDate}T12:00:00Z`);
+  const days = Math.max(1, Math.round((end - start) / 86_400_000) + 1);
+  return days <= 31 ? "day" : "month";
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -140,6 +140,75 @@ export interface ReportEnvelope<T> {
   comparisonRange?: AppliedRange;
 }
 
+export interface FinancialDataQuality {
+  snapshotBackedItems: number;
+  excludedItems: number;
+  excludedQuantity: number;
+}
+
+export interface FinancialProductMargin {
+  productId: string;
+  productName: string;
+  categoryName: string;
+  quantity: number;
+  netRevenue: string;
+  cogs: string;
+  grossProfit: string;
+  marginPercentage: number | null;
+}
+
+export interface FinancialReport {
+  netIncome: string;
+  tax: string;
+  cogs: string;
+  grossProfit: string;
+  grossMarginPercentage: number | null;
+  operatingExpenses: string;
+  netProfit: string;
+  netMarginPercentage: number | null;
+  products: FinancialProductMargin[];
+  dataQuality: FinancialDataQuality;
+}
+
+export interface FinancialDelta {
+  absolute: string;
+  percentage: number | null;
+}
+
+export interface FinancialOverview {
+  current: FinancialReport;
+  previous: FinancialReport;
+  deltas: Record<string, FinancialDelta>;
+  appliedRange: AppliedRange;
+  comparisonRange: AppliedRange;
+}
+
+export interface CashFlowReport {
+  accountingBasis: string;
+  collections: {
+    total: string;
+    byPaymentMethod: Array<{ paymentMethod: string; total: string; count: number }>;
+  };
+  expensePayments: {
+    total: string;
+    byPaymentMethod: Array<{ paymentMethod: string; total: string; count: number }>;
+  };
+  appliedRange: AppliedRange;
+}
+
+export interface InventorySnapshotReport {
+  isCurrentSnapshot: boolean;
+  valuationBasis: string;
+  current: {
+    stockQuantity: number;
+    stockValue: string;
+    retailValue: string;
+    potentialProfit: string;
+  };
+  movements: { totalQuantity: number; byType: Record<string, number> };
+  appliedRange: AppliedRange;
+}
+
 export interface DashboardData {
   totalSales: number;
   totalRevenue: number;
@@ -374,11 +443,6 @@ export interface TaskListResult {
   source: TaskDataSource;
 }
 
-export interface UserPerformanceComparison {
-  revenuePct: number | null;
-  salesPct: number | null;
-}
-
 export type PurchaseOrderStatus =
   | "DRAFT"
   | "PENDING"
@@ -431,17 +495,6 @@ export interface PurchaseOrder {
   createdAt: string;
   updatedAt: string;
   items?: PurchaseOrderItem[];
-}
-
-export interface UserPerformance {
-  userId: string;
-  userName: string;
-  role: "ADMIN" | "CASHIER" | "INVENTORY_USER";
-  salesCount: number;
-  revenue: number;
-  avgTicket: number;
-  uniqueCustomers: number;
-  comparison?: UserPerformanceComparison;
 }
 
 export interface PlanLimit {


### PR DESCRIPTION
Closes #42

## Chain Context

- Strategy: Feature Branch Chain (5 slices)
- Slice: **4 of 5 — economics-first frontend and importer move** 📍
- Base: `feat/reports-refactor` (tracker; PR1-PR3 merged)
- Follow-up: final cross-stack verification and rollback evidence

## Summary

- Refactors Reports around an economics-first information architecture using financial, cash and inventory contracts.
- Keeps operational analyses below the financial overview.
- Removes the seller-performance frontend consumer while preserving the backend compatibility route.
- Moves the product importer into Inventory as a subtle secondary action.
- Adds accessible loading, error and empty-state evidence plus presentation helpers for decimal-string values.

## Test Plan

- [x] Focused frontend tests: 7/7
- [x] Full frontend suite: 176 passed / 5 known baseline failures
- [x] Build passed
- [x] Scoped lint passed
- [ ] Typecheck: one pre-existing `AuthContext.switch.test.tsx:97` error remains
- [x] One-time size exception accepted: 1,535 changed lines due to monolith reduction

## Contributor Checklist

- [x] Issue linked (`Closes #42`)
- [x] Conventional commit, no `Co-Authored-By`
- [x] Tests kept with the work unit
- [x] No shell scripts changed
