### PR TITLE
feat(auth): migrate frontend to in-memory token with cookie refresh

### DIFF
--- a/frontend/src/app/admin/organizations/page.tsx
+++ b/frontend/src/app/admin/organizations/page.tsx
@@ -243,12 +243,13 @@ export default function OrganizationsPage() {
                 label="Contraseña del admin"
                 type="password"
                 placeholder="Dejar vacío para generar automáticamente"
+                minLength={10}
                 value={formData.adminPassword}
                 onChange={(e) => setFormData({ ...formData, adminPassword: e.target.value })}
                 error={formErrors.adminPassword}
               />
               <p className="text-xs text-muted-foreground">
-                Si dejas este campo vacío, se generará una contraseña temporal automáticamente.
+                Si dejas este campo vacío, se generará una contraseña temporal automáticamente. Mínimo 10 caracteres.
               </p>
             </div>
           )}

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -47,8 +47,8 @@ export default function ProfilePage() {
       toast.error("Las contraseñas no coinciden");
       return;
     }
-    if (passwordData.newPassword.length < 6) {
-      toast.error("La contraseña debe tener al menos 6 caracteres");
+    if (passwordData.newPassword.length < 10) {
+      toast.error("La contraseña debe tener al menos 10 caracteres");
       return;
     }
     try {
@@ -171,7 +171,7 @@ export default function ProfilePage() {
                 value={passwordData.newPassword}
                 onChange={(e) => setPasswordData({ ...passwordData, newPassword: e.target.value })}
                 required
-                minLength={6}
+                minLength={10}
               />
               <Input
                 label="Confirmar Nueva Contraseña"
@@ -179,9 +179,9 @@ export default function ProfilePage() {
                 value={passwordData.confirmPassword}
                 onChange={(e) => setPasswordData({ ...passwordData, confirmPassword: e.target.value })}
                 required
-                minLength={6}
+                minLength={10}
               />
-              <p className="text-xs text-muted-foreground">Mínimo 6 caracteres</p>
+              <p className="text-xs text-muted-foreground">Mínimo 10 caracteres</p>
               <div className="flex justify-end pt-2 border-t border-primary/20">
                 <Button type="submit" loading={changePassword.isPending}>Cambiar Contraseña</Button>
               </div>

--- a/frontend/src/components/users/UsersManagementPage.tsx
+++ b/frontend/src/components/users/UsersManagementPage.tsx
@@ -279,7 +279,8 @@ export default function UsersPage() {
         <form onSubmit={handleCreate} className="space-y-4">
           <Input label="Nombre" value={formData.name} onChange={(e) => setFormData({ ...formData, name: e.target.value })} required />
           <Input label="Correo" type="email" value={formData.email} onChange={(e) => setFormData({ ...formData, email: e.target.value })} required />
-          <Input label="Contraseña" type="password" minLength={8} value={formData.password} onChange={(e) => setFormData({ ...formData, password: e.target.value })} required />
+          <Input label="Contraseña" type="password" minLength={10} value={formData.password} onChange={(e) => setFormData({ ...formData, password: e.target.value })} required />
+          <p className="text-xs text-muted-foreground">Mínimo 10 caracteres</p>
           <Select
             label="Rol"
             value={formData.role}
@@ -307,11 +308,12 @@ export default function UsersPage() {
             <Input
               label="Nueva contraseña"
               type="password"
-              minLength={8}
+              minLength={10}
               value={newPassword}
               onChange={(e) => setNewPassword(e.target.value)}
               required
             />
+            <p className="text-xs text-muted-foreground">Mínimo 10 caracteres</p>
             <div className="flex justify-end gap-3 border-t border-border/60 pt-4">
               <Button type="button" variant="secondary" onClick={() => setShowResetModal(false)}>Cancelar</Button>
               <Button type="submit" loading={resetPassword.isPending}>Guardar</Button>

--- a/frontend/src/contexts/AuthContext.session.test.tsx
+++ b/frontend/src/contexts/AuthContext.session.test.tsx
@@ -1,0 +1,368 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AuthProvider, useAuth } from "./AuthContext";
+import { api } from "@/lib/api";
+import { ToastProvider } from "./ToastContext";
+import {
+  getAccessToken,
+  clearAccessToken,
+} from "@/lib/session";
+
+const pushMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+  usePathname: () => "/",
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+  getApiErrorMessage: (error: unknown, fallback: string) =>
+    error instanceof Error ? error.message : fallback,
+}));
+
+const testUser = {
+  id: "user-1",
+  email: "ana@example.com",
+  name: "Ana Perez",
+  role: "ADMIN",
+  active: true,
+  organizationId: "org-b",
+};
+
+function TestHarness() {
+  const { user, loading, login, logout, switchOrganization, isAuthenticated } =
+    useAuth();
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="user">{user ? user.email : "anonymous"}</span>
+      <span data-testid="authenticated">{String(isAuthenticated)}</span>
+      <button onClick={() => void login("ana@example.com", "secret123")}>
+        Iniciar Sesion
+      </button>
+      <button onClick={logout}>Cerrar Sesion</button>
+      <button
+        onClick={() =>
+          void switchOrganization("org-b").catch(() => undefined)
+        }
+      >
+        Cambiar organizacion
+      </button>
+    </div>
+  );
+}
+
+function renderHarness() {
+  const queryClient = new QueryClient();
+  const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>
+        <AuthProvider>
+          <TestHarness />
+        </AuthProvider>
+      </ToastProvider>
+    </QueryClientProvider>
+  );
+  return { invalidateSpy };
+}
+
+/** Route api.post calls by URL so every test can control refresh/login/org flows. */
+function routePostBy(
+  handler: (
+    url: string,
+    body?: unknown
+  ) => Promise<{ data: unknown }> | Promise<never>
+) {
+  (api.post as ReturnType<typeof vi.fn>).mockImplementation((url: string, body?: unknown) =>
+    handler(url, body)
+  );
+}
+
+describe("AuthContext - in-memory session migration (issue #48 slice C2)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    clearAccessToken();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    clearAccessToken();
+  });
+
+  describe("login", () => {
+    it("stores the access token only in memory and keeps the user object as a display cache", async () => {
+      routePostBy(async (url) => {
+        if (url === "/auth/refresh") {
+          return Promise.reject(new Error("No refresh cookie"));
+        }
+        if (url === "/auth/login") {
+          return Promise.resolve({
+            data: { accessToken: "access-1", refreshToken: "refresh-1", user: testUser },
+          });
+        }
+        throw new Error(`Unexpected POST ${url}`);
+      });
+
+      renderHarness();
+
+      await userEvent.click(await screen.findByRole("button", { name: /Iniciar Sesion/i }));
+
+      await waitFor(() => {
+        expect(getAccessToken()).toBe("access-1");
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId("authenticated")).toHaveTextContent("true");
+      });
+
+      // Tokens never touch localStorage — only the display-cache user does.
+      expect(localStorage.getItem("token")).toBeNull();
+      expect(localStorage.getItem("refreshToken")).toBeNull();
+
+      const cachedUser = JSON.parse(localStorage.getItem("user") ?? "null");
+      expect(cachedUser).toMatchObject({ id: "user-1", email: "ana@example.com" });
+
+      expect(pushMock).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  describe("silent restore on mount", () => {
+    it("calls POST /auth/refresh then GET /auth/profile and restores the session in memory", async () => {
+      localStorage.setItem("user", JSON.stringify(testUser));
+
+      const callOrder: string[] = [];
+      routePostBy(async (url) => {
+        if (url === "/auth/refresh") {
+          callOrder.push("refresh");
+          return Promise.resolve({ data: { accessToken: "restored-token" } });
+        }
+        throw new Error(`Unexpected POST ${url}`);
+      });
+      (api.get as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+        if (url === "/auth/profile") {
+          callOrder.push("profile");
+          return Promise.resolve({
+            data: { ...testUser, email: "restored@example.com" },
+          });
+        }
+        throw new Error(`Unexpected GET ${url}`);
+      });
+
+      renderHarness();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("loading")).toHaveTextContent("false");
+      });
+      expect(screen.getByTestId("user")).toHaveTextContent("restored@example.com");
+      expect(getAccessToken()).toBe("restored-token");
+
+      // Refresh must run BEFORE the profile revalidation.
+      expect(callOrder).toEqual(["refresh", "profile"]);
+
+      // Display cache is refreshed with the validated profile.
+      const cachedUser = JSON.parse(localStorage.getItem("user") ?? "null");
+      expect(cachedUser).toMatchObject({ email: "restored@example.com" });
+    });
+
+    it("clears the display cache and stays logged out when the silent restore fails", async () => {
+      localStorage.setItem("user", JSON.stringify(testUser));
+
+      routePostBy(async (url) => {
+        if (url === "/auth/refresh") {
+          return Promise.reject(new Error("Refresh token expired"));
+        }
+        throw new Error(`Unexpected POST ${url}`);
+      });
+
+      renderHarness();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("loading")).toHaveTextContent("false");
+      });
+
+      expect(screen.getByTestId("user")).toHaveTextContent("anonymous");
+      expect(screen.getByTestId("authenticated")).toHaveTextContent("false");
+      expect(getAccessToken()).toBeNull();
+      // Stale display cache must not survive a dead session.
+      expect(localStorage.getItem("user")).toBeNull();
+      expect(api.get).not.toHaveBeenCalledWith("/auth/profile");
+    });
+  });
+
+  describe("logout", () => {
+    it("calls POST /auth/logout, clears the in-memory token and the user display cache, and redirects to /login", async () => {
+      routePostBy(async (url) => {
+        if (url === "/auth/refresh") {
+          return Promise.resolve({ data: { accessToken: "restore-token" } });
+        }
+        if (url === "/auth/logout") {
+          return Promise.resolve({ data: {} });
+        }
+        throw new Error(`Unexpected POST ${url}`);
+      });
+      (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: testUser,
+      });
+
+      renderHarness();
+
+      // Wait until the restored session is active before logging out.
+      await waitFor(() => {
+        expect(getAccessToken()).toBe("restore-token");
+      });
+
+      await userEvent.click(await screen.findByRole("button", { name: /Cerrar Sesion/i }));
+
+      expect(api.post).toHaveBeenCalledWith("/auth/logout");
+      expect(getAccessToken()).toBeNull();
+      expect(localStorage.getItem("user")).toBeNull();
+      await waitFor(() => {
+        expect(screen.getByTestId("authenticated")).toHaveTextContent("false");
+      });
+      expect(pushMock).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  describe("switchOrganization", () => {
+    it("calls POST /auth/select-org, stores the new token pair only in memory, invalidates non-admin queries, and redirects to /dashboard", async () => {
+      routePostBy(async (url) => {
+        if (url === "/auth/refresh") {
+          return Promise.resolve({ data: { accessToken: "restore-token" } });
+        }
+        if (url === "/auth/select-org") {
+          return Promise.resolve({
+            data: {
+              accessToken: "new-access-token",
+              refreshToken: "new-refresh-token",
+              user: { ...testUser, organizationId: "org-b" },
+            },
+          });
+        }
+        throw new Error(`Unexpected POST ${url}`);
+      });
+      (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({ data: testUser });
+
+      const { invalidateSpy } = renderHarness();
+
+      await waitFor(() => {
+        expect(getAccessToken()).toBe("restore-token");
+      });
+
+      await userEvent.click(await screen.findByRole("button", { name: /Cambiar organizacion/i }));
+
+      await waitFor(() => {
+        expect(api.post).toHaveBeenCalledWith("/auth/select-org", {
+          organizationId: "org-b",
+        });
+      });
+
+      // New tokens live in memory only; nothing sensitive is persisted.
+      await waitFor(() => {
+        expect(getAccessToken()).toBe("new-access-token");
+      });
+      expect(localStorage.getItem("token")).toBeNull();
+      expect(localStorage.getItem("refreshToken")).toBeNull();
+
+      // The user display cache IS persisted (non-sensitive).
+      const cachedUser = JSON.parse(localStorage.getItem("user") ?? "{}");
+      expect(cachedUser.organizationId).toBe("org-b");
+
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        predicate: expect.any(Function),
+      });
+
+      // Cast through unknown: the real Query predicate receives a full Query object.
+      const predicate = (
+        invalidateSpy.mock.calls[0]?.[0] as unknown as
+          | { predicate?: (query: { queryKey: readonly unknown[] }) => boolean }
+          | undefined
+      )?.predicate;
+      expect(predicate).toBeDefined();
+      expect(predicate?.({ queryKey: ["products"] })).toBe(true);
+      expect(predicate?.({ queryKey: ["sales"] })).toBe(true);
+      expect(predicate?.({ queryKey: ["admin", "organizations"] })).toBe(false);
+
+      expect(pushMock).toHaveBeenCalledWith("/dashboard");
+    });
+
+    it("does not invalidate queries, store tokens, or redirect when the switch fails", async () => {
+      routePostBy(async (url) => {
+        if (url === "/auth/refresh") {
+          return Promise.resolve({ data: { accessToken: "restore-token" } });
+        }
+        if (url === "/auth/select-org") {
+          return Promise.reject(new Error("Organization is suspended"));
+        }
+        throw new Error(`Unexpected POST ${url}`);
+      });
+      (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({ data: testUser });
+
+      const { invalidateSpy } = renderHarness();
+
+      await waitFor(() => {
+        expect(getAccessToken()).toBe("restore-token");
+      });
+
+      await userEvent.click(await screen.findByRole("button", { name: /Cambiar organizacion/i }));
+
+      await waitFor(() => {
+        expect(api.post).toHaveBeenCalledWith("/auth/select-org", {
+          organizationId: "org-b",
+        });
+      });
+
+      expect(invalidateSpy).not.toHaveBeenCalled();
+      expect(pushMock).not.toHaveBeenCalled();
+
+      // Previous session token remains untouched by the failed switch.
+      expect(getAccessToken()).toBe("restore-token");
+      expect(localStorage.getItem("token")).toBeNull();
+      expect(localStorage.getItem("refreshToken")).toBeNull();
+
+      await waitFor(() => {
+        expect(screen.getByText(/Organization is suspended/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  it("scrubs legacy token leftovers from localStorage on mount and never rewrites them", async () => {
+    // Simulate pre-migration leftovers: they must be removed, not reused.
+    localStorage.setItem("token", "legacy-leftover");
+    localStorage.setItem("refreshToken", "legacy-refresh");
+
+    routePostBy(async (url) => {
+      if (url === "/auth/refresh") {
+        return Promise.reject(new Error("No refresh cookie"));
+      }
+      if (url === "/auth/login") {
+        return Promise.resolve({
+          data: { accessToken: "access-1", refreshToken: "refresh-1", user: testUser },
+        });
+      }
+      throw new Error(`Unexpected POST ${url}`);
+    });
+
+    renderHarness();
+
+    await waitFor(() => {
+      expect(localStorage.getItem("token")).toBeNull();
+    });
+    expect(localStorage.getItem("refreshToken")).toBeNull();
+
+    await userEvent.click(await screen.findByRole("button", { name: /Iniciar Sesion/i }));
+
+    await waitFor(() => {
+      expect(getAccessToken()).toBe("access-1");
+    });
+    // Login keeps tokens out of localStorage entirely.
+    expect(localStorage.getItem("token")).toBeNull();
+    expect(localStorage.getItem("refreshToken")).toBeNull();
+  });
+});

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -9,7 +9,11 @@ import {
   useMemo,
 } from "react";
 import { api, getApiErrorMessage } from "@/lib/api";
-import { safeGetItem, safeSetItem, safeRemoveItem } from "@/lib/utils";
+import { safeSetItem, safeRemoveItem } from "@/lib/utils";
+import {
+  setAccessToken,
+  clearAccessToken,
+} from "@/lib/session";
 import { useRouter } from "next/navigation";
 import { OrganizationSelectModal } from "@/components/auth/OrganizationSelectModal";
 import { useToast } from "@/contexts/ToastContext";
@@ -40,6 +44,30 @@ interface PendingOrganizationSelection {
   organizations: Array<{ id: string; name: string; role: string; plan: string }>;
 }
 
+/**
+ * Auth responses keep returning tokens in the JSON body (dual-mode backend)
+ * while also setting httpOnly cookies. Only the access token is consumed and
+ * it is stored in memory only — the refresh token is never kept client-side.
+ */
+interface AuthTokenResponse {
+  accessToken?: string;
+  /** Legacy alias still accepted by some endpoints. */
+  token?: string;
+  refreshToken?: string;
+  user?: User;
+}
+
+/** localStorage key for the user object. Display cache only, NOT auth material. */
+const USER_DISPLAY_CACHE_KEY = "user";
+
+function extractAccessToken(payload: {
+  accessToken?: string;
+  token?: string;
+}): string | null {
+  const token = payload.accessToken ?? payload.token ?? null;
+  return token && token.trim() ? token : null;
+}
+
 interface AuthContextType {
   user: User | null;
   organization: Organization | null;
@@ -63,37 +91,42 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const { error: showError } = useToast();
 
   useEffect(() => {
-    const validateSession = async () => {
-      const token = safeGetItem("token");
-      const savedUser = safeGetItem("user");
+    const restoreSession = async () => {
+      // Migration scrub: legacy localStorage tokens are no longer read by the
+      // request layer, so remove any leftovers from previous versions.
+      safeRemoveItem("token");
+      safeRemoveItem("refreshToken");
 
-      if (!token || !savedUser) {
-        setLoading(false);
-        return;
-      }
-
+      // Silent restore: the httpOnly refresh_token cookie is the only
+      // persisted credential. Refresh -> in-memory token -> revalidate user.
       try {
-        JSON.parse(savedUser);
+        const response = await api.post<AuthTokenResponse>("/auth/refresh", {});
+        const accessToken = extractAccessToken(response.data);
+        if (!accessToken) {
+          throw new Error("No access token in refresh response");
+        }
+        setAccessToken(accessToken);
+
         const profileResponse = await api.get<User>("/auth/profile");
         setUser(profileResponse.data);
-        safeSetItem("user", JSON.stringify(profileResponse.data));
+        safeSetItem(USER_DISPLAY_CACHE_KEY, JSON.stringify(profileResponse.data));
       } catch {
-        safeRemoveItem("token");
-        safeRemoveItem("user");
+        clearAccessToken();
+        safeRemoveItem(USER_DISPLAY_CACHE_KEY);
         setUser(null);
       } finally {
         setLoading(false);
       }
     };
 
-    void validateSession();
+    void restoreSession();
   }, []);
 
   const login = useCallback(
     async (email: string, password: string) => {
       try {
         const response = await api.post<
-          | { accessToken: string; refreshToken: string; user: User }
+          | AuthTokenResponse
           | {
               requiresOrganizationSelection: true;
               preAuthToken: string;
@@ -119,14 +152,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           return;
         }
 
-        const token = data.accessToken;
-        safeSetItem("token", token);
-        safeSetItem("refreshToken", data.refreshToken);
+        // Access token in memory only — never persisted.
+        const accessToken = extractAccessToken(data);
+        const authenticatedUser = data.user;
+        if (!accessToken || !authenticatedUser) {
+          throw new Error("Invalid login response");
+        }
+        setAccessToken(accessToken);
 
-        setUser(data.user);
-        safeSetItem("user", JSON.stringify(data.user));
+        setUser(authenticatedUser);
+        safeSetItem(USER_DISPLAY_CACHE_KEY, JSON.stringify(authenticatedUser));
 
-        if (data.user.role === "SUPER_ADMIN") {
+        if (authenticatedUser.role === "SUPER_ADMIN") {
           router.push("/admin");
         } else {
           router.push("/dashboard");
@@ -143,21 +180,23 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     async (organizationId: string) => {
       if (!pendingSelection) return;
 
-      const response = await api.post<{
-        accessToken: string;
-        refreshToken: string;
-        user: User;
-      }>("/auth/select-organization", {
-        preAuthToken: pendingSelection.preAuthToken,
-        organizationId,
-      });
+      const response = await api.post<AuthTokenResponse>(
+        "/auth/select-organization",
+        {
+          preAuthToken: pendingSelection.preAuthToken,
+          organizationId,
+        }
+      );
 
-      const { accessToken, refreshToken, user: selectedUser } = response.data;
-
-      safeSetItem("token", accessToken);
-      safeSetItem("refreshToken", refreshToken);
+      // New token pair goes to memory only — never persisted.
+      const accessToken = extractAccessToken(response.data);
+      const selectedUser = response.data.user;
+      if (!accessToken || !selectedUser) {
+        throw new Error("Invalid select-organization response");
+      }
+      setAccessToken(accessToken);
       setUser(selectedUser);
-      safeSetItem("user", JSON.stringify(selectedUser));
+      safeSetItem(USER_DISPLAY_CACHE_KEY, JSON.stringify(selectedUser));
       setPendingSelection(null);
 
       if (selectedUser.role === "SUPER_ADMIN") {
@@ -172,17 +211,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const switchOrganization = useCallback(
     async (organizationId: string) => {
       try {
-        const response = await api.post<{
-          accessToken: string;
-          refreshToken: string;
-          user: User;
-        }>("/auth/select-org", { organizationId });
+        const response = await api.post<AuthTokenResponse>("/auth/select-org", {
+          organizationId,
+        });
 
-        const { accessToken, refreshToken, user: switchedUser } = response.data;
-
-        safeSetItem("token", accessToken);
-        safeSetItem("refreshToken", refreshToken);
-        safeSetItem("user", JSON.stringify(switchedUser));
+        // New token pair goes to memory only — never persisted.
+        const accessToken = extractAccessToken(response.data);
+        const switchedUser = response.data.user;
+        if (!accessToken || !switchedUser) {
+          throw new Error("Invalid select-org response");
+        }
+        setAccessToken(accessToken);
+        safeSetItem(USER_DISPLAY_CACHE_KEY, JSON.stringify(switchedUser));
         setUser(switchedUser);
 
         queryClient.invalidateQueries({
@@ -204,9 +244,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   );
 
   const logout = useCallback(() => {
-    safeRemoveItem("token");
-    safeRemoveItem("refreshToken");
-    safeRemoveItem("user");
+    // Best-effort server logout: revokes the refresh token and clears the
+    // httpOnly cookies. Errors are ignored — local cleanup happens anyway.
+    void api.post("/auth/logout").catch(() => undefined);
+    clearAccessToken();
+    safeRemoveItem(USER_DISPLAY_CACHE_KEY);
     setUser(null);
     setPendingSelection(null);
     router.push("/login");

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  AxiosError,
+  AxiosHeaders,
+  type AxiosInstance,
+  type AxiosResponse,
+  type InternalAxiosRequestConfig,
+} from "axios";
+import { ApiClient } from "./api";
+import {
+  getAccessToken,
+  setAccessToken,
+  clearAccessToken,
+} from "./session";
+
+type Adapter = (
+  config: InternalAxiosRequestConfig
+) => Promise<AxiosResponse>;
+
+function baseConfig(
+  url?: string
+): InternalAxiosRequestConfig {
+  return {
+    url,
+    headers: new AxiosHeaders(),
+  } as InternalAxiosRequestConfig;
+}
+
+function okResponse(
+  config: InternalAxiosRequestConfig = baseConfig(),
+  data: unknown = {}
+): AxiosResponse {
+  return { status: 200, statusText: "OK", data, headers: {}, config };
+}
+
+function error401(config: InternalAxiosRequestConfig): AxiosError {
+  const response = {
+    status: 401,
+    statusText: "Unauthorized",
+    data: {},
+    headers: {},
+    config,
+  } as AxiosResponse;
+  return new AxiosError(
+    "Request failed with status code 401",
+    AxiosError.ERR_BAD_RESPONSE,
+    config,
+    {},
+    response
+  );
+}
+
+describe("ApiClient interceptors - in-memory session + refresh flow (issue #48 slice C2)", () => {
+  let adapter: ReturnType<typeof vi.fn<Adapter>>;
+  let onSessionExpired: ReturnType<typeof vi.fn<() => void>>;
+  let axiosInstance: AxiosInstance;
+
+  beforeEach(() => {
+    adapter = vi.fn<Adapter>();
+    onSessionExpired = vi.fn<() => void>();
+    const client = new ApiClient(onSessionExpired);
+    axiosInstance = client.getAxiosInstance();
+    axiosInstance.defaults.adapter = adapter;
+    clearAccessToken();
+    document.cookie = "csrf_token=; Max-Age=0; path=/";
+  });
+
+  afterEach(() => {
+    clearAccessToken();
+    document.cookie = "csrf_token=; Max-Age=0; path=/";
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  describe("request interceptor", () => {
+    it("attaches the Bearer token from the in-memory session store and sends credentials", async () => {
+      setAccessToken("tok-1");
+      adapter.mockResolvedValue(okResponse());
+
+      await axiosInstance.get("/products");
+
+      const config = adapter.mock.calls[0][0] as InternalAxiosRequestConfig;
+      expect(config.headers?.get("Authorization")).toBe("Bearer tok-1");
+      expect(config.withCredentials).toBe(true);
+    });
+
+    it("does not attach an Authorization header when no token is in memory", async () => {
+      adapter.mockResolvedValue(okResponse());
+
+      await axiosInstance.get("/products");
+
+      const config = adapter.mock.calls[0][0] as InternalAxiosRequestConfig;
+      expect(config.headers?.get("Authorization")).toBeFalsy();
+    });
+
+    it("sends the x-csrf-token header on mutating requests when the csrf_token cookie exists", async () => {
+      document.cookie = "csrf_token=csrf-abc123; path=/";
+      adapter.mockResolvedValue(okResponse());
+
+      await axiosInstance.post("/sales", {});
+      await axiosInstance.get("/sales");
+
+      const postConfig = adapter.mock.calls[0][0] as InternalAxiosRequestConfig;
+      const getConfig = adapter.mock.calls[1][0] as InternalAxiosRequestConfig;
+      expect(postConfig.headers?.get("x-csrf-token")).toBe("csrf-abc123");
+      expect(getConfig.headers?.get("x-csrf-token")).toBeFalsy();
+    });
+  });
+
+  describe("response interceptor - refresh and retry", () => {
+    it("performs exactly one refresh and retries the original request once after a 401", async () => {
+      setAccessToken("stale-token");
+      adapter.mockImplementation(async (config) => {
+        if (config.url === "/orders") {
+          if (!config._retry) throw error401(config);
+          return okResponse(config, { items: ["fresh"] });
+        }
+        if (config.url === "/auth/refresh") {
+          return okResponse(config, { accessToken: "fresh-token" });
+        }
+        throw new Error(`Unexpected request to ${String(config.url)}`);
+      });
+
+      const response = await axiosInstance.get("/orders");
+
+      expect(response.data).toEqual({ items: ["fresh"] });
+
+      const urls = adapter.mock.calls.map((call) => call[0]?.url);
+      // Original -> single refresh -> single retry.
+      expect(urls).toEqual(["/orders", "/auth/refresh", "/orders"]);
+
+      const retryConfig = adapter.mock.calls[2][0] as InternalAxiosRequestConfig;
+      expect(retryConfig._retry).toBe(true);
+      expect(retryConfig.headers?.get("Authorization")).toBe("Bearer fresh-token");
+      expect(getAccessToken()).toBe("fresh-token");
+      expect(onSessionExpired).not.toHaveBeenCalled();
+    });
+
+    it("dedupes concurrent 401 responses into exactly one refresh request", async () => {
+      setAccessToken("stale-token");
+      const retried = new Set<string>();
+      adapter.mockImplementation(async (config) => {
+        if (config.url === "/auth/refresh") {
+          return okResponse(config, { accessToken: "fresh-token" });
+        }
+        if (typeof config.url === "string" && !retried.has(config.url)) {
+          retried.add(config.url);
+          throw error401(config);
+        }
+        return okResponse(config, { url: config.url });
+      });
+
+      const [a, b, c] = await Promise.all([
+        axiosInstance.get("/a"),
+        axiosInstance.get("/b"),
+        axiosInstance.get("/c"),
+      ]);
+
+      expect(a.data).toEqual({ url: "/a" });
+      expect(b.data).toEqual({ url: "/b" });
+      expect(c.data).toEqual({ url: "/c" });
+
+      const refreshCalls = adapter.mock.calls.filter(
+        (call) => call[0]?.url === "/auth/refresh"
+      );
+      expect(refreshCalls).toHaveLength(1);
+      expect(onSessionExpired).not.toHaveBeenCalled();
+    });
+
+    it("clears the session, removes the user display cache and redirects to /login when the refresh fails", async () => {
+      localStorage.setItem("user", JSON.stringify({ id: "user-1" }));
+      setAccessToken("stale-token");
+      adapter.mockImplementation(async (config) => {
+        if (config.url === "/auth/refresh") throw error401(config);
+        throw error401(config);
+      });
+
+      await expect(axiosInstance.get("/orders")).rejects.toThrow();
+
+      expect(getAccessToken()).toBeNull();
+      expect(localStorage.getItem("user")).toBeNull();
+      expect(onSessionExpired).toHaveBeenCalledTimes(1);
+
+      // The refresh itself must not be retried recursively.
+      const urls = adapter.mock.calls.map((call) => call[0]?.url);
+      expect(urls).toEqual(["/orders", "/auth/refresh"]);
+    });
+
+    it("does not trigger a refresh for pre-auth endpoints that return 401", async () => {
+      setAccessToken("tok-1");
+      adapter.mockImplementation(async (config) => {
+        if (config.url === "/auth/login") throw error401(config);
+        throw new Error(`Unexpected request to ${String(config.url)}`);
+      });
+
+      await expect(
+        axiosInstance.post("/auth/login", { email: "a@b.c", password: "nope" })
+      ).rejects.toThrow();
+
+      const refreshCalls = adapter.mock.calls.filter(
+        (call) => call[0]?.url === "/auth/refresh"
+      );
+      expect(refreshCalls).toHaveLength(0);
+      expect(onSessionExpired).not.toHaveBeenCalled();
+      expect(getAccessToken()).toBe("tok-1");
+    });
+
+    it("rejects without redirecting when the retried request fails again with 401", async () => {
+      setAccessToken("stale-token");
+      adapter.mockImplementation(async (config) => {
+        if (config.url === "/auth/refresh") {
+          return okResponse(config, { accessToken: "fresh-but-revoked" });
+        }
+        throw error401(config); // /orders keeps failing even after retry
+      });
+
+      await expect(axiosInstance.get("/orders")).rejects.toThrow();
+
+      const urls = adapter.mock.calls.map((call) => call[0]?.url);
+      expect(urls).toEqual(["/orders", "/auth/refresh", "/orders"]);
+      expect(onSessionExpired).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,13 +1,44 @@
-import axios, { AxiosInstance, AxiosError } from "axios";
-import { safeGetItem, safeRemoveItem } from "@/lib/utils";
+import axios, {
+  AxiosError,
+  AxiosInstance,
+  InternalAxiosRequestConfig,
+} from "axios";
+import { safeRemoveItem } from "@/lib/utils";
+import {
+  getAccessToken,
+  setAccessToken,
+  clearAccessToken,
+} from "@/lib/session";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001/api";
+const USER_DISPLAY_CACHE_KEY = "user";
+const LOGIN_PATH = "/login";
+
+/** Endpoints that must never trigger the refresh flow (they are pre-auth or own the session lifecycle). */
+const AUTH_EXCLUDED_URLS = new Set([
+  "/auth/login",
+  "/auth/select-organization",
+  "/auth/refresh",
+  "/auth/logout",
+]);
 
 type ApiErrorData = {
   message?: string | string[];
   error?: string | { message?: string | string[] };
   errors?: Array<{ message?: string }>;
 };
+
+/**
+ * Auth responses keep returning tokens in the JSON body (dual-mode backend)
+ * while also setting httpOnly cookies. Only the access token is consumed
+ * here; it goes straight to the in-memory session store.
+ */
+interface AuthTokenResponse {
+  accessToken?: string;
+  /** Legacy alias still accepted by some endpoints. */
+  token?: string;
+  refreshToken?: string;
+}
 
 export function getApiErrorMessage(error: unknown, fallback: string): string {
   if (axios.isAxiosError(error)) {
@@ -46,12 +77,43 @@ export function getApiErrorMessage(error: unknown, fallback: string): string {
   return fallback;
 }
 
-class ApiClient {
+// Custom per-request flags used by the refresh-and-retry flow.
+// InternalAxiosRequestConfig extends this interface, so both sides get the flags.
+declare module "axios" {
+  export interface AxiosRequestConfig {
+    _retry?: boolean;
+    _isRefreshCall?: boolean;
+  }
+}
+
+function readCookie(name: string): string | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(
+    new RegExp(`(?:^|;\\s*)${name}=([^;]*)`)
+  );
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+function defaultOnSessionExpired(): void {
+  if (typeof window !== "undefined") {
+    window.location.href = LOGIN_PATH;
+  }
+}
+
+export class ApiClient {
   private client: AxiosInstance;
 
-  constructor() {
+  /** Promise shared by concurrent 401s so only ONE /auth/refresh runs at a time. */
+  private refreshInProgress: Promise<string | null> | null = null;
+
+  constructor(
+    private readonly onSessionExpired: () => void = defaultOnSessionExpired
+  ) {
     this.client = axios.create({
       baseURL: API_URL,
+      // Cookies (access/refresh/csrf) must flow on every request, including
+      // cross-site calls to the API host.
+      withCredentials: true,
       headers: {
         "Content-Type": "application/json",
       },
@@ -59,7 +121,8 @@ class ApiClient {
 
     this.client.interceptors.request.use(
       (config) => {
-        const token = safeGetItem("token");
+        // Access token lives in memory only.
+        const token = getAccessToken();
         if (token) {
           config.headers.Authorization = `Bearer ${token}`;
         }
@@ -67,6 +130,18 @@ class ApiClient {
           const orgId = localStorage.getItem("selectedOrganizationId");
           if (orgId) {
             config.headers["X-Organization-Id"] = orgId;
+          }
+          // Defense-in-depth: send the readable CSRF cookie value on mutating
+          // requests. Harmless alongside Bearer (the backend CSRF guard only
+          // enforces when no Bearer header is present).
+          if (
+            config.method &&
+            ["post", "put", "patch", "delete"].includes(config.method)
+          ) {
+            const csrfToken = readCookie("csrf_token");
+            if (csrfToken) {
+              config.headers["x-csrf-token"] = csrfToken;
+            }
           }
         }
         return config;
@@ -77,14 +152,75 @@ class ApiClient {
     this.client.interceptors.response.use(
       (response) => response,
       (error: AxiosError) => {
-        if (error.response?.status === 401) {
-          safeRemoveItem("token");
-          safeRemoveItem("user");
-          window.location.href = "/login";
+        const config = error.config;
+
+        if (
+          error.response?.status !== 401 ||
+          !config ||
+          config._retry ||
+          config._isRefreshCall ||
+          AUTH_EXCLUDED_URLS.has(config.url ?? "")
+        ) {
+          return Promise.reject(error);
         }
-        return Promise.reject(error);
+
+        return this.refreshSession().then((newToken) => {
+          if (!newToken) {
+            // Refresh failed — the session is definitively dead.
+            safeRemoveItem(USER_DISPLAY_CACHE_KEY);
+            this.onSessionExpired();
+            return Promise.reject(error);
+          }
+          // Retry the original request exactly once with the fresh token.
+          // The request interceptor picks up the new Bearer automatically.
+          config._retry = true;
+          return this.client.request(config);
+        });
       }
     );
+  }
+
+  /**
+   * POST /auth/refresh using the httpOnly refresh_token cookie.
+   * Concurrent callers share a single in-flight promise (dedupe).
+   * Resolves with the new access token, or null when the refresh failed.
+   */
+  private refreshSession(): Promise<string | null> {
+    if (!this.refreshInProgress) {
+      const refreshPromise = this.client
+        .post<AuthTokenResponse>(
+          "/auth/refresh",
+          {},
+          { _isRefreshCall: true }
+        )
+        .then((response) => {
+          const token =
+            response.data.accessToken ??
+            response.data.token ??
+            null;
+          if (token) {
+            setAccessToken(token);
+            return token;
+          }
+          clearAccessToken();
+          return null;
+        })
+        .catch(() => {
+          clearAccessToken();
+          return null;
+        })
+        .finally(() => {
+          this.refreshInProgress = null;
+        });
+
+      this.refreshInProgress = refreshPromise;
+    }
+    return this.refreshInProgress;
+  }
+
+  /** Internal axios instance. Exposed for tests only — do not use in app code. */
+  getAxiosInstance(): AxiosInstance {
+    return this.client;
   }
 
   get<T = unknown>(url: string, params?: Record<string, unknown>) {

--- a/frontend/src/lib/session.ts
+++ b/frontend/src/lib/session.ts
@@ -1,0 +1,22 @@
+/**
+ * In-memory access token store.
+ *
+ * The access token lives ONLY in this module-scoped variable. It never
+ * touches localStorage, sessionStorage, or document.cookie, so XSS cannot
+ * exfiltrate persistent credentials. A full page reload intentionally loses
+ * the token; AuthContext restores the session silently through the httpOnly
+ * refresh_token cookie (POST /auth/refresh).
+ */
+let accessToken: string | null = null;
+
+export function getAccessToken(): string | null {
+  return accessToken;
+}
+
+export function setAccessToken(token: string): void {
+  accessToken = token;
+}
+
+export function clearAccessToken(): void {
+  accessToken = null;
+}


### PR DESCRIPTION
Part of #48 (Slice C2 — frontend session migration. MERGE AFTER #53: relies on backend dual-mode cookies and POST /auth/logout.)

## Summary
- Access token now lives ONLY in module scope (lib/session.ts) - it never touches localStorage, sessionStorage, or document.cookie. XSS can no longer exfiltrate a persistent credential.
- api.ts: withCredentials everywhere; Bearer from memory; x-csrf-token from the readable csrf_token cookie on mutations (defense-in-depth); 401 handler dedupes concurrent failures into ONE /auth/refresh call, retries the original request once, then clears session + redirects.
- AuthContext: silent restore on mount (refresh -> profile), legacy localStorage token keys scrubbed once on bootstrap, logout calls POST /auth/logout. user JSON stays as display cache only (not auth material).
- Password inputs now enforce minLength 10 with es-CO helper text (aligns with PR #52 server-side policy).
- Bonus: eliminates the 2 pre-existing TypeScript errors in AuthContext.switch.test.tsx (tsc now reports 0 errors project-wide).

## Changes
| File | Change |
|------|--------|
| lib/session.ts | New in-memory token store |
| lib/api.ts (+api.test.ts) | Interceptor rewrite; single-flight refresh + retry; 8 new tests |
| contexts/AuthContext.tsx | Memory-only flows, silent restore, legacy key scrub |
| AuthContext.session.test.tsx | Replaces deleted switch.test.tsx; 7 tests covering storage-absence, restore, logout |
| profile page, UsersManagementPage, admin orgs | minLength=10 password fields |

## Test plan
- [x] npx vitest run src/contexts src/lib -> 4 files / 19 tests green
- [x] Full suite: 189 passed / 5 failed - failures byte-identical to baseline (POS x2, Sales deep-link x2, admin spinner x1)
- [x] npx tsc --noEmit -> 0 errors
- [x] npm run build clean

## Behavior notes
- Deploy order matters: backend #53 first, then this. Frontend-first degrades gracefully (users re-login on reload).
- Multi-tab sessions each restore independently via their own refresh call - acceptable; noted as follow-up.
- Register page is a stub in this app (no form), so no register-side changes were needed.