### PR TITLE
fix(reports): apply cancellation and return event periods

### DIFF
--- a/backend/src/reports/financial-reports.service.int.spec.ts
+++ b/backend/src/reports/financial-reports.service.int.spec.ts
@@ -19,11 +19,14 @@ describe('ReportsService financial integration', () => {
   let purchaseExpenseId: string;
   let supplierId: string;
   let purchaseOrderId: string;
+  let saleNumberSequence: number;
+  const eventSaleIds: string[] = [];
 
   beforeAll(async () => {
     service = new ReportsService(prisma as never, new CacheService());
     const suffix = Date.now();
     const sequence = suffix % 1_000_000_000;
+    saleNumberSequence = sequence;
     const [orgA, orgB] = await Promise.all([
       prisma.organization.create({
         data: { name: 'Reports INT A', slug: `reports-int-a-${suffix}`, plan: PlanType.BASIC },
@@ -152,6 +155,9 @@ describe('ReportsService financial integration', () => {
   });
 
   afterAll(async () => {
+    await prisma.inventoryMovement.deleteMany({ where: { saleId: { in: eventSaleIds } } });
+    await prisma.saleItem.deleteMany({ where: { saleId: { in: eventSaleIds } } });
+    await prisma.sale.deleteMany({ where: { id: { in: eventSaleIds } } });
     await prisma.expense.deleteMany({ where: { id: { in: [expenseAId, purchaseExpenseId] } } });
     await prisma.purchaseOrder.delete({ where: { id: purchaseOrderId } });
     await prisma.supplier.delete({ where: { id: supplierId } });
@@ -175,5 +181,103 @@ describe('ReportsService financial integration', () => {
     expect(reportA.current.netProfit).toBe('35.00');
     expect(reportB.current.netIncome).toBe('900.00');
     expect(reportB.current.cogs).toBe('0.00');
+  });
+
+  it('applies cancellation and partial return adjustments by event date when sales predate the range', async () => {
+    const cancellation = await prisma.sale.create({
+      data: {
+        saleNumber: saleNumberSequence + 1,
+        subtotal: 200,
+        taxAmount: 0,
+        discountAmount: 0,
+        total: 200,
+        amountPaid: 200,
+        status: 'CANCELLED',
+        cancelledAt: new Date('2026-08-20T15:00:00.000Z'),
+        userId,
+        organizationId: orgAId,
+        createdAt: new Date('2026-07-20T15:00:00.000Z'),
+      },
+    });
+    const partial = await prisma.sale.create({
+      data: {
+        saleNumber: saleNumberSequence + 2,
+        subtotal: 200,
+        taxAmount: 0,
+        discountAmount: 0,
+        total: 200,
+        amountPaid: 200,
+        status: 'RETURNED_PARTIAL',
+        userId,
+        organizationId: orgAId,
+        createdAt: new Date('2026-07-20T15:00:00.000Z'),
+      },
+    });
+    const cancelledLater = await prisma.sale.create({
+      data: {
+        saleNumber: saleNumberSequence + 3,
+        subtotal: 200,
+        taxAmount: 0,
+        discountAmount: 0,
+        total: 200,
+        amountPaid: 200,
+        status: 'CANCELLED',
+        cancelledAt: new Date('2026-08-30T15:00:00.000Z'),
+        userId,
+        organizationId: orgAId,
+        createdAt: new Date('2026-08-20T15:00:00.000Z'),
+      },
+    });
+    eventSaleIds.push(cancellation.id, partial.id, cancelledLater.id);
+
+    for (const sale of [cancellation, partial, cancelledLater]) {
+      await prisma.saleItem.create({
+        data: {
+          saleId: sale.id,
+          productId: productAId,
+          quantity: 2,
+          unitPrice: 100,
+          costPriceSnapshot: 40,
+          taxRate: 0,
+          subtotal: 200,
+          total: 200,
+          organizationId: orgAId,
+        },
+      });
+    }
+    await prisma.inventoryMovement.create({
+      data: {
+        productId: productAId,
+        type: 'RETURN',
+        quantity: 1,
+        previousStock: 0,
+        newStock: 1,
+        reason: 'Partial return',
+        userId,
+        saleId: partial.id,
+        organizationId: orgAId,
+        createdAt: new Date('2026-08-21T15:00:00.000Z'),
+      },
+    });
+    await prisma.inventoryMovement.create({
+      data: {
+        productId: productAId,
+        type: 'RETURN',
+        quantity: 2,
+        previousStock: 0,
+        newStock: 2,
+        reason: 'Sale cancelled',
+        userId,
+        saleId: cancelledLater.id,
+        organizationId: orgAId,
+        createdAt: new Date('2026-08-21T15:00:00.000Z'),
+      },
+    });
+
+    const report = await service.getFinancialOverview(orgAId, '2026-08-20', '2026-08-21');
+
+    expect(report.current.netIncome).toBe('-100.00');
+    expect(report.current.cogs).toBe('-40.00');
+    expect(report.current.grossProfit).toBe('-60.00');
   });
 });

--- a/backend/src/reports/financial-reports.service.spec.ts
+++ b/backend/src/reports/financial-reports.service.spec.ts
@@ -33,18 +33,16 @@ describe('ReportsService financial read model', () => {
       '2026-03-12',
     );
 
-    expect(prismaMock.sale.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: {
-          organizationId: 'org-a',
-          status: 'COMPLETED',
-          createdAt: expect.objectContaining({
-            gte: expect.any(Date),
-            lte: expect.any(Date),
-          }),
-        },
+    expect(prismaMock.sale.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        organizationId: 'org-a',
+        OR: expect.arrayContaining([
+          { createdAt: expect.any(Object) },
+          { cancelledAt: expect.any(Object) },
+          { inventoryMovements: { some: expect.any(Object) } },
+        ]),
       }),
-    );
+    }));
     expect(expensesMock.findForReports).toHaveBeenCalledWith(
       'org-a',
       expect.any(Date),
@@ -61,6 +59,9 @@ describe('ReportsService financial read model', () => {
     prismaMock.sale.findMany
       .mockResolvedValueOnce([
         {
+          createdAt: new Date('2026-03-11T15:00:00.000Z'),
+          cancelledAt: null,
+          status: 'COMPLETED',
           subtotal: decimal('100.00'),
           discountAmount: decimal('0.00'),
           taxAmount: decimal('19.00'),
@@ -74,6 +75,7 @@ describe('ReportsService financial read model', () => {
               product: { name: 'A', category: { name: 'General' } },
             },
           ],
+          inventoryMovements: [],
         },
       ])
       .mockResolvedValueOnce([]);
@@ -98,6 +100,89 @@ describe('ReportsService financial read model', () => {
     expect(result.previous.netIncome).toBe('0.00');
     expect(result.deltas.netIncome).toEqual({ absolute: '100.00', percentage: 100 });
     expect(result.current.netIncome).toEqual(expect.any(String));
+  });
+
+  it('applies cancellation and return events in their period without requiring the sale creation period', async () => {
+    prismaMock.sale.findMany.mockResolvedValue([
+      {
+        createdAt: new Date('2026-02-20T15:00:00.000Z'),
+        cancelledAt: new Date('2026-03-11T15:00:00.000Z'),
+        status: 'CANCELLED',
+        subtotal: decimal('100.00'),
+        discountAmount: decimal('10.00'),
+        taxAmount: decimal('19.00'),
+        items: [
+          {
+            quantity: 2,
+            subtotal: decimal('100.00'),
+            discountAmount: decimal('10.00'),
+            costPriceSnapshot: decimal('40.00'),
+            productId: 'p-1',
+            product: { name: 'A', category: { name: 'General' } },
+          },
+        ],
+        inventoryMovements: [
+          {
+            type: 'RETURN',
+            quantity: 1,
+            createdAt: new Date('2026-03-12T15:00:00.000Z'),
+            productId: 'p-1',
+          },
+        ],
+      },
+      {
+        createdAt: new Date('2026-02-20T15:00:00.000Z'),
+        cancelledAt: null,
+        status: 'RETURNED_PARTIAL',
+        subtotal: decimal('100.00'),
+        discountAmount: decimal('10.00'),
+        taxAmount: decimal('19.00'),
+        items: [
+          {
+            quantity: 2,
+            subtotal: decimal('100.00'),
+            discountAmount: decimal('10.00'),
+            costPriceSnapshot: decimal('40.00'),
+            productId: 'p-1',
+            product: { name: 'A', category: { name: 'General' } },
+          },
+        ],
+        inventoryMovements: [
+          {
+            type: 'RETURN',
+            quantity: 1,
+            createdAt: new Date('2026-03-12T15:00:00.000Z'),
+            productId: 'p-1',
+          },
+        ],
+      },
+    ]);
+    expensesMock.findForReports.mockResolvedValue([]);
+    const service = new ReportsService(
+      prismaMock as never,
+      cacheMock as never,
+      expensesMock as never,
+    );
+
+    const result = await service.getFinancialOverview(
+      'org-a',
+      '2026-03-10',
+      '2026-03-12',
+    );
+
+    expect(prismaMock.sale.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        organizationId: 'org-a',
+        OR: expect.arrayContaining([
+          { createdAt: expect.any(Object) },
+          { cancelledAt: expect.any(Object) },
+          { inventoryMovements: { some: { type: 'RETURN', createdAt: expect.any(Object) } } },
+        ]),
+      }),
+    }));
+    expect(result.current.netIncome).toBe('-135.00');
+    expect(result.current.cogs).toBe('-120.00');
+    expect(result.current.grossProfit).toBe('-15.00');
   });
 
   it('never builds a financial query without the requested organization', async () => {

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -13,7 +13,12 @@ import {
   compareFinancialReports,
   serializeFinancialReport,
 } from './financial-aggregator';
-import type { FinancialDelta, FinancialReport } from './financial-aggregator';
+import type {
+  FinancialDelta,
+  FinancialReport,
+  FinancialSale,
+  FinancialSaleItem,
+} from './financial-aggregator';
 
 // ─── Local types ──────────────────────────────────────────────────────────────
 
@@ -22,6 +27,18 @@ type SaleStatusType = 'COMPLETED' | 'CANCELLED' | 'RETURNED_PARTIAL';
 interface DateFilter {
   gte?: Date;
   lte?: Date;
+}
+
+interface FinancialSaleRecord extends FinancialSale {
+  createdAt: Date;
+  cancelledAt: Date | null;
+  status: string;
+  inventoryMovements: Array<{
+    type: string;
+    quantity: number;
+    productId: string;
+    createdAt: Date;
+  }>;
 }
 
 interface SaleWhereInput {
@@ -285,6 +302,82 @@ function aggregateCashPayments(
   };
 }
 
+function isInDateFilter(date: Date | null | undefined, filter: DateFilter): boolean {
+  return Boolean(
+    date &&
+      (!filter.gte || date >= filter.gte) &&
+      (!filter.lte || date <= filter.lte),
+  );
+}
+
+function signedSale(
+  sale: FinancialSaleRecord,
+  items: FinancialSaleItem[],
+  sign: 1 | -1,
+): FinancialSale {
+  const itemSubtotal = items.reduce(
+    (sum, item) => sum.add(item.subtotal),
+    new Prisma.Decimal(0),
+  );
+  const ratio = sale.subtotal.isZero() ? new Prisma.Decimal(1) : itemSubtotal.div(sale.subtotal);
+
+  return {
+    subtotal: sale.subtotal.mul(sign).mul(ratio),
+    discountAmount: sale.discountAmount.mul(sign).mul(ratio),
+    taxAmount: sale.taxAmount.mul(sign).mul(ratio),
+    items: items.map((item) => ({
+      ...item,
+      quantity: item.quantity * sign,
+      subtotal: item.subtotal.mul(sign),
+      discountAmount: item.discountAmount.mul(sign),
+    })),
+  };
+}
+
+function expandFinancialSale(sale: FinancialSaleRecord, dateFilter: DateFilter): FinancialSale[] {
+  const records: FinancialSale[] = [];
+
+  if (isInDateFilter(sale.createdAt, dateFilter)) {
+    records.push(sale);
+  }
+
+  if (isInDateFilter(sale.cancelledAt, dateFilter)) {
+    records.push(signedSale(sale, sale.items, -1));
+  }
+
+  if (sale.status !== 'CANCELLED') {
+    const returnedByProduct = new Map<string, number>();
+    for (const movement of sale.inventoryMovements) {
+      if (movement.type === 'RETURN' && isInDateFilter(movement.createdAt, dateFilter)) {
+        returnedByProduct.set(
+          movement.productId,
+          (returnedByProduct.get(movement.productId) ?? 0) + movement.quantity,
+        );
+      }
+    }
+
+    const returnedItems = sale.items
+      .map((item) => {
+        const returnedQuantity = returnedByProduct.get(item.productId) ?? 0;
+        if (!returnedQuantity || item.quantity === 0) return null;
+        const ratio = new Prisma.Decimal(returnedQuantity).div(item.quantity);
+        return {
+          ...item,
+          quantity: returnedQuantity,
+          subtotal: item.subtotal.mul(ratio),
+          discountAmount: item.discountAmount.mul(ratio),
+        };
+      })
+      .filter((item): item is FinancialSaleItem => item !== null);
+
+    if (returnedItems.length > 0) {
+      records.push(signedSale(sale, returnedItems, -1));
+    }
+  }
+
+  return records;
+}
+
 // ─── Service ──────────────────────────────────────────────────────────────────
 
 @Injectable()
@@ -445,8 +538,18 @@ export class ReportsService {
 
   private async findFinancialSales(organizationId: string, dateFilter: DateFilter) {
     const sales = await this.prisma.sale.findMany({
-      where: { organizationId, status: 'COMPLETED', createdAt: dateFilter },
+      where: {
+        organizationId,
+        OR: [
+          { createdAt: dateFilter },
+          { cancelledAt: dateFilter },
+          { inventoryMovements: { some: { type: 'RETURN', createdAt: dateFilter } } },
+        ],
+      },
       select: {
+        createdAt: true,
+        cancelledAt: true,
+        status: true,
         subtotal: true,
         discountAmount: true,
         taxAmount: true,
@@ -460,23 +563,36 @@ export class ReportsService {
             product: { select: { name: true, category: { select: { name: true } } } },
           },
         },
+        inventoryMovements: {
+          where: { type: 'RETURN', createdAt: dateFilter },
+          select: { type: true, quantity: true, productId: true, createdAt: true },
+        },
       },
     });
 
-    return sales.map((sale) => ({
-      subtotal: sale.subtotal,
-      discountAmount: sale.discountAmount,
-      taxAmount: sale.taxAmount,
-      items: sale.items.map((item) => ({
-        productId: item.productId,
-        productName: item.product.name,
-        categoryName: item.product.category.name,
-        quantity: item.quantity,
-        subtotal: item.subtotal,
-        discountAmount: item.discountAmount,
-        costPriceSnapshot: item.costPriceSnapshot,
-      })),
-    }));
+    return sales.flatMap((sale) =>
+      expandFinancialSale(
+        {
+          createdAt: sale.createdAt,
+          cancelledAt: sale.cancelledAt,
+          status: sale.status,
+          subtotal: sale.subtotal,
+          discountAmount: sale.discountAmount,
+          taxAmount: sale.taxAmount,
+          items: sale.items.map((item) => ({
+            productId: item.productId,
+            productName: item.product.name,
+            categoryName: item.product.category.name,
+            quantity: item.quantity,
+            subtotal: item.subtotal,
+            discountAmount: item.discountAmount,
+            costPriceSnapshot: item.costPriceSnapshot,
+          })),
+          inventoryMovements: sale.inventoryMovements,
+        },
+        dateFilter,
+      ),
+    );
   }
 
   private async findFinancialExpenses(


### PR DESCRIPTION
Closes #44

## Chain Context

- Strategy: Feature Branch Chain (5 slices)
- Slice: **5 of 5 — cancellation and return event-period accounting** 📍
- Base: `feat/reports-refactor` (tracker; PR1-PR4 merged)
- Follow-up: rerun final cross-stack verification and create the final tracker PR to master

## Summary

- Applies cancellation adjustments using the cancellation event period.
- Applies partial returns through `InventoryMovement.RETURN` event date and quantity.
- Covers original sales outside the selected period with return/cancellation events inside it.
- Prevents double-counting RETURN movements generated by cancellation flows.
- No schema migration required.

## Test Plan

- [x] Focused remediation tests: 14/14
- [x] Integration event-period tests: 2/2
- [x] Backend suite: 455 tests passed across 45 suites
- [x] Backend build passed
- [x] Scoped lint attempted without autofix; existing baseline diagnostics remain

## Contributor Checklist

- [x] Issue linked (`Closes #44`)
- [x] Conventional commit, no `Co-Authored-By`
- [x] Tests kept with the work unit
- [x] No shell scripts changed