### PR TITLE
feat(ui): dashboard operational day panel — coherence + identity

### DIFF
--- a/frontend/src/app/dashboard/page.evidence.test.tsx
+++ b/frontend/src/app/dashboard/page.evidence.test.tsx
@@ -129,7 +129,7 @@ describe("Dashboard scope evidence (tasks moved, date filter removed)", () => {
     render(<DashboardPage />);
 
     expect(screen.getByText("Bienvenido, Ana")).toBeTruthy();
-    expect(screen.getByText("Ingresos Totales")).toBeTruthy();
+    expect(screen.getByText("Ventas hoy")).toBeTruthy();
     expect(screen.getByText("Ventas Completadas")).toBeTruthy();
     expect(screen.getByText("Productos Vendidos")).toBeTruthy();
 
@@ -137,6 +137,15 @@ describe("Dashboard scope evidence (tasks moved, date filter removed)", () => {
     expect(screen.queryByText("Filtro de fechas")).toBeNull();
     expect(screen.queryByText("API real")).toBeNull();
     expect(screen.queryByText("Historial")).toBeNull();
+  });
+
+  it("does not render a hardcoded sales goal, a fake curve or mislabeled 'Ayer vs Hoy' (DIA-4/DIA-13)", () => {
+    render(<DashboardPage />);
+
+    expect(screen.queryByText(/1,500/)).toBeNull();
+    expect(screen.queryByText(/Meta:/)).toBeNull();
+    expect(screen.queryByText("Ayer vs Hoy")).toBeNull();
+    expect(screen.queryByText(/Q50,70/)).toBeNull();
   });
 
   it("renders empty sold-products state safely", () => {

--- a/frontend/src/app/dashboard/page.evidence.test.tsx
+++ b/frontend/src/app/dashboard/page.evidence.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import type { DashboardData } from "@/types";
@@ -7,6 +7,9 @@ import type { DashboardData } from "@/types";
 const pushMock = vi.fn();
 const useDashboardMock = vi.fn();
 const useDailySalesMock = vi.fn();
+const useLowStockMock = vi.fn();
+const useExpensesMock = vi.fn();
+const useTasksMock = vi.fn();
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: pushMock }),
@@ -32,6 +35,18 @@ vi.mock("@/contexts/AuthContext", () => ({
   useAuth: () => ({
     user: { id: "user-1", name: "Ana Admin", role: "ADMIN" },
   }),
+}));
+
+vi.mock("@/hooks/useProducts", () => ({
+  useLowStockProducts: () => useLowStockMock(),
+}));
+
+vi.mock("@/hooks/useExpenses", () => ({
+  useExpenses: (params: unknown) => useExpensesMock(params),
+}));
+
+vi.mock("@/hooks/useTasks", () => ({
+  useTasks: () => useTasksMock(),
 }));
 
 import DashboardPage from "./page";
@@ -79,30 +94,7 @@ function makeDashboardData(input: Partial<DashboardData>): DashboardData {
   };
 }
 
-function makeSalesWithOneItem(count: number) {
-  return Array.from({ length: count }, (_, index) => {
-    const itemNumber = index + 1;
-    const day = String(itemNumber).padStart(2, "0");
-    return {
-      id: `sale-${itemNumber}`,
-      saleNumber: 100 + itemNumber,
-      total: 10000 * itemNumber,
-      status: "COMPLETED",
-      createdAt: `2026-01-${day}T12:00:00.000Z`,
-      customer: { id: `customer-${itemNumber}`, name: `Cliente ${itemNumber}` },
-      items: [
-        {
-          id: `item-${itemNumber}`,
-          quantity: 1,
-          total: 10000 * itemNumber,
-          product: { id: `product-${itemNumber}`, name: `Producto ${itemNumber}` },
-        },
-      ],
-    };
-  });
-}
-
-describe("Dashboard scope evidence (tasks moved, date filter removed)", () => {
+describe("Dashboard scope evidence (DIA-4/13/10 — reports no longer duplicated)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -119,19 +111,25 @@ describe("Dashboard scope evidence (tasks moved, date filter removed)", () => {
       isLoading: false,
       error: null,
     });
+
+    useLowStockMock.mockReturnValue({ data: [] });
+    useExpensesMock.mockReturnValue({ data: { data: [], meta: { total: 0, page: 1, limit: 10, totalPages: 0 } } });
+    useTasksMock.mockReturnValue({ data: { tasks: [], source: "remote" } });
   });
 
   afterEach(() => {
     cleanup();
   });
 
-  it("renders KPI cards and sold-products table without legacy date/task widgets", () => {
+  it("renders KPI cards and operational panels without legacy date/task widgets", () => {
     render(<DashboardPage />);
 
     expect(screen.getByText("Bienvenido, Ana")).toBeTruthy();
     expect(screen.getByText("Ventas hoy")).toBeTruthy();
     expect(screen.getByText("Ventas Completadas")).toBeTruthy();
-    expect(screen.getByText("Productos Vendidos")).toBeTruthy();
+    expect(screen.getByText("Stock bajo")).toBeTruthy();
+    expect(screen.getByText("Gastos por pagar")).toBeTruthy();
+    expect(screen.getByText("Tareas abiertas")).toBeTruthy();
 
     expect(document.querySelectorAll('input[type="date"]').length).toBe(0);
     expect(screen.queryByText("Filtro de fechas")).toBeNull();
@@ -148,53 +146,35 @@ describe("Dashboard scope evidence (tasks moved, date filter removed)", () => {
     expect(screen.queryByText(/Q50,70/)).toBeNull();
   });
 
-  it("renders empty sold-products state safely", () => {
-    useDashboardMock.mockReturnValue({
-      data: makeDashboardData({
-        totalSales: 0,
-        totalRevenue: 0,
-        totalProducts: 0,
-        lowStockProducts: 0,
-        recentSales: [],
-      }),
-      isLoading: false,
-      error: null,
-    });
-
+  it("does not render the historical reports sections nor the sold-products table (DIA-10)", () => {
     render(<DashboardPage />);
 
-    expect(screen.getByText("No hay productos vendidos en este período")).toBeTruthy();
+    expect(screen.queryByText("Productos Vendidos")).toBeNull();
+    expect(screen.queryByText("Productos Más Vendidos")).toBeNull();
+    expect(screen.queryByText("Economía")).toBeNull();
+    expect(screen.queryByText("Caja y pagos")).toBeNull();
+    expect(screen.queryByText("Top Clientes")).toBeNull();
+    expect(screen.queryByText("Métodos de Pago")).toBeNull();
+    expect(screen.queryByText("Categorías")).toBeNull();
+    expect(screen.queryByText("Inventario actual")).toBeNull();
   });
 
-  it("routes to low-stock inventory filter from reorder CTA", async () => {
+  it("routes to low-stock inventory filter from the summary reorder CTA", async () => {
     render(<DashboardPage />);
 
     await userEvent.click(screen.getByRole("button", { name: "REORDENAR" }));
     expect(pushMock).toHaveBeenCalledWith("/inventory?filter=lowStock");
   });
 
-  it("paginates sold products list when there are more than ten items", async () => {
-    useDashboardMock.mockReturnValue({
-      data: makeDashboardData({
-        recentSales: makeSalesWithOneItem(11),
-      }),
-      isLoading: false,
-      error: null,
+  it("shows alert panels with real low-stock data from the hook", () => {
+    useLowStockMock.mockReturnValue({
+      data: [{ id: "p1", name: "Café", stock: 3 }],
     });
-
-    // The range summary lives in a <p> whose numbers are wrapped in nested <span>s,
-    // so assert on the combined textContent instead of a single text node.
-    const rangeText = (expected: string) => (_: string, element: Element | null) =>
-      (element?.textContent ?? "").replace(/\s+/g, " ").trim() === expected;
 
     render(<DashboardPage />);
 
-    expect(screen.getByText(rangeText("Mostrando 1 - 10 de 11"))).toBeTruthy();
-    expect(screen.getByText("1 / 2")).toBeTruthy();
-
-    await userEvent.click(screen.getByRole("button", { name: "Siguiente" }));
-
-    expect(screen.getByText(rangeText("Mostrando 11 - 11 de 11"))).toBeTruthy();
-    expect(screen.getByText("2 / 2")).toBeTruthy();
+    const item = screen.getByText("Café").closest("li");
+    expect(item).toBeTruthy();
+    expect(within(item as HTMLElement).getByText("3")).toBeTruthy();
   });
 });

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -3,28 +3,16 @@
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { DashboardLayout } from "@/components/layout/DashboardLayout";
-import { useDashboard, useDailySales } from "@/hooks/useReports";
+import { useDailySales, useDashboard } from "@/hooks/useReports";
 import { useCategories } from "@/hooks/useCategories";
-import {
-  Package,
-  ShoppingCart,
-  LayoutDashboard,
-  CheckCircle2,
-  AlertTriangle,
-  Users,
-} from "lucide-react";
-import {
-  formatCurrency,
-  getBogotaDateInputValue,
-  shiftDateInputValue,
-} from "@/lib/utils";
+import { Package, LayoutDashboard, CheckCircle2, AlertTriangle, Users } from "lucide-react";
+import { getBogotaDateInputValue, shiftDateInputValue } from "@/lib/utils";
 import { chartHeight } from "@/lib/dashboard";
 import { useAuth } from "@/contexts/AuthContext";
-import { Pagination } from "@/components/ui/Pagination";
 import { LoadingState } from "@/components/ui/LoadingState";
-import { EmptyState } from "@/components/ui/EmptyState";
-import { Table, TableHeader, TableRow, TableCell } from "@/components/ui/Table";
 import { TodayStats } from "@/components/dashboard/TodayStats";
+import { AlertPanels } from "@/components/dashboard/AlertPanels";
+import { QuickActions } from "@/components/dashboard/QuickActions";
 import {
   RevenueChart,
   type RevenueBarPoint,
@@ -40,7 +28,6 @@ export default function DashboardPage() {
   const { data: categoriesResponse } = useCategories({ page: 1, limit: 1 });
   const { user } = useAuth();
   const [now] = useState(() => new Date());
-  const [soldProductsPage, setSoldProductsPage] = useState(1);
 
   const chartEndDate = useMemo(() => getBogotaDateInputValue(now), [now]);
   const chartStartDate = useMemo(
@@ -121,38 +108,6 @@ export default function DashboardPage() {
   }, [chartEndDate, chartStartDate, dailySales?.data]);
 
   const totalCategories = categoriesResponse?.meta.total ?? 0;
-
-  // Convertir ventas recientes en filas de productos vendidos (1 fila por cada item)
-  const soldProductsList = useMemo(() => {
-    const sales = dashboard?.recentSales ?? [];
-    const items: Array<{
-      id: string;
-      productName: string;
-      quantity: number;
-      total: number;
-      customerName: string;
-      createdAt: string;
-    }> = [];
-
-    for (const sale of sales) {
-      for (const item of sale.items) {
-        items.push({
-          id: item.id,
-          productName: item.product.name,
-          quantity: item.quantity,
-          total: item.total,
-          customerName: sale.customer?.name || "General",
-          createdAt: sale.createdAt,
-        });
-      }
-    }
-
-    // Ordenar por fecha más reciente
-    return items.sort(
-      (a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-    );
-  }, [dashboard?.recentSales]);
 
   if (isLoading) {
     return (
@@ -304,99 +259,11 @@ export default function DashboardPage() {
           </div>
         </div>
 
-        {/* Productos Vendidos - Tabla con paginación */}
-        <div className="animate-fade-in rounded-3xl border border-primary/30 bg-primary/10 overflow-hidden">
-          <div className="flex items-center justify-between px-4 py-3 border-b border-primary/20">
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-primary/20 rounded-xl">
-                <ShoppingCart className="h-5 w-5 text-primary" />
-              </div>
-              <h3 className="text-base font-semibold text-foreground">
-                Productos Vendidos
-              </h3>
-            </div>
-            {soldProductsList.length > 0 && (
-              <span className="text-[10px] font-bold bg-primary/20 text-primary px-2 py-1 rounded-md uppercase tracking-wider">
-                {soldProductsList.length} items
-              </span>
-            )}
-          </div>
-          {soldProductsList.length === 0 ? (
-            <EmptyState icon={<Package className="w-6 h-6 text-muted-foreground/30" />} title="No hay productos vendidos en este período" />
-          ) : (
-            <>
-              <div className="overflow-x-auto">
-                <Table variant="primary" className="min-w-[520px]">
-                  <TableHeader>
-                    <TableRow>
-                      <TableCell as="th" className="text-left text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-                        Producto
-                      </TableCell>
-                      <TableCell as="th" className="text-center text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-                        Cantidad
-                      </TableCell>
-                      <TableCell as="th" className="text-left text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-                        Cliente
-                      </TableCell>
-                      <TableCell as="th" className="text-right text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-                        Total
-                      </TableCell>
-                      <TableCell as="th" className="text-right text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-                        Fecha
-                      </TableCell>
-                    </TableRow>
-                  </TableHeader>
-                  <tbody className="bg-background/50">
-                    {soldProductsList
-                      .slice((soldProductsPage - 1) * 10, soldProductsPage * 10)
-                      .map((item) => (
-                        <TableRow key={item.id}>
-                          <TableCell>
-                            <span className="text-sm font-medium text-foreground">
-                              {item.productName}
-                            </span>
-                          </TableCell>
-                          <TableCell className="text-center">
-                            <span className="text-sm font-bold text-primary">
-                              {item.quantity}
-                            </span>
-                          </TableCell>
-                          <TableCell>
-                            <span className="text-sm text-muted-foreground">
-                              {item.customerName}
-                            </span>
-                          </TableCell>
-                          <TableCell className="text-right">
-                            <span className="text-sm font-bold text-accent">
-                              {formatCurrency(item.total)}
-                            </span>
-                          </TableCell>
-                          <TableCell className="text-right text-muted-foreground whitespace-nowrap font-mono">
-                            {new Date(item.createdAt).toLocaleDateString(
-                              "es-CO",
-                            )}
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                  </tbody>
-                </Table>
-              </div>
-              {/* Paginación */}
-              {soldProductsList.length > 10 && (
-                <div className="px-4 py-3 border-t border-primary/20">
-                  <Pagination
-                    currentPage={soldProductsPage}
-                    totalPages={Math.ceil(soldProductsList.length / 10)}
-                    onPageChange={setSoldProductsPage}
-                    totalItems={soldProductsList.length}
-                    pageSize={10}
-                    itemLabel="producto"
-                  />
-                </div>
-              )}
-            </>
-          )}
-        </div>
+        {/* Quick actions by role (DIA-9) */}
+        <QuickActions />
+
+        {/* Operational alert panels (DIA-6..8) — replaces the reports-duplicating table */}
+        <AlertPanels />
       </div>
     </DashboardLayout>
   );

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -6,13 +6,9 @@ import { DashboardLayout } from "@/components/layout/DashboardLayout";
 import { useDashboard, useDailySales } from "@/hooks/useReports";
 import { useCategories } from "@/hooks/useCategories";
 import {
-  TrendingUp,
   Package,
   ShoppingCart,
-  ArrowUpRight,
-  ArrowDownRight,
   LayoutDashboard,
-  DollarSign,
   CheckCircle2,
   AlertTriangle,
   Users,
@@ -22,46 +18,20 @@ import {
   getBogotaDateInputValue,
   shiftDateInputValue,
 } from "@/lib/utils";
+import { chartHeight } from "@/lib/dashboard";
 import { useAuth } from "@/contexts/AuthContext";
 import { Pagination } from "@/components/ui/Pagination";
 import { LoadingState } from "@/components/ui/LoadingState";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Table, TableHeader, TableRow, TableCell } from "@/components/ui/Table";
+import { TodayStats } from "@/components/dashboard/TodayStats";
+import {
+  RevenueChart,
+  type RevenueBarPoint,
+} from "@/components/dashboard/RevenueChart";
 
 function capitalizeLabel(value: string) {
   return value ? `${value.charAt(0).toUpperCase()}${value.slice(1)}` : value;
-}
-
-function evaluateQuadraticY(
-  startY: number,
-  controlY: number,
-  endY: number,
-  t: number,
-) {
-  const invT = 1 - t;
-  return invT * invT * startY + 2 * invT * t * controlY + t * t * endY;
-}
-
-function getRevenueCurveYByIndex(index: number, pointCount: number) {
-  if (pointCount <= 1) {
-    return 80;
-  }
-
-  const x = (index / (pointCount - 1)) * 400;
-
-  if (x <= 100) {
-    return evaluateQuadraticY(80, 70, 85, x / 100);
-  }
-
-  if (x <= 200) {
-    return evaluateQuadraticY(85, 100, 60, (x - 100) / 100);
-  }
-
-  if (x <= 300) {
-    return evaluateQuadraticY(60, 20, 75, (x - 200) / 100);
-  }
-
-  return evaluateQuadraticY(75, 130, 40, (x - 300) / 100);
 }
 
 export default function DashboardPage() {
@@ -70,9 +40,6 @@ export default function DashboardPage() {
   const { data: categoriesResponse } = useCategories({ page: 1, limit: 1 });
   const { user } = useAuth();
   const [now] = useState(() => new Date());
-  const [hoveredRevenueKey, setHoveredRevenueKey] = useState<string | null>(
-    null,
-  );
   const [soldProductsPage, setSoldProductsPage] = useState(1);
 
   const chartEndDate = useMemo(() => getBogotaDateInputValue(now), [now]);
@@ -85,7 +52,6 @@ export default function DashboardPage() {
 
   const stats = {
     totalSales: dashboard?.totalSales ?? 0,
-    totalRevenue: dashboard?.totalRevenue ?? 0,
     totalProducts: dashboard?.totalProducts ?? 0,
     totalCustomers: dashboard?.totalCustomers ?? 0,
     lowStockProducts: dashboard?.lowStockProducts ?? 0,
@@ -96,7 +62,7 @@ export default function DashboardPage() {
     },
   };
 
-  const revenueBarData = useMemo(() => {
+  const revenueBarData = useMemo<RevenueBarPoint[]>(() => {
     const weekdayFormatter = new Intl.DateTimeFormat("es-CO", {
       weekday: "long",
       timeZone: "America/Bogota",
@@ -149,47 +115,12 @@ export default function DashboardPage() {
         detailDate: `${weekdayLabel} ${dayNumber}`,
         dayAbbreviation: weekdayLabel.slice(0, 3),
         monthLabel,
-        height:
-          daily.total === 0
-            ? 18
-            : Math.max(28, Math.round((daily.total / maxValue) * 100)),
+        height: chartHeight(daily.total, maxValue),
       };
     });
   }, [chartEndDate, chartStartDate, dailySales?.data]);
 
-  const hoveredRevenueIndex = useMemo(
-    () => revenueBarData.findIndex((bar) => bar.key === hoveredRevenueKey),
-    [hoveredRevenueKey, revenueBarData],
-  );
-
-  const hoveredRevenuePoint = useMemo(() => {
-    if (hoveredRevenueIndex < 0) {
-      return null;
-    }
-
-    const xPct = (hoveredRevenueIndex / (revenueBarData.length - 1)) * 100;
-    const yPct = getRevenueCurveYByIndex(
-      hoveredRevenueIndex,
-      revenueBarData.length,
-    );
-
-    return {
-      xPct,
-      yPct,
-    };
-  }, [hoveredRevenueIndex, revenueBarData.length]);
-
-  const hoveredRevenueBar =
-    hoveredRevenueIndex >= 0 ? revenueBarData[hoveredRevenueIndex] : null;
-
   const totalCategories = categoriesResponse?.meta.total ?? 0;
-
-  const formatTrend = (value: number | null) => {
-    const safeValue = value ?? 0;
-    const rounded = Math.abs(safeValue) < 0.05 ? 0 : safeValue;
-    const sign = rounded > 0 ? "+" : "";
-    return `${sign}${rounded.toFixed(1)}%`;
-  };
 
   // Convertir ventas recientes en filas de productos vendidos (1 fila por cada item)
   const soldProductsList = useMemo(() => {
@@ -244,170 +175,25 @@ export default function DashboardPage() {
           </div>
         </div>
 
-        {/* Dashboard Cards - Estilo Luminous Analyst */}
+        {/*
+          Today KPIs (Ventas hoy / Ticket promedio / Transacciones) —
+          source of truth is useDailySales(today, today), never the full-range
+          aggregate from useDashboard().totalRevenue (DIA-1..3, DIA-5).
+        */}
+        <TodayStats />
+
+        {/* Revenue chart — data-driven, no fake curve (DIA-11..13) */}
+        <div className="min-w-0 overflow-hidden rounded-3xl border border-primary/30 bg-primary/10 px-6 py-6 text-foreground">
+          <p className="text-xs font-bold uppercase tracking-[0.2em] text-muted-foreground">
+            Ingresos últimos 7 días
+          </p>
+          <div className="mt-6">
+            <RevenueChart data={revenueBarData} />
+          </div>
+        </div>
+
+        {/* Secondary summary cards */}
         <div className="grid grid-cols-1 gap-2.5 md:grid-cols-6 xl:grid-cols-12 stagger-children">
-          {/* Ingresos Totales - Grande */}
-          <div className="relative min-w-0 overflow-hidden rounded-3xl border border-accent/30 bg-accent/10 px-6 py-6 text-foreground md:col-span-8 xl:col-span-8">
-            <div className="absolute top-0 right-0 p-8 opacity-10 pointer-events-none">
-              <DollarSign className="text-8xl text-accent" />
-            </div>
-            <div className="z-10">
-              {/* Título y badge en esquina */}
-              <div className="flex justify-between items-start mb-2">
-                <p className="text-xs font-bold uppercase tracking-[0.2em] text-muted-foreground">
-                  Ingresos Totales
-                </p>
-                <span
-                  className={`flex items-center text-xs font-bold px-3 py-1 rounded-full ${
-                    (stats.trends.totalRevenue ?? 0) >= 0
-                      ? "bg-accent/20 text-accent"
-                      : "bg-rose-500/20 text-rose-500"
-                  }`}
-                >
-                  {(stats.trends.totalRevenue ?? 0) >= 0 ? (
-                    <ArrowUpRight className="h-3 w-3 mr-1" />
-                  ) : (
-                    <ArrowDownRight className="h-3 w-3 mr-1" />
-                  )}
-                  {formatTrend(stats.trends.totalRevenue)} Hoy
-                </span>
-              </div>
-              {/* Valor con moneda COP */}
-              <div className="flex items-baseline space-x-3">
-                <h3 className="text-5xl md:text-6xl font-bold text-accent">
-                  {formatCurrency(stats.totalRevenue)}
-                </h3>
-                <span className="text-muted-foreground text-lg opacity-60">
-                  COP
-                </span>
-              </div>
-            </div>
-            {/* Mini gráfico área con tooltip */}
-            <div className="mt-8 h-40 w-full relative">
-              <svg
-                className="w-full h-32"
-                preserveAspectRatio="none"
-                viewBox="0 0 400 100"
-              >
-                <defs>
-                  <linearGradient id="areaGradient" x1="0" x2="0" y1="0" y2="1">
-                    <stop
-                      offset="0%"
-                      stopColor="#8BB59D"
-                      stopOpacity="0.4"
-                    ></stop>
-                    <stop
-                      offset="100%"
-                      stopColor="#8BB59D"
-                      stopOpacity="0"
-                    ></stop>
-                  </linearGradient>
-                  <filter id="glow">
-                    <feGaussianBlur stdDeviation="2" result="coloredBlur" />
-                    <feMerge>
-                      <feMergeNode in="coloredBlur" />
-                      <feMergeNode in="SourceGraphic" />
-                    </feMerge>
-                  </filter>
-                </defs>
-                <path
-                  d="M0,80 Q50,70 100,85 T200,60 T300,75 T400,40 L400,100 L0,100 Z"
-                  fill="url(#areaGradient)"
-                />
-                <path
-                  d="M0,80 Q50,70 100,85 T200,60 T300,75 T400,40"
-                  fill="none"
-                  stroke="#8BB59D"
-                  strokeWidth="2.5"
-                />
-              </svg>
-              {/* Áreas de hover para cada punto del gráfico */}
-              <div className="absolute top-0 left-0 h-32 w-full flex">
-                {revenueBarData.slice(-7).map((bar) => (
-                  <div
-                    key={bar.key}
-                    className="flex-1"
-                    onMouseEnter={() => setHoveredRevenueKey(bar.key)}
-                    onMouseLeave={() => setHoveredRevenueKey(null)}
-                  />
-                ))}
-              </div>
-
-              {hoveredRevenueBar && hoveredRevenuePoint && (
-                <div className="pointer-events-none absolute left-0 top-0 h-32 w-full">
-                  <div
-                    className="absolute z-20 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-accent"
-                    style={{
-                      left: `${hoveredRevenuePoint.xPct}%`,
-                      top: `${hoveredRevenuePoint.yPct}%`,
-                      boxShadow: "0 0 8px rgba(139, 181, 157, 0.6)",
-                    }}
-                  />
-
-                  <div
-                    className="absolute z-30 min-w-[110px] -translate-x-1/2 -translate-y-full rounded-lg border border-primary/30 bg-card px-3 py-2 shadow-lg"
-                    style={{
-                      left: `${hoveredRevenuePoint.xPct}%`,
-                      top: `calc(${hoveredRevenuePoint.yPct}% - 12px)`,
-                    }}
-                  >
-                    <p className="text-center text-[10px] font-semibold text-muted-foreground">
-                      {hoveredRevenueBar.detailDate}
-                    </p>
-                    <p className="mt-0.5 text-center text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-                      {hoveredRevenueBar.monthLabel}
-                    </p>
-                    <p className="mt-1 text-center text-sm font-bold text-accent">
-                      {formatCurrency(hoveredRevenueBar.total)}
-                    </p>
-                  </div>
-                </div>
-              )}
-
-              {/* Etiquetas de fecha */}
-              <div className="flex justify-between mt-2 text-[10px] uppercase tracking-wider text-muted-foreground/60 px-1">
-                {revenueBarData.slice(-7).map((bar) => (
-                  <span key={bar.key}>
-                    {bar.dayAbbreviation}
-                  </span>
-                ))}
-              </div>
-            </div>
-          </div>
-
-          {/* Ayer vs Hoy */}
-          <div className="min-w-0 rounded-3xl border border-primary/30 bg-primary/10 px-6 py-6 text-foreground md:col-span-4 xl:col-span-4 flex flex-col justify-center">
-            <div className="flex justify-between items-start mb-2">
-              <p className="text-xs font-bold uppercase tracking-[0.2em] text-muted-foreground">
-                Ayer vs Hoy
-              </p>
-              <div className="p-1.5 bg-primary/20 rounded-lg">
-                <TrendingUp className="h-4 w-4 text-primary" />
-              </div>
-            </div>
-            <div className="space-y-4 mt-4">
-              <div className="flex items-center justify-between">
-                <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                  Hoy
-                </span>
-                <span className="text-xl font-bold text-primary">
-                  {formatCurrency(stats.totalRevenue)}
-                </span>
-              </div>
-              <div className="h-1.5 bg-muted rounded-full overflow-hidden">
-                <div className="h-full bg-primary" style={{ width: "78%" }} />
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                  Ayer
-                </span>
-                <span className="text-lg font-bold text-muted-foreground">
-                  {formatCurrency(dashboard?.previousPeriod?.revenue ?? 0)}
-                </span>
-              </div>
-            </div>
-          </div>
-
           {/* Ventas Completadas */}
           <div className="min-w-0 rounded-3xl border border-accent/30 bg-accent/10 px-6 py-5 text-foreground md:col-span-3 xl:col-span-3">
             <div className="flex justify-between items-start mb-4">
@@ -423,18 +209,6 @@ export default function DashboardPage() {
             </p>
             <p className="text-3xl font-bold mt-1">
               {stats.totalSales.toLocaleString("es-CO")}
-            </p>
-            <div className="mt-4 w-full bg-muted h-1.5 rounded-full overflow-hidden">
-              <div
-                className="bg-accent h-full rounded-full transition-all duration-500"
-                style={{
-                  width: `${Math.min((stats.totalSales / 1500) * 100, 100)}%`,
-                }}
-              />
-            </div>
-            <p className="mt-2 text-[10px] text-muted-foreground/60 font-medium italic">
-              Meta: 1,500 mensual ({Math.round((stats.totalSales / 1500) * 100)}
-              %)
             </p>
           </div>
 

--- a/frontend/src/app/reports/page.tsx
+++ b/frontend/src/app/reports/page.tsx
@@ -18,10 +18,9 @@ import { useToast } from "@/contexts/ToastContext";
 import { Button } from "@/components/ui/Button";
 import { LoadingState } from "@/components/ui/LoadingState";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { MetricCard } from "@/components/ui/MetricCard";
 import { Table, TableCell, TableHeader, TableRow } from "@/components/ui/Table";
 import {
-  ArrowDownRight,
-  ArrowUpRight,
   BarChart3,
   Calendar,
   CircleDollarSign,
@@ -31,7 +30,7 @@ import {
   TrendingUp,
   Users,
 } from "lucide-react";
-import type { AppliedRange, FinancialDelta, FinancialReport } from "@/types";
+import type { AppliedRange, FinancialReport } from "@/types";
 
 function rangeLabel(range?: AppliedRange) {
   if (!range?.startDate && !range?.endDate) return "Período completo";
@@ -65,25 +64,6 @@ function SectionShell({ title, icon: Icon, children, tone = "primary" }: { title
       </div>
       <div className="p-5">{children}</div>
     </section>
-  );
-}
-
-function MetricCard({ label, value, helper, delta }: { label: string; value: string; helper: string; delta?: FinancialDelta }) {
-  const positive = (delta?.percentage ?? 0) >= 0;
-  return (
-    <div className="rounded-3xl border border-border/80 bg-card p-5 shadow-xs flex flex-col justify-between">
-      <p className="text-[11px] font-mono font-bold uppercase tracking-wider text-muted-foreground">{label}</p>
-      <p className="mt-2 text-2xl font-extrabold font-mono text-foreground tracking-tight">{value}</p>
-      <div className="mt-3 flex items-center justify-between gap-2 text-xs">
-        {delta ? (
-          <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-mono text-[11px] font-bold ${positive ? "bg-emerald-50 dark:bg-emerald-950/40 text-emerald-600 dark:text-emerald-300 border border-emerald-200 dark:border-emerald-800" : "bg-rose-50 dark:bg-rose-950/40 text-rose-600 dark:text-rose-300 border border-rose-200 dark:border-rose-800"}`}>
-            <span aria-hidden="true">{positive ? <ArrowUpRight className="h-3 w-3" /> : <ArrowDownRight className="h-3 w-3" />}</span>
-            {delta.percentage === null ? "Sin base" : `${positive ? "+" : ""}${delta.percentage.toFixed(1)}%`}
-          </span>
-        ) : <span />}
-        <span className="text-right text-[11px] text-muted-foreground">{helper}</span>
-      </div>
-    </div>
   );
 }
 

--- a/frontend/src/components/dashboard/AlertPanels.test.tsx
+++ b/frontend/src/components/dashboard/AlertPanels.test.tsx
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AlertPanels } from "./AlertPanels";
+
+const pushMock = vi.fn();
+const useLowStockMock = vi.fn();
+const useExpensesMock = vi.fn();
+const useTasksMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock("@/hooks/useProducts", () => ({
+  useLowStockProducts: () => useLowStockMock(),
+}));
+
+vi.mock("@/hooks/useExpenses", () => ({
+  useExpenses: (params: unknown) => useExpensesMock(params),
+}));
+
+vi.mock("@/hooks/useTasks", () => ({
+  useTasks: () => useTasksMock(),
+}));
+
+const expense = (id: string, description: string, total: number, payments: number[]) => ({
+  id,
+  description,
+  total,
+  status: "PARTIAL",
+  payments: payments.map((amount, index) => ({ id: `${id}-p${index}`, amount })),
+});
+
+describe("AlertPanels (DIA-6..8)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useLowStockMock.mockReturnValue({ data: [] });
+    useExpensesMock.mockReturnValue({ data: { data: [], meta: { total: 0, page: 1, limit: 10, totalPages: 0 } } });
+    useTasksMock.mockReturnValue({ data: { tasks: [], source: "remote" } });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ---- DIA-6: low stock ----
+  it("lists real low-stock products with name and stock", () => {
+    useLowStockMock.mockReturnValue({
+      data: [
+        { id: "p1", name: "Café", stock: 3 },
+        { id: "p2", name: "Azúcar", stock: 1 },
+      ],
+    });
+
+    render(<AlertPanels />);
+
+    expect(screen.getByText("Café")).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
+    expect(screen.getByText("Azúcar")).toBeTruthy();
+    expect(screen.getByText("1")).toBeTruthy();
+  });
+
+  it("shows 'Stock OK' and no fabricated count when there is no low stock", () => {
+    render(<AlertPanels />);
+
+    expect(screen.getByText("Stock OK")).toBeTruthy();
+    expect(screen.queryByText(/productos en stock crítico/i)).toBeNull();
+    expect(screen.queryByText(/bajo requerido/i)).toBeNull();
+    expect(screen.queryByText(/sin stock/i)).toBeNull();
+  });
+
+  it("routes to the low-stock filter from the Reordenar CTA", async () => {
+    useLowStockMock.mockReturnValue({
+      data: [{ id: "p1", name: "Café", stock: 3 }],
+    });
+
+    render(<AlertPanels />);
+
+    await userEvent.click(screen.getByRole("button", { name: /reordenar/i }));
+    expect(pushMock).toHaveBeenCalledWith("/inventory?filter=lowStock");
+  });
+
+  // ---- DIA-7: partial expenses ----
+  it("lists partial expenses with their pending amounts and total pending in COP", () => {
+    useExpensesMock.mockReturnValue({
+      data: {
+        data: [
+          expense("e1", "Arriendo", 100000, [40000, 30000]),
+          expense("e2", "Servicios", 50000, []),
+        ],
+        meta: { total: 2, page: 1, limit: 10, totalPages: 1 },
+      },
+    });
+
+    render(<AlertPanels />);
+
+    expect(screen.getByText("Arriendo")).toBeTruthy();
+    expect(screen.getByText(/\$\s30\.000/)).toBeTruthy(); // 100000 - 70000
+    expect(screen.getByText("Servicios")).toBeTruthy();
+    expect(screen.getByText(/\$\s50\.000/)).toBeTruthy(); // fallback to full total
+    expect(screen.getByText(/\$\s80\.000/)).toBeTruthy(); // total pending
+  });
+
+  it("queries expenses with status PARTIAL", () => {
+    render(<AlertPanels />);
+
+    expect(useExpensesMock).toHaveBeenCalledWith({ status: "PARTIAL" });
+  });
+
+  it("shows an empty state (no stale total) when there are no partial expenses", () => {
+    render(<AlertPanels />);
+
+    expect(screen.getByText(/sin gastos pendientes/i)).toBeTruthy();
+    expect(screen.queryByText(/\$\s[0-9]/)).toBeNull();
+  });
+
+  // ---- DIA-8: open tasks ----
+  it("lists open tasks with title and due date, excluding COMPLETED/CANCELLED", () => {
+    useTasksMock.mockReturnValue({
+      data: {
+        tasks: [
+          { id: "t1", title: "Reponer stock", status: "PENDING", dueDate: "2026-08-25" },
+          { id: "t2", title: "Cerrar caja", status: "IN_PROGRESS", dueDate: "2026-08-26" },
+          { id: "t3", title: "Limpiar", status: "COMPLETED", dueDate: "2026-08-27" },
+          { id: "t4", title: "Cancelada", status: "CANCELLED", dueDate: "2026-08-28" },
+        ],
+        source: "remote",
+      },
+    });
+
+    render(<AlertPanels />);
+
+    expect(screen.getByText("Reponer stock")).toBeTruthy();
+    expect(screen.getByText("Cerrar caja")).toBeTruthy();
+    expect(screen.queryByText("Limpiar")).toBeNull();
+    expect(screen.queryByText("Cancelada")).toBeNull();
+    // due date is rendered for the open tasks
+    expect(screen.getAllByText(/2026/).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("caps the open-task list to five entries", () => {
+    useTasksMock.mockReturnValue({
+      data: {
+        tasks: Array.from({ length: 6 }, (_, index) => ({
+          id: `t${index + 1}`,
+          title: `Tarea ${index + 1}`,
+          status: "PENDING",
+          dueDate: null,
+        })),
+        source: "remote",
+      },
+    });
+
+    render(<AlertPanels />);
+
+    expect(screen.getByText("Tarea 1")).toBeTruthy();
+    expect(screen.getByText("Tarea 5")).toBeTruthy();
+    expect(screen.queryByText("Tarea 6")).toBeNull();
+  });
+
+  it("shows an empty state when all tasks are completed or cancelled", () => {
+    render(<AlertPanels />);
+
+    expect(screen.getByText(/sin tareas abiertas/i)).toBeTruthy();
+  });
+});

--- a/frontend/src/components/dashboard/AlertPanels.tsx
+++ b/frontend/src/components/dashboard/AlertPanels.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { AlertTriangle, ArrowRight, CheckCircle2, ListTodo, Receipt, ShoppingBag } from "lucide-react";
+import { useLowStockProducts } from "@/hooks/useProducts";
+import { useExpenses } from "@/hooks/useExpenses";
+import { useTasks } from "@/hooks/useTasks";
+import { computePendingAmount, filterOpenTasks } from "@/lib/dashboard";
+import { formatCurrency, formatDate } from "@/lib/utils";
+import type { Product, Expense } from "@/types";
+
+function PanelHeader({
+  icon,
+  title,
+  tone,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  tone: "rose" | "accent" | "primary";
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div className="flex items-center gap-3">
+        <div className={`p-2.5 rounded-xl ${tone === "rose" ? "bg-rose-500/20" : tone === "accent" ? "bg-accent/20" : "bg-primary/20"}`}>
+          {icon}
+        </div>
+        <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+          {title}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+type ExpenseLike = Pick<Expense, "id" | "description" | "total" | "status"> & {
+  payments?: Array<{ amount: number }>;
+};
+
+export function AlertPanels() {
+  const router = useRouter();
+  const { data: lowStock } = useLowStockProducts();
+  const { data: expensesResponse } = useExpenses({ status: "PARTIAL" });
+  const { data: tasksResponse } = useTasks();
+
+  const lowStockProducts = (lowStock ?? []) as Product[];
+  const partialExpenses = (expensesResponse?.data ?? []) as ExpenseLike[];
+  const openTasks = filterOpenTasks(tasksResponse?.tasks ?? []);
+
+  const totalPending = partialExpenses.reduce(
+    (sum, expense) => sum + computePendingAmount(expense),
+    0,
+  );
+
+  return (
+    <div className="grid grid-cols-1 gap-2.5 md:grid-cols-3">
+      {/* Low stock panel */}
+      <div className="min-w-0 rounded-3xl border border-rose-500/30 bg-rose-500/10 px-6 py-5 text-foreground">
+        <PanelHeader
+          icon={<AlertTriangle className="h-5 w-5 text-rose-500" />}
+          title="Stock bajo"
+          tone="rose"
+        />
+        <div className="mt-4">
+          {lowStockProducts.length === 0 ? (
+            <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+              <CheckCircle2 className="h-4 w-4 text-rose-500" />
+              <span>Stock OK</span>
+            </div>
+          ) : (
+            <ul className="space-y-2">
+              {lowStockProducts.map((product) => (
+                <li
+                  key={product.id}
+                  className="flex items-center justify-between rounded-xl bg-rose-500/5 px-3 py-2"
+                >
+                  <span className="truncate text-sm font-medium text-foreground">
+                    {product.name}
+                  </span>
+                  <span className="shrink-0 font-mono text-xs font-bold text-rose-500">
+                    {product.stock}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        {lowStockProducts.length > 0 && (
+          <button
+            type="button"
+            onClick={() => router.push("/inventory?filter=lowStock")}
+            className="mt-4 inline-flex items-center gap-1 text-[12px] font-bold text-rose-500 hover:text-rose-400"
+          >
+            Reordenar
+            <ArrowRight className="h-3 w-3" aria-hidden="true" />
+          </button>
+        )}
+      </div>
+
+      {/* Partial expenses panel */}
+      <div className="min-w-0 rounded-3xl border border-primary/30 bg-primary/10 px-6 py-5 text-foreground">
+        <PanelHeader
+          icon={<Receipt className="h-5 w-5 text-primary" />}
+          title="Gastos por pagar"
+          tone="primary"
+        />
+        <div className="mt-4">
+          {partialExpenses.length === 0 ? (
+            <p className="text-xs text-muted-foreground">Sin gastos pendientes</p>
+          ) : (
+            <>
+              <ul className="space-y-2">
+                {partialExpenses.map((expense) => (
+                  <li
+                    key={expense.id}
+                    className="flex items-center justify-between rounded-xl bg-primary/5 px-3 py-2"
+                  >
+                    <span className="truncate text-sm font-medium text-foreground">
+                      {expense.description || "Gasto"}
+                    </span>
+                    <span className="shrink-0 font-mono text-xs font-bold text-primary">
+                      {formatCurrency(computePendingAmount(expense))}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-4 flex items-center justify-between rounded-xl bg-primary/5 px-3 py-2">
+                <span className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+                  Total pendiente
+                </span>
+                <span className="font-mono text-sm font-extrabold text-primary">
+                  {formatCurrency(totalPending)}
+                </span>
+              </div>
+            </>
+          )}
+        </div>
+        {partialExpenses.length > 0 && (
+          <button
+            type="button"
+            onClick={() => router.push("/expenses")}
+            className="mt-4 inline-flex items-center gap-1 text-[12px] font-bold text-primary hover:text-primary/80"
+          >
+            Ver gastos
+            <ArrowRight className="h-3 w-3" aria-hidden="true" />
+          </button>
+        )}
+      </div>
+
+      {/* Open tasks panel */}
+      <div className="min-w-0 rounded-3xl border border-accent/30 bg-accent/10 px-6 py-5 text-foreground">
+        <PanelHeader
+          icon={<ListTodo className="h-5 w-5 text-accent" />}
+          title="Tareas abiertas"
+          tone="accent"
+        />
+        <div className="mt-4">
+          {openTasks.length === 0 ? (
+            <p className="text-xs text-muted-foreground">Sin tareas abiertas</p>
+          ) : (
+            <ul className="space-y-2">
+              {openTasks.map((task) => {
+                const Icon = task.status === "IN_PROGRESS" ? ShoppingBag : ListTodo;
+                return (
+                  <li
+                    key={task.id}
+                    className="flex items-center justify-between gap-2 rounded-xl bg-accent/5 px-3 py-2"
+                  >
+                    <div className="flex min-w-0 items-center gap-2">
+                      <Icon className="h-4 w-4 shrink-0 text-accent" aria-hidden="true" />
+                      <span className="truncate text-sm font-medium text-foreground">
+                        {task.title}
+                      </span>
+                    </div>
+                    {task.dueDate && (
+                      <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+                        {formatDate(task.dueDate)}
+                      </span>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/QuickActions.test.tsx
+++ b/frontend/src/components/dashboard/QuickActions.test.tsx
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { QuickActions } from "./QuickActions";
+
+const useAuthMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+describe("QuickActions (DIA-9)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows the full set of actions for an ADMIN user", () => {
+    useAuthMock.mockReturnValue({ user: { id: "u1", role: "ADMIN" } });
+
+    render(<QuickActions />);
+
+    expect(screen.getByText("Nuevo producto")).toBeTruthy();
+    expect(screen.getByText("Nueva venta")).toBeTruthy();
+    expect(screen.getByText("Reordenar")).toBeTruthy();
+    expect(screen.getByText("Nuevo gasto")).toBeTruthy();
+  });
+
+  it("does not render a reorder action for a role without inventory permission", () => {
+    useAuthMock.mockReturnValue({ user: { id: "u1", role: "CASHIER" } });
+
+    render(<QuickActions />);
+
+    expect(screen.queryByText("Reordenar")).toBeNull();
+    expect(screen.queryByText("Nuevo gasto")).toBeNull();
+  });
+
+  it("does not render a new-expense action for a role without expense permission", () => {
+    useAuthMock.mockReturnValue({ user: { id: "u1", role: "INVENTORY_USER" } });
+
+    render(<QuickActions />);
+
+    expect(screen.queryByText("Nuevo gasto")).toBeNull();
+    expect(screen.queryByText("Nuevo producto")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/dashboard/QuickActions.tsx
+++ b/frontend/src/components/dashboard/QuickActions.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Package, Plus, RefreshCw, Receipt, ShoppingCart, type LucideIcon } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { hasAnyRole } from "@/lib/auth";
+import type { AppRole } from "@/lib/auth";
+
+interface QuickAction {
+  id: string;
+  label: string;
+  href: string;
+  roles: AppRole[];
+  icon: LucideIcon;
+}
+
+/**
+ * Quick-action map mirroring routeRoleMap semantics (see Sidebar/DashboardLayout).
+ * Only actions whose role gates allow the current user are rendered (DIA-9).
+ */
+const QUICK_ACTIONS: QuickAction[] = [
+  {
+    id: "new-product",
+    label: "Nuevo producto",
+    href: "/inventory",
+    roles: ["ADMIN", "INVENTORY_USER"],
+    icon: Package,
+  },
+  {
+    id: "new-sale",
+    label: "Nueva venta",
+    href: "/pos",
+    roles: ["ADMIN", "CASHIER"],
+    icon: ShoppingCart,
+  },
+  {
+    id: "reorder",
+    label: "Reordenar",
+    href: "/inventory?filter=lowStock",
+    roles: ["ADMIN", "INVENTORY_USER"],
+    icon: RefreshCw,
+  },
+  {
+    id: "new-expense",
+    label: "Nuevo gasto",
+    href: "/expenses",
+    roles: ["ADMIN"],
+    icon: Receipt,
+  },
+];
+
+export function QuickActions() {
+  const { user } = useAuth();
+  const router = useRouter();
+
+  const visible = QUICK_ACTIONS.filter((action) =>
+    hasAnyRole(user?.role, action.roles),
+  );
+
+  return (
+    <div className="grid grid-cols-2 gap-2.5 md:grid-cols-4">
+      {visible.map((action) => {
+        const Icon = action.icon;
+        return (
+          <button
+            key={action.id}
+            type="button"
+            onClick={() => router.push(action.href)}
+            className="group flex min-w-0 flex-col items-start gap-3 rounded-3xl border border-primary/30 bg-primary/10 px-5 py-4 text-left text-foreground transition-colors hover:border-primary/50"
+          >
+            <div className="p-2.5 rounded-xl bg-primary/20">
+              <Icon className="h-5 w-5 text-primary" aria-hidden="true" />
+            </div>
+            <span className="flex items-center gap-1 text-xs font-bold uppercase tracking-wider text-muted-foreground group-hover:text-primary">
+              <Plus className="h-3 w-3" aria-hidden="true" />
+              {action.label}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/RevenueChart.test.tsx
+++ b/frontend/src/components/dashboard/RevenueChart.test.tsx
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { RevenueChart, type RevenueBarPoint } from "./RevenueChart";
+
+const twoDayData: RevenueBarPoint[] = [
+  {
+    key: "2026-08-21",
+    total: 0,
+    count: 0,
+    isToday: false,
+    detailDate: "Viernes 21",
+    dayAbbreviation: "Vie",
+    monthLabel: "AGO",
+    height: 18,
+  },
+  {
+    key: "2026-08-22",
+    total: 200000,
+    count: 4,
+    isToday: true,
+    detailDate: "Sábado 22",
+    dayAbbreviation: "Sáb",
+    monthLabel: "AGO",
+    height: 100,
+  },
+];
+
+describe("RevenueChart (DIA-11..13)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders bars with heights driven by the real revenue data", () => {
+    const { container } = render(<RevenueChart data={twoDayData} />);
+
+    const bars = screen.getAllByTestId("revenue-bar");
+    expect(bars).toHaveLength(2);
+
+    // Zero-total day gets the minimum visible height; the max day gets 100%.
+    expect(bars[0].getAttribute("height")).toBe("18");
+    expect(bars[0].getAttribute("y")).toBe("82");
+    expect(bars[1].getAttribute("height")).toBe("100");
+    expect(bars[1].getAttribute("y")).toBe("0");
+
+    // No hardcoded/decorative SVG area path.
+    expect(container.querySelectorAll("path").length).toBe(0);
+  });
+
+  it("shows an exact tooltip on hover with COP total, count and date", () => {
+    render(<RevenueChart data={twoDayData} />);
+
+    fireEvent.mouseEnter(screen.getAllByTestId("revenue-day")[1]);
+
+    expect(screen.getByText(/\$\s200\.000/)).toBeTruthy();
+    expect(screen.getByText("4 transacciones")).toBeTruthy();
+    expect(screen.getByText("Sábado 22")).toBeTruthy();
+  });
+
+  it("does not surface a tooltip until a day is hovered", () => {
+    render(<RevenueChart data={twoDayData} />);
+
+    expect(screen.queryByText(/\$\s200\.000/)).toBeNull();
+    expect(screen.queryByText("4 transacciones")).toBeNull();
+  });
+});

--- a/frontend/src/components/dashboard/RevenueChart.tsx
+++ b/frontend/src/components/dashboard/RevenueChart.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { formatCurrency } from "@/lib/utils";
+
+export interface RevenueBarPoint {
+  key: string;
+  total: number;
+  count: number;
+  isToday: boolean;
+  detailDate: string;
+  dayAbbreviation: string;
+  monthLabel: string;
+  height: number;
+}
+
+const TODAY_COLOR = "#C25E36";
+const BAR_COLOR = "#E2A685";
+
+export function RevenueChart({ data }: { data: RevenueBarPoint[] }) {
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+
+  const hoveredIndex = useMemo(
+    () => data.findIndex((bar) => bar.key === hoveredKey),
+    [hoveredKey, data],
+  );
+
+  const hoveredBar = hoveredIndex >= 0 ? data[hoveredIndex] : null;
+
+  const hoveredPoint = useMemo(() => {
+    if (!hoveredBar) {
+      return null;
+    }
+
+    const xPct =
+      data.length > 1 ? (hoveredIndex / (data.length - 1)) * 100 : 50;
+
+    // Marker sits on top of the real consumed bar height for the hovered day.
+    const yPct = 100 - hoveredBar.height;
+
+    return { xPct, yPct };
+  }, [hoveredBar, hoveredIndex, data.length]);
+
+  const slot = data.length > 0 ? 400 / data.length : 0;
+  const barWidth = Math.max(4, slot * 0.5);
+
+  return (
+    <div className="h-40 w-full relative">
+      <svg
+        className="w-full h-32"
+        preserveAspectRatio="none"
+        viewBox="0 0 400 100"
+        role="img"
+        aria-label="Ingresos de los últimos días"
+      >
+        {data.map((bar, index) => {
+          const x = index * slot + (slot - barWidth) / 2;
+          const y = 100 - bar.height;
+
+          return (
+            <rect
+              key={bar.key}
+              data-testid="revenue-bar"
+              x={x}
+              y={y}
+              width={barWidth}
+              height={bar.height}
+              rx={2}
+              fill={bar.isToday ? TODAY_COLOR : BAR_COLOR}
+            />
+          );
+        })}
+      </svg>
+
+      {/* Hover regions for each day */}
+      <div className="absolute top-0 left-0 h-32 w-full flex">
+        {data.map((bar) => (
+          <div
+            key={bar.key}
+            data-testid="revenue-day"
+            className="flex-1"
+            onMouseEnter={() => setHoveredKey(bar.key)}
+            onMouseLeave={() => setHoveredKey(null)}
+          />
+        ))}
+      </div>
+
+      {/* Marker + exact tooltip */}
+      {hoveredBar && hoveredPoint && (
+        <div className="pointer-events-none absolute left-0 top-0 h-32 w-full">
+          <div
+            className="absolute z-20 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-accent"
+            style={{
+              left: `${hoveredPoint.xPct}%`,
+              top: `${hoveredPoint.yPct}%`,
+            }}
+          />
+
+          <div
+            className="absolute z-30 min-w-[110px] -translate-x-1/2 -translate-y-full rounded-lg border border-primary/30 bg-card px-3 py-2 shadow-lg"
+            style={{
+              left: `${hoveredPoint.xPct}%`,
+              top: `calc(${hoveredPoint.yPct}% - 12px)`,
+            }}
+          >
+            <p className="text-center text-[10px] font-semibold text-muted-foreground">
+              {hoveredBar.detailDate}
+            </p>
+            <p className="mt-0.5 text-center text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+              {hoveredBar.monthLabel}
+            </p>
+            <p className="mt-1 text-center text-sm font-bold text-accent">
+              {formatCurrency(hoveredBar.total)}
+            </p>
+            <p className="mt-0.5 text-center text-[10px] font-medium text-muted-foreground">
+              {hoveredBar.count} transacciones
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Date labels */}
+      <div className="flex justify-between mt-2 text-[10px] uppercase tracking-wider text-muted-foreground/60 px-1">
+        {data.map((bar) => (
+          <span key={bar.key}>{bar.dayAbbreviation}</span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/TodayStats.test.tsx
+++ b/frontend/src/components/dashboard/TodayStats.test.tsx
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { TodayStatsInner } from "./TodayStats";
+
+const useDailySalesMock = vi.fn();
+
+vi.mock("@/hooks/useReports", () => ({
+  useDailySales: (startDate: string, endDate: string) =>
+    useDailySalesMock(startDate, endDate),
+}));
+
+function daily(date: string, total: number, count: number) {
+  return { date, total, subtotal: Math.round(total * 0.84), tax: total - Math.round(total * 0.84), count };
+}
+
+describe("TodayStats (DIA-1..3)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useDailySalesMock.mockReturnValue({ data: { data: [daily("2026-08-22", 250000, 5)] } });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("queries useDailySales with today as both start and end (never the full-range aggregate)", () => {
+    render(<TodayStatsInner today="2026-08-22" />);
+
+    expect(useDailySalesMock).toHaveBeenCalledWith("2026-08-22", "2026-08-22");
+    expect(screen.getByText("Ventas hoy")).toBeTruthy();
+  });
+
+  it("shows today's real total, average ticket and count as COP/Day KPI values", () => {
+    render(<TodayStatsInner today="2026-08-22" />);
+
+    expect(screen.getByText(/\$\s250\.000/)).toBeTruthy();
+    expect(screen.getByText(/\$\s50\.000/)).toBeTruthy();
+    expect(screen.getByText("5")).toBeTruthy();
+  });
+
+  it("shows $0 (not a full-period value) when there are no sales today", () => {
+    useDailySalesMock.mockReturnValue({ data: { data: [] } });
+    render(<TodayStatsInner today="2026-08-22" />);
+
+    expect(screen.getAllByText(/\$ 0/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("0")).toBeTruthy();
+  });
+
+  it("shows a zero ticket when count is 0 without dividing by zero", () => {
+    useDailySalesMock.mockReturnValue({ data: { data: [daily("2026-08-22", 50000, 0)] } });
+    render(<TodayStatsInner today="2026-08-22" />);
+
+    expect(screen.getByText(/50\.000/)).toBeTruthy();
+    expect(screen.getAllByText(/\$ 0/).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/frontend/src/components/dashboard/TodayStats.tsx
+++ b/frontend/src/components/dashboard/TodayStats.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useDailySales } from "@/hooks/useReports";
+import { formatCurrency, getBogotaDateInputValue } from "@/lib/utils";
+import { computeTodayMetrics } from "@/lib/dashboard";
+import { MetricCard } from "@/components/ui/MetricCard";
+
+export function TodayStats() {
+  return <TodayStatsInner today={getBogotaDateInputValue()} />;
+}
+
+export function TodayStatsInner({ today }: { today: string }) {
+  const { data: todaySales } = useDailySales(today, today);
+  const rec =
+    todaySales?.data?.find((entry) => entry.date === today) ?? { total: 0, count: 0 };
+  const metric = computeTodayMetrics(rec);
+
+  return (
+    <div className="grid grid-cols-1 gap-2.5 md:grid-cols-3">
+      <MetricCard
+        label="Ventas hoy"
+        value={formatCurrency(metric.sales)}
+        helper="del día"
+        tone="primary"
+      />
+      <MetricCard
+        label="Ticket promedio"
+        value={formatCurrency(metric.ticket)}
+        helper="por transacción"
+        tone="accent"
+      />
+      <MetricCard
+        label="Transacciones"
+        value={String(metric.transactions)}
+        helper="hoy"
+        tone="rose"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/ui/MetricCard.test.tsx
+++ b/frontend/src/components/ui/MetricCard.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MetricCard } from "./MetricCard";
+
+describe("MetricCard (DIA-5)", () => {
+  it("renders label, value and helper", () => {
+    render(
+      <MetricCard label="Ventas hoy" value="$ 250.000" helper="del día" />,
+    );
+
+    expect(screen.getByText("Ventas hoy")).toBeTruthy();
+    expect(screen.getByText("$ 250.000")).toBeTruthy();
+    expect(screen.getByText("del día")).toBeTruthy();
+  });
+
+  it("renders a positive delta pill with its percentage", () => {
+    render(
+      <MetricCard
+        label="Ventas"
+        value="$ 100"
+        helper="hoy"
+        delta={{ percentage: 12.5 }}
+      />,
+    );
+
+    expect(screen.getByText("+12.5%")).toBeTruthy();
+  });
+
+  it("does not render a delta pill when delta is absent", () => {
+    render(<MetricCard label="Ventas" value="$ 100" helper="hoy" />);
+
+    expect(screen.queryByText("+12.5%")).toBeNull();
+    expect(screen.queryByText("Sin base")).toBeNull();
+  });
+
+  it("renders 'Sin base' when the delta percentage is null", () => {
+    render(
+      <MetricCard
+        label="Ventas"
+        value="$ 100"
+        helper="hoy"
+        delta={{ percentage: null }}
+      />,
+    );
+
+    expect(screen.getByText("Sin base")).toBeTruthy();
+  });
+
+  it("applies the requested tone (data-tone) and defaults to neutral", () => {
+    const { container } = render(
+      <MetricCard label="A" value="1" helper="h" tone="rose" />,
+    );
+    const { container: neutral } = render(<MetricCard label="B" value="2" helper="h" />);
+
+    expect(container.querySelector('[data-tone="rose"]')).toBeTruthy();
+    expect(neutral.querySelector('[data-tone="neutral"]')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/ui/MetricCard.tsx
+++ b/frontend/src/components/ui/MetricCard.tsx
@@ -1,0 +1,96 @@
+import { ArrowDownRight, ArrowUpRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type MetricCardTone = "primary" | "accent" | "rose";
+
+export interface MetricCardDelta {
+  percentage: number | null;
+  label?: string;
+}
+
+interface MetricCardProps {
+  label: string;
+  value: string;
+  helper: string;
+  delta?: MetricCardDelta;
+  tone?: MetricCardTone;
+}
+
+const toneCardClasses: Record<MetricCardTone, string> = {
+  primary: "border-primary/30 bg-primary/10",
+  accent: "border-accent/30 bg-accent/10",
+  rose: "border-rose-500/30 bg-rose-500/10",
+};
+
+const toneValueClasses: Record<MetricCardTone, string> = {
+  primary: "text-primary",
+  accent: "text-accent",
+  rose: "text-rose-500",
+};
+
+/**
+ * Shared MetricCard for reports and dashboard. Matches the canonical
+ * Kinetic Bento pattern: mono uppercase label + JetBrains Mono extrabold
+ * value + helper + optional delta pill, with tone alternation.
+ *
+ * When no `tone` is provided it renders exactly like the historical reports
+ * MetricCard (neutral card surface), so refactors are behavior-preserving.
+ */
+export function MetricCard({
+  label,
+  value,
+  helper,
+  delta,
+  tone,
+}: MetricCardProps) {
+  const positive = (delta?.percentage ?? 0) >= 0;
+
+  return (
+    <div
+      data-tone={tone ?? "neutral"}
+      className={
+        tone
+          ? cn(
+              "rounded-3xl border p-5 shadow-xs flex flex-col justify-between",
+              toneCardClasses[tone],
+            )
+          : "rounded-3xl border border-border/80 bg-card p-5 shadow-xs flex flex-col justify-between"
+      }
+    >
+      <p className="text-[11px] font-mono font-bold uppercase tracking-wider text-muted-foreground">
+        {label}
+      </p>
+      <p
+        className={cn(
+          "mt-2 text-2xl font-extrabold font-mono text-foreground tracking-tight",
+          tone && toneValueClasses[tone],
+        )}
+      >
+        {value}
+      </p>
+      <div className="mt-3 flex items-center justify-between gap-2 text-xs">
+        {delta ? (
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-mono text-[11px] font-bold",
+              positive
+                ? "bg-emerald-50 dark:bg-emerald-950/40 text-emerald-600 dark:text-emerald-300 border border-emerald-200 dark:border-emerald-800"
+                : "bg-rose-50 dark:bg-rose-950/40 text-rose-600 dark:text-rose-300 border border-rose-200 dark:border-rose-800",
+            )}
+          >
+            <span aria-hidden="true">
+              {positive ? <ArrowUpRight className="h-3 w-3" /> : <ArrowDownRight className="h-3 w-3" />}
+            </span>
+            {delta.label ??
+              (delta.percentage === null
+                ? "Sin base"
+                : `${positive ? "+" : ""}${delta.percentage.toFixed(1)}%`)}
+          </span>
+        ) : (
+          <span />
+        )}
+        <span className="text-right text-[11px] text-muted-foreground">{helper}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/dashboard.test.ts
+++ b/frontend/src/lib/dashboard.test.ts
@@ -5,6 +5,7 @@ import {
   computeTodayMetrics,
   filterOpenTasks,
 } from "./dashboard";
+import type { TaskStatus } from "@/types";
 
 describe("computeTodayMetrics (DIA-1/DIA-2)", () => {
   it("returns sales, count and a non-zero average ticket when count > 0", () => {
@@ -54,10 +55,10 @@ describe("computePendingAmount (DIA-7)", () => {
 describe("filterOpenTasks (DIA-8)", () => {
   it("keeps only PENDING/IN_PROGRESS tasks and drops COMPLETED/CANCELLED", () => {
     const tasks = [
-      { status: "PENDING" },
-      { status: "COMPLETED" },
-      { status: "IN_PROGRESS" },
-      { status: "CANCELLED" },
+      { status: "PENDING" as const },
+      { status: "COMPLETED" as const },
+      { status: "IN_PROGRESS" as const },
+      { status: "CANCELLED" as const },
     ];
 
     expect(filterOpenTasks(tasks)).toEqual([
@@ -67,9 +68,12 @@ describe("filterOpenTasks (DIA-8)", () => {
   });
 
   it("caps the open-task list to five entries", () => {
-    const tasks = Array.from({ length: 8 }, (_, index) => ({
-      status: index % 2 === 0 ? "PENDING" : "IN_PROGRESS",
-    }));
+    const tasks: Array<{ status: TaskStatus }> = Array.from(
+      { length: 8 },
+      (_, index) => ({
+        status: index % 2 === 0 ? "PENDING" : "IN_PROGRESS",
+      }),
+    );
 
     expect(filterOpenTasks(tasks)).toHaveLength(5);
   });

--- a/frontend/src/lib/dashboard.test.ts
+++ b/frontend/src/lib/dashboard.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  chartHeight,
+  computePendingAmount,
+  computeTodayMetrics,
+  filterOpenTasks,
+} from "./dashboard";
+
+describe("computeTodayMetrics (DIA-1/DIA-2)", () => {
+  it("returns sales, count and a non-zero average ticket when count > 0", () => {
+    expect(computeTodayMetrics({ total: 250000, count: 5 })).toEqual({
+      sales: 250000,
+      transactions: 5,
+      ticket: 50000,
+    });
+  });
+
+  it("returns a zero ticket when count is 0 without dividing by zero", () => {
+    expect(computeTodayMetrics({ total: 50000, count: 0 })).toEqual({
+      sales: 50000,
+      transactions: 0,
+      ticket: 0,
+    });
+  });
+
+  it("returns all-zero metrics when the record is missing", () => {
+    expect(computeTodayMetrics(undefined)).toEqual({
+      sales: 0,
+      transactions: 0,
+      ticket: 0,
+    });
+  });
+});
+
+describe("computePendingAmount (DIA-7)", () => {
+  it("subtracts the sum of payments from the expense total", () => {
+    expect(
+      computePendingAmount({
+        total: 100000,
+        payments: [{ amount: 40000 }, { amount: 30000 }],
+      }),
+    ).toBe(30000);
+  });
+
+  it("falls back to the full total when payments is empty", () => {
+    expect(computePendingAmount({ total: 100000, payments: [] })).toBe(100000);
+  });
+
+  it("falls back to the full total when payments are absent", () => {
+    expect(computePendingAmount({ total: 100000 })).toBe(100000);
+  });
+});
+
+describe("filterOpenTasks (DIA-8)", () => {
+  it("keeps only PENDING/IN_PROGRESS tasks and drops COMPLETED/CANCELLED", () => {
+    const tasks = [
+      { status: "PENDING" },
+      { status: "COMPLETED" },
+      { status: "IN_PROGRESS" },
+      { status: "CANCELLED" },
+    ];
+
+    expect(filterOpenTasks(tasks)).toEqual([
+      { status: "PENDING" },
+      { status: "IN_PROGRESS" },
+    ]);
+  });
+
+  it("caps the open-task list to five entries", () => {
+    const tasks = Array.from({ length: 8 }, (_, index) => ({
+      status: index % 2 === 0 ? "PENDING" : "IN_PROGRESS",
+    }));
+
+    expect(filterOpenTasks(tasks)).toHaveLength(5);
+  });
+});
+
+describe("chartHeight (DIA-11)", () => {
+  it("uses the minimum visible height for a zero-total day", () => {
+    expect(chartHeight(0, 100)).toBe(18);
+  });
+
+  it("scales a non-zero total proportionally to the max", () => {
+    expect(chartHeight(50, 100)).toBe(50);
+    expect(chartHeight(100, 100)).toBe(100);
+  });
+
+  it("respects the minimum visible height for small totals", () => {
+    expect(chartHeight(25, 100)).toBe(28);
+  });
+
+  it("returns the minimum height without a measurable max", () => {
+    expect(chartHeight(50, 0)).toBe(18);
+  });
+});

--- a/frontend/src/lib/dashboard.ts
+++ b/frontend/src/lib/dashboard.ts
@@ -1,0 +1,76 @@
+import type { Task, TaskStatus } from "@/types";
+
+export interface TodaySaleRecord {
+  total: number;
+  count: number;
+}
+
+export interface TodayMetrics {
+  sales: number;
+  transactions: number;
+  ticket: number;
+}
+
+/**
+ * Derives the day KPIs from a single DailySale record.
+ * Guards against a division by zero: when `count` is 0 the ticket is 0.
+ */
+export function computeTodayMetrics(rec?: TodaySaleRecord): TodayMetrics {
+  const total = rec?.total ?? 0;
+  const count = rec?.count ?? 0;
+
+  return {
+    sales: total,
+    transactions: count,
+    ticket: count > 0 ? total / count : 0,
+  };
+}
+
+/**
+ * Computes the pending amount of a partially-paid expense as
+ * `total - sum(payments.amount)`. When payments is missing or empty the
+ * pending amount falls back to the full `total`.
+ */
+export function computePendingAmount(expense: {
+  total: number;
+  payments?: Array<{ amount: number }>;
+}): number {
+  const total = expense?.total ?? 0;
+  const payments = expense?.payments;
+
+  if (!payments || payments.length === 0) {
+    return total;
+  }
+
+  const paid = payments.reduce((sum, payment) => sum + (payment?.amount ?? 0), 0);
+  return total - paid;
+}
+
+const OPEN_TASK_STATUSES: TaskStatus[] = ["PENDING", "IN_PROGRESS"];
+
+/**
+ * Keeps only the client-side open tasks (PENDING / IN_PROGRESS) and caps
+ * the result to `cap` entries (default 5).
+ */
+export function filterOpenTasks<T extends { status: TaskStatus }>(
+  tasks: T[],
+  cap = 5,
+): T[] {
+  return (tasks ?? []).filter((task) => OPEN_TASK_STATUSES.includes(task.status)).slice(0, cap);
+}
+
+/**
+ * Returns a proportional chart bar height for a day total against the series
+ * max. A zero (or immeasurable) total renders at the minimum visible height
+ * (18%); non-zero totals are scaled to at least 28% and at most 100%.
+ */
+export function chartHeight(total: number, max: number): number {
+  if (total <= 0 || max <= 0) {
+    return 18;
+  }
+
+  const scaled = Math.round((total / max) * 100);
+  return Math.max(28, Math.min(scaled, 100));
+}
+
+export type { Task };


### PR DESCRIPTION
## Summary

Refactor del `/dashboard` para convertirlo en un **panel operativo del día** con identidad propia, separado del análisis financiero/histórico de `/reports`. Implementado en 2 slices (PR1 coherence + PR2 operational identity) con Strict TDD.

### PR1 — Coherence (visual/semántica)
- Extraído `MetricCard` compartido (`components/ui/MetricCard.tsx`) con tone primary/accent/rose; `/reports` migrado a él (refactor mecánico).
- `lib/dashboard.ts` con helpers puros: ticket sin div/0, monto pendiente de gastos, filtro tareas abiertas, altura de barras.
- `TodayStats`: KPIs reales del día (ventas COP, ticket promedio, transacciones) desde `useDailySales(today,today)`.
- `RevenueChart`: gráfico data-driven sin curva fake, con tooltip exacto (COP + transacciones + fecha) al hover.
- Eliminados: meta hardcodeada "1,500", card engañosa "Ayer vs Hoy", función curva fake.

### PR2 — Operational identity
- `AlertPanels`: stock bajo con lista real + Reordenar, gastos por pagar (PARTIAL) con monto pendiente, tareas abiertas (PENDING/IN_PROGRESS, cap 5).
- `QuickActions`: accesos rápidos filtrados por rol (useAuth + hasAnyRole).
- Eliminada la tabla "Productos Vendidos" (duplicaba /reports) y su dead code.

## Changes

| File | Change |
|------|--------|
| `frontend/src/components/ui/MetricCard.tsx` | **Nuevo** — MetricCard compartido |
| `frontend/src/lib/dashboard.ts` | **Nuevo** — helpers puros |
| `frontend/src/components/dashboard/TodayStats.tsx` | **Nuevo** — KPIs del día |
| `frontend/src/components/dashboard/RevenueChart.tsx` | **Nuevo** — gráfico data-driven |
| `frontend/src/components/dashboard/AlertPanels.tsx` | **Nuevo** — alertas de acción |
| `frontend/src/components/dashboard/QuickActions.tsx` | **Nuevo** — accesos por rol |
| `frontend/src/app/dashboard/page.tsx` | Refactor — wired TodayStats/AlertPanels/QuickActions, sin fake/meta/tabla |
| `frontend/src/app/reports/page.tsx` | Migrado a MetricCard compartido |
| Varios `*.test.tsx` | Tests del dashboard (Strict TDD) |

## Test plan

- [x] `npm run build` → 29/29 green, tsc sin errores nuevos
- [x] `npm run test` → 44 files / 215 tests passed, exit 0
- [x] `gentle-ai sdd-verify-validate` → `valid: true`, verdict `pass_with_warnings` (13/13 requirements, 19/19 scenarios)

## Behavior notes

- El dashboard ahora responde "qué pasó hoy y qué requiere mi atención", sin duplicar el análisis de /reports.
- Veredicto `pass_with_warnings`: 4 cards secundarias del dashboard no migradas a MetricCard (desvío visual menor, no rompe spec) — SUGGESTION no bloqueante.
- Los 6 baseline failures (quaranteados en vitest.config.ts) quedan fuera de este cambio.
