### PR TITLE
fix(ui): fix BentoSelect popover clipping and standardize native selects

### DIFF
--- a/frontend/src/app/expenses/expenses-page.evidence.test.tsx
+++ b/frontend/src/app/expenses/expenses-page.evidence.test.tsx
@@ -211,6 +211,7 @@ describe("Expenses page evidence", () => {
     render(<ExpensesPage />);
 
     await user.click(screen.getByRole("button", { name: /Exportar/i }));
+    await user.click(screen.getByRole("button", { name: /Exportar archivo/i }));
 
     expect(exportDataMock).toHaveBeenCalledWith(
       "/exports/expenses",

--- a/frontend/src/app/expenses/page.tsx
+++ b/frontend/src/app/expenses/page.tsx
@@ -16,6 +16,7 @@ import { api, getApiErrorMessage } from "@/lib/api";
 import { formatCurrency, formatDate, getBogotaDateInputValue } from "@/lib/utils";
 import { Button } from "@/components/ui/Button";
 import { Pagination } from "@/components/ui/Pagination";
+import { BentoSelect } from "@/components/ui/BentoSelect";
 import { FilterBar } from "@/components/ui/FilterBar";
 import { Table, TableHeader, TableRow, TableCell } from "@/components/ui/Table";
 import { LoadingState } from "@/components/ui/LoadingState";
@@ -58,6 +59,7 @@ export default function ExpensesPage() {
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
   const [exportFormat, setExportFormat] = useState<"excel" | "csv">("excel");
+  const [showExportSection, setShowExportSection] = useState(false);
 
   const [formOpen, setFormOpen] = useState(false);
   const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
@@ -186,17 +188,36 @@ export default function ExpensesPage() {
             </p>
           </div>
           <div className="flex items-center gap-2 w-full sm:w-auto">
-            <select
-              aria-label="Formato de exportación"
-              value={exportFormat}
-              onChange={(e) =>
-                setExportFormat(e.target.value as "excel" | "csv")
-              }
-              className="h-8 px-2.5 rounded-lg text-xs font-semibold bg-muted/40 border border-border/60 text-foreground focus:outline-none focus:border-primary/50"
+            <Button
+              variant="ghost"
+              type="button"
+              onClick={() => setShowExportSection((current) => !current)}
+              className="shrink-0"
             >
-              <option value="excel">Excel</option>
-              <option value="csv">CSV</option>
-            </select>
+              <Download className="w-3.5 h-3.5" />
+              {showExportSection ? "Ocultar exportación" : "Exportar"}
+            </Button>
+            <Button type="button" onClick={openCreate} className="shrink-0">
+              <Plus className="w-4 h-4" /> Nuevo gasto
+            </Button>
+          </div>
+        </div>
+
+        {showExportSection && (
+          <div className="flex flex-col sm:flex-row sm:items-center gap-3 rounded-2xl border border-border/80 bg-card p-3 shadow-xs">
+            <span className="flex-1 text-sm text-muted-foreground">
+              Exporta las salidas del mes seleccionado.
+            </span>
+            <BentoSelect
+              value={exportFormat}
+              onChange={(value) => setExportFormat(value as "excel" | "csv")}
+              className="w-44"
+              placeholder="Formato de exportación"
+              options={[
+                { value: "excel", label: "Excel" },
+                { value: "csv", label: "CSV" },
+              ]}
+            />
             <Button
               variant="secondary"
               size="sm"
@@ -204,13 +225,10 @@ export default function ExpensesPage() {
               onClick={handleExport}
               className="shrink-0"
             >
-              <Download className="w-3.5 h-3.5" /> Exportar
-            </Button>
-            <Button type="button" onClick={openCreate} className="shrink-0">
-              <Plus className="w-4 h-4" /> Nuevo gasto
+              <Download className="w-3.5 h-3.5" /> Exportar archivo
             </Button>
           </div>
-        </div>
+        )}
 
         <ExpenseSummaryCards month={month} summary={summary} />
 
@@ -233,50 +251,51 @@ export default function ExpensesPage() {
                 }}
                 className="h-8 px-2 rounded-lg text-xs font-semibold bg-muted/40 border border-border/60 text-foreground focus:outline-none focus:border-primary/50"
               />
-              <select
+              <BentoSelect
                 value={categoryId}
-                onChange={(e) => {
+                onChange={(value) => {
                   setPage(1);
-                  setCategoryId(e.target.value);
+                  setCategoryId(value);
                 }}
-                className="h-8 px-2.5 rounded-lg text-xs font-semibold bg-muted/40 border border-border/60 text-foreground focus:outline-none focus:border-primary/50 max-w-[180px]"
-              >
-                <option value="">Todas las categorías</option>
-                {categories.map((category) => (
-                  <option key={category.id} value={category.id}>
-                    {category.name}
-                  </option>
-                ))}
-              </select>
-              <select
+                className="w-52"
+                placeholder="Todas las categorías"
+                options={[
+                  { value: "", label: "Todas las categorías" },
+                  ...categories.map((category) => ({
+                    value: category.id,
+                    label: category.name,
+                  })),
+                ]}
+              />
+              <BentoSelect
                 value={supplierId}
-                onChange={(e) => {
+                onChange={(value) => {
                   setPage(1);
-                  setSupplierId(e.target.value);
+                  setSupplierId(value);
                 }}
-                className="h-8 px-2.5 rounded-lg text-xs font-semibold bg-muted/40 border border-border/60 text-foreground focus:outline-none focus:border-primary/50 max-w-[180px]"
-              >
-                <option value="">Todos los proveedores</option>
-                {suppliers.map((supplier) => (
-                  <option key={supplier.id} value={supplier.id}>
-                    {supplier.name}
-                  </option>
-                ))}
-              </select>
-              <select
+                className="w-52"
+                placeholder="Todos los proveedores"
+                options={[
+                  { value: "", label: "Todos los proveedores" },
+                  ...suppliers.map((supplier) => ({
+                    value: supplier.id,
+                    label: supplier.name,
+                  })),
+                ]}
+              />
+              <BentoSelect
                 value={status}
-                onChange={(e) => {
+                onChange={(value) => {
                   setPage(1);
-                  setStatus(e.target.value as "" | ExpenseStatus);
+                  setStatus(value as "" | ExpenseStatus);
                 }}
-                className="h-8 px-2.5 rounded-lg text-xs font-semibold bg-muted/40 border border-border/60 text-foreground focus:outline-none focus:border-primary/50"
-              >
-                {STATUS_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
+                className="w-44"
+                placeholder="Todos los estados"
+                options={STATUS_OPTIONS.map((option) => ({
+                  value: option.value,
+                  label: option.label,
+                }))}
+              />
               {hasFilters && (
                 <button
                   onClick={clearFilters}

--- a/frontend/src/app/purchase-orders/page.tsx
+++ b/frontend/src/app/purchase-orders/page.tsx
@@ -12,6 +12,7 @@ import { PurchaseOrderStatusBadge } from "@/components/purchase-orders/PurchaseO
 import { LoadingState } from "@/components/ui/LoadingState";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { FilterBar } from "@/components/ui/FilterBar";
+import { BentoSelect } from "@/components/ui/BentoSelect";
 import { Table, TableHeader, TableRow, TableCell } from "@/components/ui/Table";
 import { Plus, Eye, ClipboardList, X } from "lucide-react";
 import { formatCurrency, formatDate } from "@/lib/utils";
@@ -107,35 +108,35 @@ export default function PurchaseOrdersPage() {
           searchPlaceholder="Buscar por N° OC o proveedor..."
           filterControls={
             <>
-              <select
+              <BentoSelect
                 value={supplierId}
-                onChange={(e) => {
+                onChange={(value) => {
                   setPage(1);
-                  setSupplierId(e.target.value);
+                  setSupplierId(value);
                 }}
-                className="h-8 px-2.5 rounded-lg text-xs font-semibold bg-muted/40 border border-border/60 text-foreground focus:outline-none focus:border-primary/50 max-w-[180px]"
-              >
-                <option value="">Todos los proveedores</option>
-                {suppliers.map((s) => (
-                  <option key={s.id} value={s.id}>
-                    {s.name}
-                  </option>
-                ))}
-              </select>
-              <select
+                className="w-52"
+                placeholder="Todos los proveedores"
+                options={[
+                  { value: "", label: "Todos los proveedores" },
+                  ...suppliers.map((s) => ({
+                    value: s.id,
+                    label: s.name,
+                  })),
+                ]}
+              />
+              <BentoSelect
                 value={status}
-                onChange={(e) => {
+                onChange={(value) => {
                   setPage(1);
-                  setStatus(e.target.value as "" | PurchaseOrderStatus);
+                  setStatus(value as "" | PurchaseOrderStatus);
                 }}
-                className="h-8 px-2.5 rounded-lg text-xs font-semibold bg-muted/40 border border-border/60 text-foreground focus:outline-none focus:border-primary/50"
-              >
-                {statusOptions.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </option>
-                ))}
-              </select>
+                className="w-44"
+                placeholder="Todos los estados"
+                options={statusOptions.map((opt) => ({
+                  value: opt.value,
+                  label: opt.label,
+                }))}
+              />
               <input
                 type="date"
                 value={dateFrom}

--- a/frontend/src/components/expenses/ExpenseFormModal.tsx
+++ b/frontend/src/components/expenses/ExpenseFormModal.tsx
@@ -179,7 +179,7 @@ export function ExpenseFormModal({ isOpen, onClose, expense }: Props) {
       isOpen={isOpen}
       onClose={onClose}
       title={expense ? "Editar gasto" : "Nuevo gasto"}
-      size="lg"
+      size="md"
     >
       <div className="space-y-5">
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
@@ -284,7 +284,7 @@ export function ExpenseFormModal({ isOpen, onClose, expense }: Props) {
               </Button>
             </div>
             <div className="space-y-3 p-4">
-              {rows.map((row, index) => (
+              {rows.map((row) => (
                 <div key={row.tempId} className="flex flex-wrap gap-2 items-end">
                   <div className="min-w-[120px] flex-1">
                     <CurrencyInput
@@ -299,31 +299,17 @@ export function ExpenseFormModal({ isOpen, onClose, expense }: Props) {
                       }
                     />
                   </div>
-                  <div>
-                    <label
-                      htmlFor={`${uid}-method-${row.tempId}`}
-                      className="mb-1 block text-[11px] font-semibold uppercase tracking-wide text-muted-foreground"
-                    >
-                      Método
-                    </label>
-                    <select
-                      id={`${uid}-method-${row.tempId}`}
-                      aria-label={`Método de pago ${index + 1}`}
-                      value={row.method}
-                      onChange={(e) =>
-                        updateRow(row.tempId, {
-                          method: e.target.value as ExpensePayment["method"],
-                        })
-                      }
-                      className="rounded-lg border border-border bg-card px-3 py-2 text-sm focus:outline-none focus:border-primary/50"
-                    >
-                      {PAYMENT_METHOD_OPTIONS.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
+                  <BentoSelect
+                    label="Método"
+                    value={row.method}
+                    onChange={(value) =>
+                      updateRow(row.tempId, {
+                        method: value as ExpensePayment["method"],
+                      })
+                    }
+                    className="w-32"
+                    options={PAYMENT_METHOD_OPTIONS}
+                  />
                   <div>
                     <label
                       htmlFor={`${uid}-paydate-${row.tempId}`}
@@ -371,27 +357,29 @@ export function ExpenseFormModal({ isOpen, onClose, expense }: Props) {
           <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             Comprobante
           </p>
-          {expense ? (
-            <ImageUpload
-              value={expense.receiptUrl ?? undefined}
-              onChange={() => {}}
-              onUpload={async (file) => {
-                const updated = await uploadReceipt.mutateAsync({
-                  id: expense.id,
-                  file,
-                });
-                return updated.receiptUrl ?? "";
-              }}
-            />
-          ) : (
-            <ImageUpload
-              onChange={() => {}}
-              onUpload={(file) => {
-                setPendingReceiptFile(file);
-                return Promise.resolve(URL.createObjectURL(file));
-              }}
-            />
-          )}
+          <div className="max-w-[200px]">
+            {expense ? (
+              <ImageUpload
+                value={expense.receiptUrl ?? undefined}
+                onChange={() => {}}
+                onUpload={async (file) => {
+                  const updated = await uploadReceipt.mutateAsync({
+                    id: expense.id,
+                    file,
+                  });
+                  return updated.receiptUrl ?? "";
+                }}
+              />
+            ) : (
+              <ImageUpload
+                onChange={() => {}}
+                onUpload={(file) => {
+                  setPendingReceiptFile(file);
+                  return Promise.resolve(URL.createObjectURL(file));
+                }}
+              />
+            )}
+          </div>
         </div>
 
         {error && (

--- a/frontend/src/components/purchase-orders/EditDraftModal.tsx
+++ b/frontend/src/components/purchase-orders/EditDraftModal.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import { Modal } from "@/components/ui/Modal";
 import { Button } from "@/components/ui/Button";
 import { CurrencyInput } from "@/components/ui/CurrencyInput";
+import { BentoSelect } from "@/components/ui/BentoSelect";
 import { useSuppliers } from "@/hooks/useSuppliers";
 import { useProducts } from "@/hooks/useProducts";
 import { useUpdatePurchaseOrder } from "@/hooks/usePurchaseOrders";
@@ -133,22 +134,15 @@ export function EditDraftModal({ order, isOpen, onClose }: Props) {
     >
       <div className="space-y-5">
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <div>
-            <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Proveedor
-            </label>
-            <select
-              value={supplierId}
-              onChange={(e) => setSupplierId(e.target.value)}
-              className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm focus:outline-none focus:border-primary/50"
-            >
-              {suppliers.map((s) => (
-                <option key={s.id} value={s.id}>
-                  {s.name}
-                </option>
-              ))}
-            </select>
-          </div>
+          <BentoSelect
+            label="Proveedor"
+            value={supplierId}
+            onChange={(value) => setSupplierId(value)}
+            options={suppliers.map((s) => ({
+              value: s.id,
+              label: s.name,
+            }))}
+          />
           <div>
             <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               Notas

--- a/frontend/src/components/ui/FilterBar.tsx
+++ b/frontend/src/components/ui/FilterBar.tsx
@@ -24,7 +24,7 @@ export function FilterBar({
   return (
     <div
       className={cn(
-        "rounded-2xl border border-border/80 bg-card p-1.5 shadow-xs overflow-hidden",
+        "rounded-2xl border border-border/80 bg-card p-1.5 shadow-xs overflow-visible",
         className,
       )}
     >


### PR DESCRIPTION
## Summary

Refactor de UI del design system Kinetic Bento. Arregla un bug de dropdowns y estandariza selects nativos a `BentoSelect`, compacta el modal de gastos y convierte el botón Exportar de /expenses en un toggle oculto como el importador.

### 🐛 Fix prioritario — dropdowns de /inventory no se veían
- `FilterBar` tenía `overflow-hidden`, que **recortaba el popover** del `BentoSelect`. Al migrar los dropdowns de /inventory a BentoSelect, el popover quedaba oculto.
- **Fix**: `FilterBar` ahora es `overflow-visible` → los popovers se ven correctamente. Es global (afecta /inventory, /categories, /sales, /expenses, /purchase-orders).

### Estandarización de selects
- **8 selects nativos** (azul del navegador) migrados a `BentoSelect`:
  - `/expenses`: formato de exportación + filtros (categoría, proveedor, estado).
  - `/purchase-orders`: filtros (proveedor, estado).
  - `ExpenseFormModal`: método de pago.
  - `EditDraftModal`: proveedor.
  - `/categories`: verificado, no tenía `<select>` nativo.

### Modal de Expenses compacto
- `size="lg"` → `size="md"`.
- `ImageUpload` de "Comprobante" acotado a `max-w-[200px]` (elimina el cuadrado vacío gigante).

### Botón Exportar oculto (tipo importador)
- `/expenses`: "Exportar" ahora es `Button variant="ghost"` que alterna (Exportar / Ocultar exportación) con panel inline (formato + botón de descarga). Lógica de `handleExport` intacta.

## Changes

| File | Change |
|------|--------|
| `frontend/src/components/ui/FilterBar.tsx` | `overflow-hidden` → `overflow-visible` (fix popover clipping) |
| `frontend/src/app/expenses/page.tsx` | BentoSelect en filtros + export ghost toggle |
| `frontend/src/app/purchase-orders/page.tsx` | BentoSelect en filtros |
| `frontend/src/components/expenses/ExpenseFormModal.tsx` | BentoSelect método + modal compacto |
| `frontend/src/components/purchase-orders/EditDraftModal.tsx` | BentoSelect proveedor |
| `frontend/src/app/expenses/expenses-page.evidence.test.tsx` | Alineado al flujo de export toggle |

## Test plan

- [x] `npm run build` → 29/29 green
- [x] `npm run test` → 38 files / 178 tests passed, exit 0
- [x] `npx tsc --noEmit` → sin errores nuevos

## Behavior notes

- El fix de `overflow-visible` en `FilterBar` es global y es el buscado: los popovers de BentoSelect ahora se ven en todas las páginas con FilterBar.
- Queda un `<select>` nativo fuera de alcance en `/purchase-orders/new/page.tsx` (~línea 159) — follow-up opcional.
