### PR TITLE
feat(ui): full-month stacked chart with thin opencode-style bars

### DIFF
--- a/frontend/src/app/dashboard/page.evidence.test.tsx
+++ b/frontend/src/app/dashboard/page.evidence.test.tsx
@@ -153,12 +153,14 @@ describe("Dashboard scope evidence (DIA-4/13/10 — reports no longer duplicated
     expect(screen.getByText("Tareas abiertas")).toBeTruthy();
   });
 
-  it("renders the stacked category chart title in place of the simple revenue bars", () => {
+  it("renders the stacked category chart for the full current month", () => {
     render(<DashboardPage />);
 
-    expect(screen.getByText("Ingresos últimos 7 días")).toBeTruthy();
-    // One bar per day across the 7-day window.
-    expect(screen.getAllByTestId("category-daily-bar")).toHaveLength(7);
+    expect(screen.getByText(/^Ingresos de /)).toBeTruthy();
+    // One bar per day across every day of the current month (>= 28 days).
+    const barsCount = screen.getAllByTestId("category-daily-bar").length;
+    expect(barsCount).toBeGreaterThanOrEqual(28);
+    expect(barsCount).toBeLessThanOrEqual(31);
   });
 
   it("does not render a hardcoded sales goal, a fake curve or mislabeled 'Ayer vs Hoy' (DIA-4/DIA-13)", () => {

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react";
 import { DashboardLayout } from "@/components/layout/DashboardLayout";
 import { useDashboard, useSalesByCategoryDaily } from "@/hooks/useReports";
 import { LayoutDashboard } from "lucide-react";
-import { getBogotaDateInputValue, shiftDateInputValue } from "@/lib/utils";
+import { getBogotaDateInputValue } from "@/lib/utils";
 import { useAuth } from "@/contexts/AuthContext";
 import { LoadingState } from "@/components/ui/LoadingState";
 import { TodayStats } from "@/components/dashboard/TodayStats";
@@ -19,19 +19,14 @@ export default function DashboardPage() {
 
   const chartEndDate = useMemo(() => getBogotaDateInputValue(now), [now]);
   const chartStartDate = useMemo(
-    () => shiftDateInputValue(chartEndDate, -6),
+    () => `${chartEndDate.slice(0, 8)}01`,
     [chartEndDate],
   );
 
   const { data: categoryDaily } = useSalesByCategoryDaily(chartStartDate, chartEndDate);
 
-  const dateRange = useMemo(
-    () =>
-      Array.from({ length: 7 }, (_, index) =>
-        shiftDateInputValue(chartStartDate, index),
-      ),
-    [chartStartDate],
-  );
+  const dateRange = useMemo(() => buildMonthRange(chartEndDate), [chartEndDate]);
+  const monthLabel = useMemo(() => buildMonthLabel(now), [now]);
 
   if (isLoading) {
     return (
@@ -66,7 +61,7 @@ export default function DashboardPage() {
         {/* Stacked category chart — replaces the simple revenue bars */}
         <div className="min-w-0 overflow-hidden rounded-3xl border border-border/80 bg-card px-6 py-6 text-foreground">
           <p className="text-xs font-bold uppercase tracking-[0.2em] text-muted-foreground">
-            Ingresos últimos 7 días
+            Ingresos de {monthLabel}
           </p>
           <div className="mt-6">
             <CategoryStackedChart data={categoryDaily?.data ?? []} days={dateRange} />
@@ -78,4 +73,31 @@ export default function DashboardPage() {
       </div>
     </DashboardLayout>
   );
+}
+
+/**
+ * Builds the full list of `YYYY-MM-DD` dates for the month that `endDate`
+ * (a Bogotá `YYYY-MM-DD` value) belongs to, from the 1st to the last day.
+ */
+function buildMonthRange(endDate: string): string[] {
+  const [year, month] = endDate.split("-").map(Number);
+  if (!year || !month) {
+    return [endDate];
+  }
+
+  const daysInMonth = new Date(year, month, 0).getDate();
+  return Array.from(
+    { length: daysInMonth },
+    (_, index) => `${endDate.slice(0, 8)}${String(index + 1).padStart(2, "0")}`,
+  );
+}
+
+/**
+ * Spanish month name for the chart title, e.g. "agosto" (Bogotá timezone).
+ */
+function buildMonthLabel(date: Date): string {
+  return new Intl.DateTimeFormat("es-CO", {
+    month: "long",
+    timeZone: "America/Bogota",
+  }).format(date);
 }

--- a/frontend/src/components/dashboard/CategoryStackedChart.test.tsx
+++ b/frontend/src/components/dashboard/CategoryStackedChart.test.tsx
@@ -81,3 +81,62 @@ describe("CategoryStackedChart (daily stacked by category)", () => {
     expect(screen.getByTestId("category-tooltip").className).toContain("-translate-x-full");
   });
 });
+
+describe("CategoryStackedChart full-month behavior", () => {
+  const monthDays = Array.from(
+    { length: 30 },
+    (_, index) => `2026-08-${String(index + 1).padStart(2, "0")}`,
+  );
+
+  it("renders one bar per day across the full month", () => {
+    render(<CategoryStackedChart data={data} days={monthDays} />);
+
+    expect(screen.getAllByTestId("category-daily-bar")).toHaveLength(30);
+  });
+
+  it("spaces the day-number labels so a full month does not crowd", () => {
+    render(<CategoryStackedChart data={data} days={monthDays} />);
+
+    const labels = screen.getAllByTestId("category-day-label");
+    expect(labels).toHaveLength(30);
+
+    const visibleLabels = labels
+      .map((label) => label.textContent?.trim())
+      .filter((text) => text);
+    expect(visibleLabels).toEqual(["1", "5", "10", "15", "20", "25", "30"]);
+  });
+
+  it("leaves a clear thin-bar gap between adjacent bars", () => {
+    const { container } = render(
+      <CategoryStackedChart data={data} days={monthDays} />,
+    );
+
+    const slot = 400 / 30;
+    const bars = container.querySelectorAll(
+      '[data-testid="category-segment"], [data-testid="category-empty-bar"]',
+    );
+    const width = Number(bars[0].getAttribute("width"));
+
+    expect(width).toBeGreaterThan(0);
+    expect(width).toBeLessThan(slot * 0.8);
+  });
+
+  it("handles a 31-day month without dropping the last day or overflowing labels", () => {
+    const november = Array.from(
+      { length: 31 },
+      (_, index) => `2026-11-${String(index + 1).padStart(2, "0")}`,
+    );
+
+    render(<CategoryStackedChart data={data} days={november} />);
+
+    // Day 31 is still rendered as a bar.
+    expect(screen.getAllByTestId("category-daily-bar")).toHaveLength(31);
+
+    // Only the stepped days get a numeric label; day 31 stays unlabeled.
+    const labels = screen.getAllByTestId("category-day-label");
+    const visibleLabels = labels
+      .map((label) => label.textContent?.trim())
+      .filter((text) => text);
+    expect(visibleLabels).toEqual(["1", "5", "10", "15", "20", "25", "30"]);
+  });
+});

--- a/frontend/src/components/dashboard/CategoryStackedChart.tsx
+++ b/frontend/src/components/dashboard/CategoryStackedChart.tsx
@@ -49,7 +49,7 @@ export function CategoryStackedChart({
         : "-translate-x-1/2";
 
   const slot = series.length > 0 ? 400 / series.length : 0;
-  const barWidth = Math.max(6, slot * 0.96);
+  const barWidth = Math.max(3, slot * 0.72);
 
   const dayLabel = (date: string) => {
     const [year, month, day] = date.split("-").map(Number);
@@ -76,7 +76,7 @@ export function CategoryStackedChart({
         preserveAspectRatio="none"
         viewBox="0 0 400 100"
         role="img"
-        aria-label="Ventas por categoría de los últimos días"
+        aria-label="Ventas por categoría del mes"
       >
         {series.map((day, index) => {
           const dayHeight = dayHeightFor(day.total, maxDayTotal);
@@ -158,28 +158,22 @@ export function CategoryStackedChart({
         </div>
       )}
 
-      {/* Date labels */}
-      <div className="flex justify-between mt-2 text-[10px] uppercase tracking-wider text-muted-foreground/60 px-1">
-        {series.map((day) => (
-          <span key={day.date}>
-            {new Intl.DateTimeFormat("es-CO", {
-              weekday: "short",
-              timeZone: "America/Bogota",
-            })
-              .format(
-                new Date(
-                  Date.UTC(
-                    Number(day.date.split("-")[0]),
-                    Number(day.date.split("-")[1]) - 1,
-                    Number(day.date.split("-")[2]),
-                    12,
-                  ),
-                ),
-              )
-              .replace(".", "")
-              .slice(0, 3)}
-          </span>
-        ))}
+      {/* Date labels — spaced across the month so ~30 days don't crowd */}
+      <div className="mt-2 flex px-1 text-[8px] uppercase tracking-wider text-muted-foreground/60">
+        {series.map((day) => {
+          const dayNumber = Number(day.date.split("-")[2]);
+          const showLabel = dayNumber === 1 || dayNumber % 5 === 0;
+
+          return (
+            <span
+              key={day.date}
+              data-testid="category-day-label"
+              className="flex-1 text-center leading-none"
+            >
+              {showLabel ? dayNumber : ""}
+            </span>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

El gráfico apilado del dashboard ahora muestra el **mes completo actual** (todos los días del mes, no solo los últimos 7) con **barras delgadas** estilo opencode.ai.

### Cambios
- **Rango del mes completo**: el gráfico abarca del día 1 al último día del mes actual (`buildMonthRange`), en vez de los últimos 7 días.
- **Barras delgadas**: `barWidth` de `slot*0.96` → `slot*0.72` (mín 3px) → barras finas con mini-gap, la temática delgada de opencode.
- **Etiquetas de día espaciadas**: con ~30 días, se muestran etiquetas cada 5 días (día 1, 5, 10, 15...) para no saturarse.
- **Título del gráfico refleja el mes**: "Ingresos de {mes}".
- Tooltip de desglose por categoría preservado (sin cortarse, clamp existente).

## Changes

| File | Change |
|------|--------|
| `frontend/src/app/dashboard/page.tsx` | Rango mes completo (`buildMonthRange`), título del mes |
| `frontend/src/components/dashboard/CategoryStackedChart.tsx` | Barras delgadas + etiquetas espaciadas |
| `frontend/src/components/dashboard/CategoryStackedChart.test.tsx` | Tests 28-31 días |
| `frontend/src/app/dashboard/page.evidence.test.tsx` | Título mes + conteo de barras |

## Test plan

- [x] `npx vitest run src/components/dashboard/CategoryStackedChart.test.tsx src/app/dashboard/page.evidence.test.tsx` → 16/16 green
- [x] `npm run test` → 231/231 green (exit 0)
- [x] `npm run build` → 29/29, tsc limpio

## Behavior notes

- El gráfico ahora usa todo el mes; la leyenda/etiquetas espaciadas evitan el solapamiento con 30+ días.
- Día 31 sin etiqueta por diseño (solo cada 5 días).
- Los helpers de datos (`buildStackedDailySeries`/`buildCategoryColorMap`) y `formatCurrency` intactos.
