### PR TITLE
fix(api): enforce organization scoping on assignment, removal, and aggregates

### DIFF
--- a/backend/src/products/products.service.spec.ts
+++ b/backend/src/products/products.service.spec.ts
@@ -26,6 +26,7 @@ describe('ProductsService — Opt-in tax resolution', () => {
     inventoryMovement: {
       create: jest.fn(),
     },
+    $queryRaw: jest.fn(),
   };
 
   const cloudinaryServiceMock = {};
@@ -486,6 +487,27 @@ describe('ProductsService — Opt-in tax resolution', () => {
           where: expect.objectContaining({ organizationId: ORG_ID }),
         }),
       );
+    });
+  });
+
+  // ════════════════════════════════════════════════════════════════════
+  // Low stock lookup
+  // ════════════════════════════════════════════════════════════════════
+  describe('Low stock lookup', () => {
+    it('rejects low-stock lookups without an organization context', async () => {
+      await expect(
+        service.getLowStockProducts(undefined),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('filters low-stock products by organization', async () => {
+      prismaMock.$queryRaw.mockResolvedValue([
+        { id: 'prod-1', name: 'Panela' },
+      ]);
+
+      const result = await service.getLowStockProducts(ORG_ID);
+
+      expect(result).toEqual([{ id: 'prod-1', name: 'Panela' }]);
     });
   });
 });

--- a/backend/src/products/products.service.ts
+++ b/backend/src/products/products.service.ts
@@ -333,13 +333,9 @@ export class ProductsService {
 
   async getLowStockProducts(organizationId: string | undefined) {
     if (!organizationId) {
-      return this.prisma.$queryRaw`
-        SELECT p.*, c.name as "categoryName"
-        FROM "Product" p
-        LEFT JOIN "Category" c ON p."categoryId" = c.id
-        WHERE p.active = true AND p.stock <= p."minStock"
-        ORDER BY p.stock ASC
-      `;
+      throw new BadRequestException(
+        'Organization ID is required for this operation',
+      );
     }
     return this.prisma.$queryRaw`
       SELECT p.*, c.name as "categoryName"

--- a/backend/src/reports/reports.service.spec.ts
+++ b/backend/src/reports/reports.service.spec.ts
@@ -6,10 +6,19 @@ describe('ReportsService', () => {
   const prismaMock = {
     sale: {
       findMany: jest.fn(),
+      count: jest.fn(),
+      aggregate: jest.fn(),
     },
     user: {
       findMany: jest.fn(),
     },
+    product: {
+      count: jest.fn(),
+    },
+    customer: {
+      count: jest.fn(),
+    },
+    $queryRaw: jest.fn(),
   };
   const cacheMock = {
     get: jest.fn(),
@@ -25,6 +34,33 @@ describe('ReportsService', () => {
     await expect(
       service.getSalesByPaymentMethod('org-1', '2026-03-10', '2026-03-05'),
     ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects dashboard KPIs without an organization context', async () => {
+    await expect(
+      service.getDashboardKPIs(undefined),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('scopes dashboard KPI queries to the requested organization', async () => {
+    prismaMock.sale.count.mockResolvedValue(0);
+    prismaMock.sale.aggregate.mockResolvedValue({ _sum: { total: null } });
+    prismaMock.product.count.mockResolvedValue(0);
+    prismaMock.customer.count.mockResolvedValue(0);
+    prismaMock.sale.findMany.mockResolvedValue([]);
+    prismaMock.$queryRaw.mockResolvedValue([{ count: 3n }]);
+
+    const result = (await service.getDashboardKPIs('org-1')) as {
+      lowStockProducts: number;
+    };
+
+    expect(result.lowStockProducts).toBe(3);
+    expect(prismaMock.product.count).toHaveBeenCalledWith({
+      where: { organizationId: 'org-1', active: true },
+    });
+    expect(prismaMock.customer.count).toHaveBeenCalledWith({
+      where: { organizationId: 'org-1', active: true },
+    });
   });
 
   it('returns appliedRange metadata with the queried date range', async () => {

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -622,9 +622,10 @@ export class ReportsService {
     startDate?: string,
     endDate?: string,
   ) {
+    const orgId = this.requireOrganizationId(organizationId);
     validateDateRange(startDate, endDate);
 
-    const cacheKey = `dashboard:${organizationId || 'all'}:${startDate || ''}:${endDate || ''}`;
+    const cacheKey = `dashboard:${orgId}:${startDate || ''}:${endDate || ''}`;
     const cached = this.cache.get(cacheKey);
 
     if (cached) {
@@ -634,17 +635,17 @@ export class ReportsService {
     const dateFilter = buildDateFilter(startDate, endDate);
     const comparisonPeriod = buildComparisonPeriod(startDate, endDate);
     const baseWhere: SaleWhereInput = {
-      ...(organizationId ? { organizationId } : ({} as any)),
+      organizationId: orgId,
       ...(dateFilter && { createdAt: dateFilter }),
     };
     const salesWhere = { ...baseWhere, status: 'COMPLETED' as const };
     const currentPeriodSalesWhere = {
-      ...(organizationId ? { organizationId } : ({} as any)),
+      organizationId: orgId,
       status: 'COMPLETED' as const,
       createdAt: comparisonPeriod.current,
     };
     const previousPeriodSalesWhere = {
-      ...(organizationId ? { organizationId } : ({} as any)),
+      organizationId: orgId,
       status: 'COMPLETED' as const,
       createdAt: comparisonPeriod.previous,
     };
@@ -669,19 +670,14 @@ export class ReportsService {
         _sum: { total: true },
       }),
       this.prisma.product.count({
-        where: { ...(organizationId ? { organizationId } : {}), active: true },
+        where: { organizationId: orgId, active: true },
       }),
       this.prisma.customer.count({
-        where: { ...(organizationId ? { organizationId } : {}), active: true },
+        where: { organizationId: orgId, active: true },
       }),
-      organizationId
-        ? this.prisma.$queryRaw<[{ count: bigint }]>`
+      this.prisma.$queryRaw<[{ count: bigint }]>`
             SELECT COUNT(*)::bigint as count FROM "Product"
-            WHERE "organizationId" = ${organizationId} AND active = true AND stock <= "minStock"
-          `.then((r) => Number(r[0].count))
-        : this.prisma.$queryRaw<[{ count: bigint }]>`
-            SELECT COUNT(*)::bigint as count FROM "Product"
-            WHERE active = true AND stock <= "minStock"
+            WHERE "organizationId" = ${orgId} AND active = true AND stock <= "minStock"
           `.then((r) => Number(r[0].count)),
       this.prisma.sale.findMany({
         where: salesWhere,
@@ -726,14 +722,14 @@ export class ReportsService {
       }),
       this.prisma.customer.count({
         where: {
-          ...(organizationId ? { organizationId } : {}),
+          organizationId: orgId,
           active: true,
           createdAt: comparisonPeriod.current,
         },
       }),
       this.prisma.customer.count({
         where: {
-          ...(organizationId ? { organizationId } : {}),
+          organizationId: orgId,
           active: true,
           createdAt: comparisonPeriod.previous,
         },

--- a/backend/src/tasks/tasks.service.spec.ts
+++ b/backend/src/tasks/tasks.service.spec.ts
@@ -10,6 +10,9 @@ describe('TasksService', () => {
     user: {
       findUnique: jest.fn(),
     },
+    organizationUser: {
+      findFirst: jest.fn(),
+    },
     task: {
       create: jest.fn(),
       findMany: jest.fn(),
@@ -220,9 +223,11 @@ describe('TasksService', () => {
       assignedToId: null,
       deletedAt: null,
     });
-    prismaMock.user.findUnique.mockResolvedValue({
-      id: 'user-x',
-      active: false,
+    prismaMock.organizationUser.findFirst.mockResolvedValue({
+      id: 'ou-x',
+      userId: 'user-x',
+      organizationId: 'org-1',
+      user: { active: false },
     });
 
     await expect(
@@ -232,5 +237,50 @@ describe('TasksService', () => {
         { assignedToId: 'user-x' },
       ),
     ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('rejects assigning a task to a user without membership in the organization', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: 'user-ext',
+      active: true,
+    });
+    prismaMock.organizationUser.findFirst.mockResolvedValue(null);
+
+    await expect(
+      service.create(baseUser, {
+        title: 'Tarea cruzada',
+        assignedToId: 'user-ext',
+      }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+    expect(prismaMock.task.create).not.toHaveBeenCalled();
+  });
+
+  it('assigns tasks to active members of the same organization', async () => {
+    prismaMock.user.findUnique.mockResolvedValueOnce({ id: 'user-1' });
+    prismaMock.organizationUser.findFirst.mockResolvedValue({
+      id: 'ou-2',
+      userId: 'user-2',
+      organizationId: 'org-1',
+      user: { active: true },
+    });
+    prismaMock.task.create.mockResolvedValue({
+      id: 'task-9',
+      title: 'Tarea interna',
+      status: TaskStatus.PENDING,
+      createdById: 'user-1',
+    });
+    prismaMock.taskEvent.create.mockResolvedValue({ id: 'event-9' });
+
+    const result = await service.create(baseUser, {
+      title: 'Tarea interna',
+      assignedToId: 'user-2',
+    });
+
+    expect(prismaMock.organizationUser.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: 'user-2', organizationId: 'org-1' },
+      }),
+    );
+    expect(result).toEqual(expect.objectContaining({ id: 'task-9' }));
   });
 });

--- a/backend/src/tasks/tasks.service.ts
+++ b/backend/src/tasks/tasks.service.ts
@@ -65,7 +65,7 @@ export class TasksService {
 
   async create(user: RequestUser, dto: CreateTaskDto) {
     await this.ensureUserExists(user.userId);
-    await this.ensureAssignableUser(dto.assignedToId);
+    await this.ensureAssignableUser(user.organizationId!, dto.assignedToId);
 
     return this.prisma.$transaction(async (tx) => {
       const task = await tx.task.create({
@@ -152,7 +152,7 @@ export class TasksService {
     }
 
     if (dto.assignedToId !== undefined) {
-      await this.ensureAssignableUser(dto.assignedToId);
+      await this.ensureAssignableUser(user.organizationId!, dto.assignedToId);
     }
 
     const data = {
@@ -351,17 +351,22 @@ export class TasksService {
     }
   }
 
-  private async ensureAssignableUser(userId?: string | null) {
+  private async ensureAssignableUser(
+    organizationId: string,
+    userId?: string | null,
+  ) {
     if (!userId) {
       return;
     }
 
-    const user = await this.prisma.user.findUnique({
-      where: { id: userId },
-      select: { id: true, active: true },
+    // Assignment is scoped to the caller's organization: the assignee must
+    // hold an active membership there, not merely exist globally.
+    const membership = await this.prisma.organizationUser.findFirst({
+      where: { userId, organizationId },
+      select: { id: true, user: { select: { active: true } } },
     });
 
-    if (!user || !user.active) {
+    if (!membership || !membership.user.active) {
       throw new NotFoundException('Assigned user not found');
     }
   }

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -20,6 +20,7 @@ describe('UsersService', () => {
     organizationUser: {
       findFirst: jest.fn(),
       count: jest.fn(),
+      delete: jest.fn(),
     },
     auditLog: {
       create: jest.fn(),
@@ -262,6 +263,7 @@ describe('UsersService', () => {
       service.remove('admin-1', 'user-2', 'org-1'),
     ).rejects.toBeInstanceOf(BadRequestException);
     expect(prismaMock.user.delete).not.toHaveBeenCalled();
+    expect(prismaMock.organizationUser.delete).not.toHaveBeenCalled();
   });
 
   it('prevents removing the last admin of an organization', async () => {
@@ -284,6 +286,63 @@ describe('UsersService', () => {
       service.remove('admin-1', 'user-2', 'org-1'),
     ).rejects.toBeInstanceOf(BadRequestException);
     expect(prismaMock.user.delete).not.toHaveBeenCalled();
+    expect(prismaMock.organizationUser.delete).not.toHaveBeenCalled();
+  });
+
+  it('removes only the membership when the user belongs to another organization', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: 'user-2',
+      email: 'shared@example.com',
+      name: 'Shared User',
+      active: true,
+    });
+    prismaMock.organizationUser.findFirst.mockResolvedValue({
+      id: 'ou-1',
+      userId: 'user-2',
+      organizationId: 'org-1',
+      role: 'MEMBER',
+      isPrimaryOwner: false,
+    });
+    prismaMock.organizationUser.delete.mockResolvedValue({ id: 'ou-1' });
+    // One membership remains in the other organization.
+    prismaMock.organizationUser.count.mockResolvedValue(1);
+
+    const result = await service.remove('admin-1', 'user-2', 'org-1');
+
+    expect(prismaMock.organizationUser.delete).toHaveBeenCalledWith({
+      where: { id: 'ou-1' },
+    });
+    expect(prismaMock.user.delete).not.toHaveBeenCalled();
+    expect(result).toEqual({ message: 'User removed from organization' });
+  });
+
+  it('hard-deletes the global account when removing the last membership', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: 'user-2',
+      email: 'solo@example.com',
+      name: 'Solo User',
+      active: true,
+    });
+    prismaMock.organizationUser.findFirst.mockResolvedValue({
+      id: 'ou-1',
+      userId: 'user-2',
+      organizationId: 'org-1',
+      role: 'CASHIER',
+      isPrimaryOwner: false,
+    });
+    prismaMock.organizationUser.delete.mockResolvedValue({ id: 'ou-1' });
+    prismaMock.organizationUser.count.mockResolvedValue(0);
+    prismaMock.user.delete.mockResolvedValue({ id: 'user-2' });
+
+    const result = await service.remove('admin-1', 'user-2', 'org-1');
+
+    expect(prismaMock.organizationUser.delete).toHaveBeenCalledWith({
+      where: { id: 'ou-1' },
+    });
+    expect(prismaMock.user.delete).toHaveBeenCalledWith({
+      where: { id: 'user-2' },
+    });
+    expect(result).toEqual({ message: 'User deleted successfully' });
   });
 
   it('allows removing an admin when there are other admins', async () => {
@@ -300,7 +359,12 @@ describe('UsersService', () => {
       role: 'ADMIN',
       isPrimaryOwner: false,
     });
-    prismaMock.organizationUser.count.mockResolvedValue(2);
+    // Admin-count query sees other admins; membership count shows this is
+    // the user's only membership, so the global account is removed too.
+    prismaMock.organizationUser.count.mockImplementation(async ({ where }) =>
+      'role' in where ? 2 : 0,
+    );
+    prismaMock.organizationUser.delete.mockResolvedValue({ id: 'ou-1' });
     prismaMock.user.delete.mockResolvedValue({ id: 'user-2' });
 
     const result = await service.remove('admin-1', 'user-2', 'org-1');

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -244,6 +244,8 @@ export class UsersService {
 
     const user = await this.findUserOrThrow(userId, organizationId);
 
+    let deletedGlobalUser = false;
+
     if (organizationId) {
       const orgUser = await this.prisma.organizationUser.findFirst({
         where: { userId, organizationId },
@@ -275,22 +277,46 @@ export class UsersService {
           );
         }
       }
+
+      // Organization-scoped removal: only the membership in the caller's
+      // organization is deleted so other organizations sharing this user
+      // keep their account intact.
+      await this.prisma.organizationUser.delete({
+        where: { id: orgUser.id },
+      });
+
+      const remainingMemberships = await this.prisma.organizationUser.count({
+        where: { userId },
+      });
+
+      deletedGlobalUser = remainingMemberships === 0;
     }
 
-    await this.prisma.user.delete({
-      where: { id: userId },
-    });
+    if (deletedGlobalUser || !organizationId) {
+      await this.prisma.user.delete({
+        where: { id: userId },
+      });
+    }
 
     return attachAuditContext(
-      { message: 'User deleted successfully' },
+      {
+        message: deletedGlobalUser || !organizationId
+          ? 'User deleted successfully'
+          : 'User removed from organization',
+      },
       {
         resource: 'User',
         resourceId: userId,
-        summary: `Deleted user ${user.name} (${user.email})`,
+        summary:
+          deletedGlobalUser || !organizationId
+            ? `Deleted user ${user.name} (${user.email})`
+            : `Removed user ${user.name} (${user.email}) from organization`,
         metadata: {
           targetUserEmail: user.email,
           targetUserName: user.name,
           active: user.active,
+          ...(organizationId ? { organizationId } : {}),
+          removedFromOrganization: Boolean(organizationId) && !deletedGlobalUser,
         },
       },
     );

--- a/docs/url-identifier-policy.md
+++ b/docs/url-identifier-policy.md
@@ -1,0 +1,82 @@
+# URL Identifier Policy
+
+Scope: backend authorization for endpoints that address resources through
+identifiers in the URL (path or query). Status: enforced as of issue #47.
+
+## 1. Principle
+
+Identifiers in URLs are **not secrets**. UUIDv4 unguessability is a collision
+property, not an access-control mechanism, and it is never treated as
+authorization. Any authenticated client may observe, guess, replay, or leak
+identifiers (logs, browser history, referrer headers, support tickets), so
+every `:id` endpoint must enforce, **per request**:
+
+1. **Organization scoping** — the requested resource must belong to the
+   caller's organization (`organizationId` from the verified JWT, re-validated
+   against the current `OrganizationUser` membership), and
+2. **Role authorization** — the caller's role must permit the operation
+   (`JwtAuthGuard` + role guards/decorators).
+
+Because scoping in this codebase is a service-layer convention (no Prisma row
+level extension), every service method reachable from a controller is expected
+to filter by `organizationId` explicitly. A missing organization context is a
+hard error, never an implicit "all organizations" query.
+
+## 2. Guarantees added by this change
+
+- **Tasks — cross-org assignment blocked.** Assigning a task now requires the
+  assignee to hold an active `OrganizationUser` membership in the caller's
+  organization (`TasksService.ensureAssignableUser`). A user id that exists
+  globally but belongs to another organization is rejected with
+  `NotFoundException`, on both create and update.
+- **Users — membership-safe delete.** `DELETE /users/:id` with an organization
+  context removes only the `(userId, organizationId)` membership row. The
+  global `User` account is hard-deleted exclusively when no memberships remain,
+  so removing a shared user from one organization can no longer destroy their
+  account everywhere else. Existing guard rails are preserved: self-deletion,
+  primary-owner removal, and last-admin removal remain forbidden.
+- **Dashboard KPIs and low-stock report require organization context.**
+  `ReportsService.getDashboardKPIs` and
+  `ProductsService.getLowStockProducts` throw `BadRequestException` when called
+  without an `organizationId`. The previous unscoped fallbacks (including the
+  `dashboard:all` cache key) are removed; SuperAdmin tokens without an
+  `x-organization-id` header no longer resolve cross-organization aggregates.
+
+## 3. Accepted risks pending product decision
+
+The following behaviors intentionally remain unchanged and are flagged for an
+owner decision:
+
+- **Password reset by org admin mutates the global account.** An
+  organization-scoped admin password reset changes the credential for *every*
+  organization the target user belongs to, after org-scoped authorization of
+  the request itself.
+- **Name/email updates mutate the global record.** The same applies to admin
+  edits of user name/email: authorization is org-scoped, but the write hits the
+  shared `User` row.
+
+Both affect users shared across multiple organizations. Resolving them likely
+requires a product decision (per-org credentials/identity vs. accepting the
+shared-account semantics) and is out of scope for this change.
+
+## 4. Known test-coverage follow-ups
+
+- `cash-registers` module: no organization-isolation specs yet.
+- `imports` module: no organization-isolation specs yet.
+
+New isolation specs should follow the pattern used in
+`tasks.service.spec.ts` / `users.service.spec.ts`: assert rejection when a
+resource from another organization is addressed, and correct scoping filters
+when it is not.
+
+## 5. Frontend detail routes
+
+Frontend detail pages place identifiers in the URL bar:
+`/sales/[id]`, `/purchase-orders/[id]`, `/admin/organizations/[id]`.
+
+This is acceptable. URL visibility exposes the identifier, not the resource:
+every page load triggers server-side requests that re-check the JWT, the
+organization scope, and the caller's role before returning data. Deep links,
+bookmarks, and refreshes stay functional, while a forged or foreign id yields
+the same response as a nonexistent one (`404`/`403`) — information about other
+organizations never leaves the API layer.


### PR DESCRIPTION
Closes #47

## Summary

- Authorization audit of ~90 backend routes found the architecture sound (JWT org claim re-validated against DB per request; `x-organization-id` honored only for SuperAdmin impersonation) but surfaced 3 real cross-org gaps, fixed here with strict TDD.
- Task assignment now requires an active membership in the caller's organization instead of accepting any global `userId`.
- Organization-scoped user removal deletes only the membership row; the global account is hard-deleted solely when zero memberships remain.
- Dashboard KPIs and low-stock queries reject a missing `organizationId` with `400` instead of silently aggregating across all organizations.
- Adds `docs/url-identifier-policy.md`: identifiers in URLs are not secrets; UUIDv4 unguessability is never treated as authorization.

## Changes

| File | Change |
|------|--------|
| `backend/src/tasks/tasks.service.ts` | `ensureAssignableUser` requires `OrganizationUser` membership in caller's org |
| `backend/src/tasks/tasks.service.spec.ts` | Cross-org assignment rejection + in-org assignment tests |
| `backend/src/users/users.service.ts` | Scoped delete removes membership; global delete only when last membership removed; audit message distinguishes both outcomes |
| `backend/src/users/users.service.spec.ts` | Membership-only removal, single-org hard-delete, preserved last-admin/owner guards |
| `backend/src/reports/reports.service.ts` | `getDashboardKPIs` throws `BadRequestException` without org; `'all'` cache-key branch removed |
| `backend/src/reports/reports.service.spec.ts` | Org-less rejection test |
| `backend/src/products/products.service.ts` | `getLowStockProducts` throws `BadRequestException` without org; unscoped raw-SQL branch removed |
| `backend/src/products/products.service.spec.ts` | Org-less rejection test |
| `docs/url-identifier-policy.md` | New policy doc: principle, guarantees, accepted risks, coverage follow-ups |

## Test plan

- [x] TDD: each fix landed RED first (cross-org assignment resolved instead of rejected; `user.delete` called on scoped removal; org-less KPIs/low-stock not rejecting), then GREEN.
- [x] Focused: `npx jest src/tasks src/users src/reports src/products` → unit specs 54/54 passed.
- [x] Full backend suite: `npm run test` → 455 passed / 8 failed; all 8 failures are pre-existing int suites requiring live PostgreSQL at localhost:5432 (identical to baseline before this change).
- [x] `npx tsc --noEmit`: no errors in touched files (pre-existing errors confined to untouched expenses specs).

## Behavior notes

- SuperAdmin callers without `x-organization-id` now get `400` from dashboard-KPIs and low-stock endpoints; pass an explicit org header to aggregate.
- Intentionally unchanged (documented as accepted risks pending product decision): password reset and name/email admin updates mutate the GLOBAL user record after org-scoped authorization — affects users shared across organizations.
- Follow-ups noted in the policy doc: cash-registers and imports modules have no isolation specs yet.
