### PR TITLE
feat(auth): password policy and bcrypt cost hardening

### DIFF
--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -8,6 +8,7 @@ import {
 import * as bcrypt from 'bcryptjs';
 import * as crypto from 'crypto';
 import { PrismaService } from '../prisma/prisma.service';
+import { BCRYPT_ROUNDS } from '../common/constants/security.constants';
 import { AuthService } from '../auth/auth.service';
 import { CreateOrganizationDto } from './dto/create-organization.dto';
 import { UpdateOrganizationStatusDto } from './dto/update-organization-status.dto';
@@ -49,7 +50,7 @@ export class AdminService {
         } else {
           tempPassword =
             dto.admin.password || crypto.randomBytes(8).toString('hex');
-          const hashedPassword = await bcrypt.hash(tempPassword, 10);
+          const hashedPassword = await bcrypt.hash(tempPassword, BCRYPT_ROUNDS);
 
           adminUser = await tx.user.create({
             data: {
@@ -420,7 +421,7 @@ export class AdminService {
 
     if (!user) {
       tempPassword = dto.password || crypto.randomBytes(8).toString('hex');
-      const hashedPassword = await bcrypt.hash(tempPassword, 10);
+      const hashedPassword = await bcrypt.hash(tempPassword, BCRYPT_ROUNDS);
 
       user = await this.prisma.user.create({
         data: {

--- a/backend/src/admin/dto/add-organization-member.dto.ts
+++ b/backend/src/admin/dto/add-organization-member.dto.ts
@@ -5,9 +5,9 @@ import {
   IsOptional,
   IsString,
   MaxLength,
-  MinLength,
 } from 'class-validator';
 import { OrgRole } from '@prisma/client';
+import { IsValidPassword } from '../../common/validators/password.policy';
 
 export class AddOrganizationMemberDto {
   @IsEmail()
@@ -23,6 +23,6 @@ export class AddOrganizationMemberDto {
 
   @IsString()
   @IsOptional()
-  @MinLength(6)
+  @IsValidPassword()
   password?: string;
 }

--- a/backend/src/admin/dto/create-organization.dto.ts
+++ b/backend/src/admin/dto/create-organization.dto.ts
@@ -10,6 +10,7 @@ import {
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { PlanType } from '@prisma/client';
+import { IsValidPassword } from '../../common/validators/password.policy';
 
 class CreateAdminDto {
   @IsString()
@@ -22,7 +23,7 @@ class CreateAdminDto {
 
   @IsString()
   @IsOptional()
-  @MinLength(6)
+  @IsValidPassword()
   password?: string;
 }
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -9,6 +9,7 @@ import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcryptjs';
 import * as crypto from 'crypto';
 import { PrismaService } from '../prisma/prisma.service';
+import { BCRYPT_ROUNDS } from '../common/constants/security.constants';
 import {
   LoginDto,
   RegisterDto,
@@ -35,7 +36,7 @@ export class AuthService {
       throw new ConflictException('User already exists');
     }
 
-    const hashedPassword = await bcrypt.hash(password, 10);
+    const hashedPassword = await bcrypt.hash(password, BCRYPT_ROUNDS);
 
     const user = await this.prisma.user.create({
       data: {
@@ -467,7 +468,7 @@ export class AuthService {
       throw new BadRequestException('Current password is incorrect');
     }
 
-    const hashedPassword = await bcrypt.hash(newPassword, 10);
+    const hashedPassword = await bcrypt.hash(newPassword, BCRYPT_ROUNDS);
 
     await this.prisma.user.update({
       where: { id: userId },

--- a/backend/src/auth/dto/auth.dto.ts
+++ b/backend/src/auth/dto/auth.dto.ts
@@ -7,8 +7,8 @@ import {
   IsOptional,
   IsUUID,
   IsNotEmpty,
-  Matches,
 } from 'class-validator';
+import { IsValidPassword } from '../../common/validators/password.policy';
 
 export class LoginDto {
   @ApiProperty({ example: 'admin@example.com' })
@@ -35,9 +35,15 @@ export class RegisterDto {
   @IsEmail()
   email: string;
 
-  @ApiProperty({ example: 'password123', minLength: 6 })
+  @ApiProperty({
+    example: 'correct-horse-battery-staple',
+    description:
+      'New password (min 10 chars, must not be a commonly breached password)',
+    minLength: 10,
+    maxLength: 128,
+  })
   @IsString()
-  @MinLength(6)
+  @IsValidPassword()
   password: string;
 
   @ApiProperty({ example: 'John Doe' })
@@ -50,9 +56,15 @@ export class CreateUserDto {
   @IsEmail()
   email: string;
 
-  @ApiProperty({ example: 'password123', minLength: 6 })
+  @ApiProperty({
+    example: 'correct-horse-battery-staple',
+    description:
+      'New password (min 10 chars, must not be a commonly breached password)',
+    minLength: 10,
+    maxLength: 128,
+  })
   @IsString()
-  @MinLength(6)
+  @IsValidPassword()
   password: string;
 
   @ApiProperty({ example: 'John Doe' })
@@ -84,13 +96,15 @@ export class ChangePasswordDto {
   @IsString()
   currentPassword: string;
 
-  @ApiProperty({ example: 'newPassword123' })
-  @IsString()
-  @MinLength(6)
-  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/, {
-    message:
-      'Password must contain at least one uppercase letter, one lowercase letter, and one number',
+  @ApiProperty({
+    example: 'correct-horse-battery-staple',
+    description:
+      'New password (min 10 chars, must not be a commonly breached password)',
+    minLength: 10,
+    maxLength: 128,
   })
+  @IsString()
+  @IsValidPassword()
   newPassword: string;
 }
 
@@ -104,17 +118,14 @@ export class AdminResetPasswordDto {
   userId: string;
 
   @ApiProperty({
-    example: 'NewSecure1Pass',
+    example: 'correct-horse-battery-staple',
     description:
-      'New password (min 8 chars, must contain uppercase, lowercase, and number)',
-    minLength: 8,
+      'New password (min 10 chars, must not be a commonly breached password)',
+    minLength: 10,
+    maxLength: 128,
   })
   @IsString()
-  @MinLength(8)
-  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/, {
-    message:
-      'Password must contain at least one uppercase letter, one lowercase letter, and one number',
-  })
+  @IsValidPassword()
   newPassword: string;
 }
 

--- a/backend/src/common/constants/security.constants.ts
+++ b/backend/src/common/constants/security.constants.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared security constants.
+ *
+ * BCRYPT_ROUNDS is the single source of truth for the bcrypt cost factor
+ * used whenever a password hash is created. Verification auto-detects the
+ * cost embedded in each hash, so raising this value keeps existing hashes
+ * valid; they are upgraded to the new cost the next time a user sets a
+ * new password.
+ */
+export const BCRYPT_ROUNDS = 12;

--- a/backend/src/common/validators/password.policy.spec.ts
+++ b/backend/src/common/validators/password.policy.spec.ts
@@ -1,0 +1,193 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import {
+  PASSWORD_MAX_LENGTH,
+  PASSWORD_MIN_LENGTH,
+  validatePasswordPolicy,
+} from './password.policy';
+import { ChangePasswordDto, RegisterDto } from '../../auth/dto/auth.dto';
+import { CreateUserDto } from '../../users/dto/create-user.dto';
+import { ResetUserPasswordDto } from '../../users/dto/reset-user-password.dto';
+import { CreateOrganizationDto } from '../../admin/dto/create-organization.dto';
+import { AddOrganizationMemberDto } from '../../admin/dto/add-organization-member.dto';
+
+describe('validatePasswordPolicy', () => {
+  it('rejects passwords shorter than the minimum length', () => {
+    expect(validatePasswordPolicy('Pass123')).toBe(
+      `Password must be at least ${PASSWORD_MIN_LENGTH} characters`,
+    );
+  });
+
+  it('accepts a password of exactly the minimum length', () => {
+    expect(validatePasswordPolicy('luna-sol-1')).toBeNull();
+  });
+
+  it('rejects top-common passwords case-insensitively', () => {
+    expect(validatePasswordPolicy('PASSWORD123')).toBe(
+      'This password is too common',
+    );
+    expect(validatePasswordPolicy('QwertyUiop')).toBe(
+      'This password is too common',
+    );
+    expect(validatePasswordPolicy('Welcome123')).toBe(
+      'This password is too common',
+    );
+  });
+
+  it('rejects passwords longer than the maximum length', () => {
+    expect(validatePasswordPolicy('a'.repeat(PASSWORD_MAX_LENGTH + 1))).toBe(
+      `Password must not exceed ${PASSWORD_MAX_LENGTH} characters`,
+    );
+  });
+
+  it('accepts a password of exactly the maximum length', () => {
+    expect(validatePasswordPolicy('a'.repeat(PASSWORD_MAX_LENGTH))).toBeNull();
+  });
+
+  it('accepts a strong passphrase without composition rules', () => {
+    expect(validatePasswordPolicy('correct-horse-battery-staple')).toBeNull();
+  });
+
+  it('rejects non-string values defensively', () => {
+    expect(validatePasswordPolicy(null)).toBe('Password must be a string');
+    expect(validatePasswordPolicy(1234567890)).toBe(
+      'Password must be a string',
+    );
+  });
+});
+
+describe('password policy DTO enforcement', () => {
+  const strongPassword = 'correct-horse-battery-staple';
+
+  function passwordConstraintOf(errors: Record<string, unknown>[]) {
+    return errors
+      .filter((error) => error['property'] === 'password')
+      .flatMap((error) => error['constraints']);
+  }
+
+  it('enforces the policy on RegisterDto.password', async () => {
+    const dto = plainToInstance(RegisterDto, {
+      email: 'user@example.com',
+      name: 'John Doe',
+      password: 'short',
+    });
+
+    const errors = await validate(dto);
+
+    expect(passwordConstraintOf(errors as never)).toEqual([
+      { isValidPassword: 'Password must be at least 10 characters' },
+    ]);
+  });
+
+  it('accepts a policy-compliant RegisterDto', async () => {
+    const dto = plainToInstance(RegisterDto, {
+      email: 'user@example.com',
+      name: 'John Doe',
+      password: strongPassword,
+    });
+
+    expect(await validate(dto)).toEqual([]);
+  });
+
+  it('enforces the policy on ChangePasswordDto.newPassword only', async () => {
+    const weakNewPassword = plainToInstance(ChangePasswordDto, {
+      currentPassword: 'whatever-current',
+      newPassword: 'password123',
+    });
+
+    const errors = await validate(weakNewPassword);
+    const newPasswordError = errors.find(
+      (error) => error.property === 'newPassword',
+    );
+
+    expect(newPasswordError?.constraints?.isValidPassword).toBe(
+      'This password is too common',
+    );
+
+    // The current-password field is a verification input, not a new secret:
+    // it must never be rejected for failing the set-policy.
+    const verificationOnly = plainToInstance(ChangePasswordDto, {
+      currentPassword: 'legacy',
+      newPassword: strongPassword,
+    });
+
+    const verificationErrors = await validate(verificationOnly);
+    expect(
+      verificationErrors.filter((error) => error.property === 'currentPassword'),
+    ).toEqual([]);
+  });
+
+  it('enforces the policy on the users module CreateUserDto.password', async () => {
+    const dto = plainToInstance(CreateUserDto, {
+      email: 'user@example.com',
+      name: 'John Doe',
+      password: 'abc123',
+    });
+
+    const errors = await validate(dto);
+    const passwordError = errors.find((error) => error.property === 'password');
+
+    expect(passwordError?.constraints?.isValidPassword).toBe(
+      'Password must be at least 10 characters',
+    );
+  });
+
+  it('enforces the policy on ResetUserPasswordDto.newPassword', async () => {
+    const dto = plainToInstance(ResetUserPasswordDto, {
+      newPassword: 'PASSWORD123',
+    });
+
+    const errors = await validate(dto);
+    const passwordError = errors.find(
+      (error) => error.property === 'newPassword',
+    );
+
+    expect(passwordError?.constraints?.isValidPassword).toBe(
+      'This password is too common',
+    );
+  });
+
+  it('enforces the policy on the nested admin password of CreateOrganizationDto', async () => {
+    const dto = plainToInstance(CreateOrganizationDto, {
+      name: 'Org',
+      slug: 'org',
+      admin: {
+        name: 'Admin',
+        email: 'admin@example.com',
+        password: 'short',
+      },
+    });
+
+    const errors = await validate(dto);
+    const adminError = errors.find((error) => error.property === 'admin');
+    const passwordChild = adminError?.children?.find(
+      (error) => error.property === 'password',
+    );
+
+    expect(passwordChild?.constraints?.isValidPassword).toBe(
+      'Password must be at least 10 characters',
+    );
+  });
+
+  it('keeps AddOrganizationMemberDto.password optional but validated when present', async () => {
+    const withoutPassword = plainToInstance(AddOrganizationMemberDto, {
+      email: 'member@example.com',
+      role: 'CASHIER',
+    });
+
+    expect(await validate(withoutPassword)).toEqual([]);
+
+    const withWeakPassword = plainToInstance(AddOrganizationMemberDto, {
+      email: 'member@example.com',
+      role: 'CASHIER',
+      password: 'password123',
+    });
+
+    const errors = await validate(withWeakPassword);
+    const passwordError = errors.find((error) => error.property === 'password');
+
+    expect(passwordError?.constraints?.isValidPassword).toBe(
+      'This password is too common',
+    );
+  });
+});

--- a/backend/src/common/validators/password.policy.ts
+++ b/backend/src/common/validators/password.policy.ts
@@ -1,0 +1,210 @@
+import {
+  ValidationArguments,
+  ValidationOptions,
+  registerDecorator,
+} from 'class-validator';
+
+/**
+ * Password policy (issue #48, Slice B).
+ *
+ * Modern NIST guidance: length plus a denylist of breached/common
+ * passwords beats composition-rule theater. No uppercase/digit/symbol
+ * requirements are enforced on purpose.
+ */
+export const PASSWORD_MIN_LENGTH = 10;
+export const PASSWORD_MAX_LENGTH = 128;
+
+/**
+ * Embedded denylist of the most common leaked passwords. Comparison is
+ * done against the lowercased password. Short entries are kept for
+ * defense in depth even though the minimum length already rejects them.
+ */
+export const COMMON_PASSWORDS: readonly string[] = [
+  // Numeric sequences
+  '123456',
+  '123456789',
+  '12345678',
+  '1234567',
+  '1234567890',
+  '000000',
+  '111111',
+  '121212',
+  '123123',
+  '112233',
+  // More numeric patterns
+  '654321',
+  '666666',
+  '696969',
+  '123321',
+  '159753',
+  '987654321',
+  '102030',
+  '1234321',
+  '147258369',
+  '1123581321',
+  // Keyboard walks
+  'qwerty',
+  'qwertyuiop',
+  'qazwsx',
+  'qazwsxedc',
+  'zaq12wsx',
+  '1q2w3e4r',
+  '1q2w3e4r5t',
+  '1qaz2wsx',
+  'asdfgh',
+  'zxcvbnm',
+  // Classic passwords and variants
+  'abc123',
+  'abc123456',
+  'iloveyou',
+  'iloveu',
+  'password',
+  'password1',
+  'password123',
+  'passw0rd',
+  'p@ssw0rd',
+  'passwd',
+  // Administrative defaults
+  'admin',
+  'admin123',
+  'administrator',
+  'root',
+  'toor',
+  'guest',
+  'test',
+  'welcome',
+  'welcome1',
+  'welcome123',
+  'letmein',
+  // Common dictionary choices
+  'login',
+  'monkey',
+  'dragon',
+  'sunshine',
+  'princess',
+  'football',
+  'baseball',
+  'basketball',
+  'soccer',
+  'hockey',
+  'master',
+  'shadow',
+  'superman',
+  'batman',
+  'spiderman',
+  'trustno1',
+  'freedom',
+  'whatever',
+  'secret',
+  'summer',
+  'winter',
+  'love',
+  'angel',
+  'family',
+  'money',
+  'diamond',
+  'killer',
+  'hunter',
+  'jordan',
+  'michael',
+  // Frequent first names
+  'jennifer',
+  'jessica',
+  'charlie',
+  'thomas',
+  'robert',
+  'daniel',
+  'andrew',
+  'matthew',
+  'joshua',
+  'ashley',
+  // Pets, colors, food, brands
+  'maggie',
+  'chelsea',
+  'harley',
+  'ranger',
+  'buster',
+  'pepper',
+  'ginger',
+  'cookie',
+  'chocolate',
+  'coffee',
+  'flower',
+  'tigger',
+  'purple',
+  'silver',
+  'golden',
+  'banana',
+  'cheese',
+  'chicken',
+  'computer',
+  'google',
+];
+
+const commonPasswordSet = new Set(COMMON_PASSWORDS);
+
+/**
+ * Validates a candidate password against the shared policy.
+ *
+ * @returns A user-facing error message when the password is rejected,
+ *          or `null` when it complies with the policy.
+ */
+export function validatePasswordPolicy(password: unknown): string | null {
+  if (typeof password !== 'string') {
+    return 'Password must be a string';
+  }
+
+  if (password.length < PASSWORD_MIN_LENGTH) {
+    return `Password must be at least ${PASSWORD_MIN_LENGTH} characters`;
+  }
+
+  if (password.length > PASSWORD_MAX_LENGTH) {
+    return `Password must not exceed ${PASSWORD_MAX_LENGTH} characters`;
+  }
+
+  if (commonPasswordSet.has(password.toLowerCase())) {
+    return 'This password is too common';
+  }
+
+  return null;
+}
+
+/**
+ * class-validator decorator that enforces {@link validatePasswordPolicy}
+ * so DTOs reject weak passwords through the global ValidationPipe.
+ *
+ * Pair with `@IsOptional()` for optional fields; pair with `@IsString()`
+ * when a dedicated type error is preferred over the policy message.
+ */
+export function IsValidPassword(
+  validationOptions?: ValidationOptions,
+): PropertyDecorator {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isValidPassword',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown): boolean {
+          return validatePasswordPolicy(value) === null;
+        },
+        defaultMessage(validationArguments?: ValidationArguments): string {
+          const policyMessage = validatePasswordPolicy(
+            validationArguments?.value,
+          );
+          if (policyMessage) {
+            return policyMessage;
+          }
+
+          // ValidationOptions.message may also be a function; only inline
+          // string overrides are supported here.
+          const customMessage = validationOptions?.message;
+          return typeof customMessage === 'string'
+            ? customMessage
+            : 'Password does not meet the security policy';
+        },
+      },
+    });
+  };
+}

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -1,21 +1,22 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import {
-  IsEmail,
-  IsEnum,
-  IsOptional,
-  IsString,
-  MinLength,
-} from 'class-validator';
+import { IsEmail, IsEnum, IsOptional, IsString } from 'class-validator';
 import { OrgRole } from '@prisma/client';
+import { IsValidPassword } from '../../common/validators/password.policy';
 
 export class CreateUserDto {
   @ApiProperty({ example: 'user@example.com' })
   @IsEmail()
   email: string;
 
-  @ApiProperty({ example: 'password123', minLength: 6 })
+  @ApiProperty({
+    example: 'correct-horse-battery-staple',
+    description:
+      'New password (min 10 chars, must not be a commonly breached password)',
+    minLength: 10,
+    maxLength: 128,
+  })
   @IsString()
-  @MinLength(6)
+  @IsValidPassword()
   password: string;
 
   @ApiProperty({ example: 'John Doe' })

--- a/backend/src/users/dto/reset-user-password.dto.ts
+++ b/backend/src/users/dto/reset-user-password.dto.ts
@@ -1,18 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, Matches, MinLength } from 'class-validator';
+import { IsString } from 'class-validator';
+import { IsValidPassword } from '../../common/validators/password.policy';
 
 export class ResetUserPasswordDto {
   @ApiProperty({
-    example: 'NewSecure1Pass',
+    example: 'correct-horse-battery-staple',
     description:
-      'New password (min 8 chars, must contain uppercase, lowercase, and number)',
-    minLength: 8,
+      'New password (min 10 chars, must not be a commonly breached password)',
+    minLength: 10,
+    maxLength: 128,
   })
   @IsString()
-  @MinLength(8)
-  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/, {
-    message:
-      'Password must contain at least one uppercase letter, one lowercase letter, and one number',
-  })
+  @IsValidPassword()
   newPassword: string;
 }

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -51,7 +51,7 @@ describe('UsersService', () => {
 
     const result = await service.create({
       email: 'user@example.com',
-      password: 'password123',
+      password: 'S3cure-Passphrase-42',
       name: 'User One',
     });
 
@@ -73,6 +73,31 @@ describe('UsersService', () => {
       }),
     );
     expect(result).not.toHaveProperty('password');
+  });
+
+  it('hashes new passwords with the configured bcrypt cost', async () => {
+    prismaMock.user.findFirst.mockResolvedValue(null);
+    prismaMock.user.create.mockResolvedValue({
+      id: 'user-cost',
+      email: 'cost@example.com',
+      name: 'Cost Check',
+      active: true,
+      createdAt: new Date('2026-03-24T00:00:00.000Z'),
+      updatedAt: new Date('2026-03-24T00:00:00.000Z'),
+    });
+
+    await service.create({
+      email: 'cost@example.com',
+      password: 'S3cure-Passphrase-42',
+      name: 'Cost Check',
+    });
+
+    const invocation = prismaMock.user.create.mock.calls[0][0] as {
+      data: { password: string };
+    };
+
+    // bcrypt embeds the cost factor in the hash prefix ($2a$12$...).
+    expect(invocation.data.password).toMatch(/^\$2[aby]\$12\$/);
   });
 
   it('rejects duplicate emails on update', async () => {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/common';
 import * as bcrypt from 'bcryptjs';
 import { PrismaService } from '../prisma/prisma.service';
+import { BCRYPT_ROUNDS } from '../common/constants/security.constants';
 import { OrgRole } from '@prisma/client';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -54,7 +55,7 @@ export class UsersService {
 
     await this.ensureEmailAvailable(email);
 
-    const hashedPassword = await bcrypt.hash(password, 10);
+    const hashedPassword = await bcrypt.hash(password, BCRYPT_ROUNDS);
 
     const createdUser = await this.prisma.user.create({
       data: {
@@ -210,7 +211,7 @@ export class UsersService {
     organizationId: string,
   ) {
     const targetUser = await this.findUserOrThrow(userId, organizationId);
-    const hashedPassword = await bcrypt.hash(dto.newPassword, 10);
+    const hashedPassword = await bcrypt.hash(dto.newPassword, BCRYPT_ROUNDS);
 
     await this.prisma.user.update({
       where: { id: userId },


### PR DESCRIPTION
Part of #48 (Slice B of 3 — password policy; transport hardening is PR #51, cookie sessions follow)

## Summary
- One shared policy enforced at every endpoint that SETS a password: min 10 chars, max 128, ~111-entry common-password denylist matched case-insensitively. No composition rules (NIST-aligned: length + denylist).
- New @IsValidPassword() class-validator decorator applied to all 8 password-set DTO fields across auth, users, and admin modules; login DTOs untouched.
- Bcrypt cost raised 10 -> 12 via single BCRYPT_ROUNDS constant at all 6 hash sites; existing hashes remain valid (bcrypt auto-detects cost on verify).

## Changes
| File | Change |
|------|--------|
| backend/src/common/validators/password.policy.ts (+spec) | New validator + decorator, 14 tests |
| backend/src/common/constants/security.constants.ts | New - BCRYPT_ROUNDS = 12 |
| auth/users/admin DTOs (6 files) | @IsValidPassword() replacing ad-hoc MinLength/Matches rules |
| auth.service.ts, users.service.ts, admin.service.ts | Hash with BCRYPT_ROUNDS |
| users.service.spec.ts | Fixture upgraded to valid password; new \[aby]\\$ hash-prefix assertion |

## Test plan
- [x] Focused: npx jest src/common src/auth src/users src/admin -> 13 suites / 164 tests green
- [x] Full suite: baseline-identical (only the 4 int suites fail without live PostgreSQL)
- [x] npm run build clean

## Behavior notes
- Existing weak passwords stay valid until each user changes them (by design).
- Frontend forms still allow short passwords client-side; users get clear 400 messages until a UX pass (noted for Slice C follow-up).
- prisma/seed.ts writes passwords directly bypassing DTOs - flagged as follow-up.