### PR TITLE
feat(backend): add customer reference/plate and supplier account fields

### DIFF
--- a/backend/prisma/migrations/20260823025004_add_customer_reference_and_plate/migration.sql
+++ b/backend/prisma/migrations/20260823025004_add_customer_reference_and_plate/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Customer" ADD COLUMN     "placaMoto" TEXT,
+ADD COLUMN     "referencia" TEXT;

--- a/backend/prisma/migrations/20260823025019_add_supplier_account_fields/migration.sql
+++ b/backend/prisma/migrations/20260823025019_add_supplier_account_fields/migration.sql
@@ -1,0 +1,6 @@
+-- CreateEnum
+CREATE TYPE "SupplierAccountType" AS ENUM ('SAVINGS', 'CHECKING');
+
+-- AlterTable
+ALTER TABLE "Supplier" ADD COLUMN     "accountNumber" TEXT,
+ADD COLUMN     "accountType" "SupplierAccountType";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -206,6 +206,8 @@ model Customer {
   documentNumber String
   email          String?
   phone          String?
+  referencia     String?
+  placaMoto      String?
   address        String?
   segment        CustomerSegment @default(OCCASIONAL)
   active         Boolean         @default(true)
@@ -333,6 +335,8 @@ model Supplier {
   phone          String?
   address        String?
   contactName    String?
+  accountNumber  String?
+  accountType    SupplierAccountType?
   active         Boolean         @default(true)
   createdAt      DateTime        @default(now())
   updatedAt      DateTime        @updatedAt
@@ -528,6 +532,11 @@ enum PaymentMethod {
   CASH
   CARD
   TRANSFER
+}
+
+enum SupplierAccountType {
+  SAVINGS
+  CHECKING
 }
 
 enum ExpensePaymentStatus {

--- a/backend/src/common/interfaces/export-formats.interface.ts
+++ b/backend/src/common/interfaces/export-formats.interface.ts
@@ -46,6 +46,8 @@ export interface ExportCustomer {
   email: string | null;
   phone: string | null;
   address: string | null;
+  referencia: string | null;
+  placaMoto: string | null;
   segment: string;
   totalPurchases: number;
 }

--- a/backend/src/customers/customers.service.spec.ts
+++ b/backend/src/customers/customers.service.spec.ts
@@ -141,6 +141,34 @@ describe('CustomersService', () => {
       expect(result.name).toBe('John');
     });
 
+    it('survives referencia and placaMoto into the create payload', async () => {
+      prismaMock.customer.findFirst.mockResolvedValue(null);
+      prismaMock.customer.create.mockResolvedValue({
+        id: 'c1',
+        name: 'John',
+        documentType: 'CC',
+        documentNumber: '123',
+        referencia: 'Entrega en portería',
+        placaMoto: 'ABC-123',
+        active: true,
+      });
+
+      const dto = {
+        name: 'John',
+        documentType: 'CC',
+        documentNumber: '123',
+        referencia: 'Entrega en portería',
+        placaMoto: 'ABC-123',
+      };
+      const result = await service.create(dto, orgId);
+
+      expect(prismaMock.customer.create).toHaveBeenCalledWith({
+        data: { ...dto, organizationId: orgId },
+      });
+      expect(result.referencia).toBe('Entrega en portería');
+      expect(result.placaMoto).toBe('ABC-123');
+    });
+
     it('throws ConflictException when document exists in organization', async () => {
       prismaMock.customer.findFirst.mockResolvedValue({ id: 'existing' });
 

--- a/backend/src/customers/dto/customer.dto.ts
+++ b/backend/src/customers/dto/customer.dto.ts
@@ -30,6 +30,16 @@ export class CreateCustomerDto {
   @IsOptional()
   phone?: string;
 
+  @ApiProperty({ example: 'Entrega en portería', required: false })
+  @IsString()
+  @IsOptional()
+  referencia?: string;
+
+  @ApiProperty({ example: 'ABC-123', required: false })
+  @IsString()
+  @IsOptional()
+  placaMoto?: string;
+
   @ApiProperty({ example: '123 Main St', required: false })
   @IsString()
   @IsOptional()
@@ -70,6 +80,16 @@ export class UpdateCustomerDto {
   @IsString()
   @IsOptional()
   phone?: string;
+
+  @ApiProperty({ example: 'Entrega en portería', required: false })
+  @IsString()
+  @IsOptional()
+  referencia?: string;
+
+  @ApiProperty({ example: 'ABC-123', required: false })
+  @IsString()
+  @IsOptional()
+  placaMoto?: string;
 
   @ApiProperty({ example: '123 Main St', required: false })
   @IsString()

--- a/backend/src/exports/exports.service.spec.ts
+++ b/backend/src/exports/exports.service.spec.ts
@@ -142,6 +142,91 @@ describe('ExportsService', () => {
     );
   });
 
+  it('exportCustomers writes 8 customer headers and rows with referencia/placaMoto (null renders N/A)', async () => {
+    prismaMock.customer.findMany.mockResolvedValue([
+      {
+        name: 'Juan Pérez',
+        documentType: 'CC',
+        documentNumber: '1234567890',
+        email: null,
+        phone: null,
+        segment: 'OCCASIONAL',
+        referencia: null,
+        placaMoto: null,
+      },
+    ]);
+
+    await service.exportCustomers(
+      ORG_ID,
+      { format: 'csv', type: 'customers' } as ExportQueryDto,
+      buildResMock(),
+    );
+
+    expect(csv.write).toHaveBeenCalledWith(
+      [
+        [
+          'Name',
+          'Document Type',
+          'Document #',
+          'Email',
+          'Phone',
+          'Segment',
+          'Referencia',
+          'Placa de la moto',
+        ],
+        [
+          'Juan Pérez',
+          'CC',
+          '1234567890',
+          'N/A',
+          'N/A',
+          'OCCASIONAL',
+          'N/A',
+          'N/A',
+        ],
+      ],
+      { headers: false },
+    );
+  });
+
+  it('exportCustomers renders real referencia/placaMoto values, not N/A', async () => {
+    prismaMock.customer.findMany.mockResolvedValue([
+      {
+        name: 'Laura Gómez',
+        documentType: 'CC',
+        documentNumber: '555666777',
+        email: 'laura@example.com',
+        phone: '3001234567',
+        segment: 'VIP',
+        referencia: 'Ref-01',
+        placaMoto: 'ABC-123',
+      },
+    ]);
+
+    await service.exportCustomers(
+      ORG_ID,
+      { format: 'csv', type: 'customers' } as ExportQueryDto,
+      buildResMock(),
+    );
+
+    expect(csv.write).toHaveBeenCalledWith(
+      [
+        expect.arrayContaining(['Name', 'Referencia', 'Placa de la moto']),
+        [
+          'Laura Gómez',
+          'CC',
+          '555666777',
+          'laura@example.com',
+          '3001234567',
+          'VIP',
+          'Ref-01',
+          'ABC-123',
+        ],
+      ],
+      { headers: false },
+    );
+  });
+
   it('exportInventory filters by organizationId', async () => {
     prismaMock.inventoryMovement.findMany.mockResolvedValue([]);
     const res = {

--- a/backend/src/exports/exports.service.ts
+++ b/backend/src/exports/exports.service.ts
@@ -372,6 +372,8 @@ export class ExportsService {
         'Email',
         'Phone',
         'Segment',
+        'Referencia',
+        'Placa de la moto',
       ],
       inventory: [
         'Date',
@@ -415,6 +417,8 @@ export class ExportsService {
         item.email || 'N/A',
         item.phone || 'N/A',
         item.segment,
+        item.referencia || 'N/A',
+        item.placaMoto || 'N/A',
       ],
       inventory: (item) => [
         new Date(item.createdAt).toLocaleDateString(),
@@ -441,7 +445,7 @@ export class ExportsService {
     const widths: Record<string, number[]> = {
       sales: [20, 30, 40, 25, 25, 30],
       products: [50, 25, 25, 20, 20, 15, 15],
-      customers: [35, 25, 25, 30, 25, 20],
+      customers: [35, 25, 25, 30, 25, 20, 30, 28],
       inventory: [25, 40, 25, 15, 20, 20, 25],
       expenses: [25, 40, 40, 20, 20],
       economic: [30, 40, 30],

--- a/backend/src/suppliers/dto/create-supplier.dto.ts
+++ b/backend/src/suppliers/dto/create-supplier.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsEmail, IsOptional, IsBoolean } from 'class-validator';
+import {
+  IsString,
+  IsEmail,
+  IsOptional,
+  IsBoolean,
+  IsEnum,
+} from 'class-validator';
+import { SupplierAccountType } from '@prisma/client';
 
 export class CreateSupplierDto {
   @ApiProperty({ example: 'Distribuidora XYZ S.A.S.' })
@@ -29,6 +36,16 @@ export class CreateSupplierDto {
   @IsString()
   @IsOptional()
   contactName?: string;
+
+  @ApiProperty({ example: '1234567890', required: false })
+  @IsString()
+  @IsOptional()
+  accountNumber?: string;
+
+  @ApiProperty({ enum: SupplierAccountType, example: 'SAVINGS', required: false })
+  @IsEnum(SupplierAccountType)
+  @IsOptional()
+  accountType?: SupplierAccountType;
 
   @ApiProperty({ example: true, required: false })
   @IsBoolean()

--- a/backend/src/suppliers/dto/update-supplier.dto.ts
+++ b/backend/src/suppliers/dto/update-supplier.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsEmail, IsOptional, IsBoolean } from 'class-validator';
+import {
+  IsString,
+  IsEmail,
+  IsOptional,
+  IsBoolean,
+  IsEnum,
+} from 'class-validator';
+import { SupplierAccountType } from '@prisma/client';
 
 export class UpdateSupplierDto {
   @ApiProperty({ required: false })
@@ -31,6 +38,16 @@ export class UpdateSupplierDto {
   @IsString()
   @IsOptional()
   contactName?: string;
+
+  @ApiProperty({ required: false })
+  @IsString()
+  @IsOptional()
+  accountNumber?: string;
+
+  @ApiProperty({ enum: SupplierAccountType, required: false })
+  @IsEnum(SupplierAccountType)
+  @IsOptional()
+  accountType?: SupplierAccountType;
 
   @ApiProperty({ required: false })
   @IsBoolean()

--- a/backend/src/suppliers/suppliers.service.spec.ts
+++ b/backend/src/suppliers/suppliers.service.spec.ts
@@ -1,4 +1,8 @@
 import { SuppliersService } from './suppliers.service';
+import { validate } from 'class-validator';
+import { SupplierAccountType } from '@prisma/client';
+import { CreateSupplierDto } from './dto/create-supplier.dto';
+import { UpdateSupplierDto } from './dto/update-supplier.dto';
 
 describe('SuppliersService', () => {
   let service: SuppliersService;
@@ -16,7 +20,7 @@ describe('SuppliersService', () => {
   };
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
     service = new SuppliersService(prismaMock as never);
   });
 
@@ -41,6 +45,32 @@ describe('SuppliersService', () => {
         data: { ...dto, organizationId: orgId },
       });
       expect(result.name).toBe('Proveedor Andino');
+    });
+
+    it('survives accountNumber and accountType into the create payload', async () => {
+      prismaMock.supplier.findFirst.mockResolvedValue(null);
+      prismaMock.supplier.create.mockResolvedValue({
+        id: 's1',
+        name: 'Proveedor Andino',
+        documentNumber: '900123456',
+        accountNumber: '1234567890',
+        accountType: 'SAVINGS',
+        organizationId: orgId,
+        active: true,
+      });
+
+      const dto = {
+        name: 'Proveedor Andino',
+        documentNumber: '900123456',
+        accountNumber: '1234567890',
+        accountType: 'SAVINGS' as SupplierAccountType,
+      };
+      const result = await service.create(dto, orgId);
+
+      expect(prismaMock.supplier.create).toHaveBeenCalledWith({
+        data: { ...dto, organizationId: orgId },
+      });
+      expect(result.accountType).toBe('SAVINGS');
     });
 
     it('throws ConflictException when document exists in organization', async () => {
@@ -143,6 +173,32 @@ describe('SuppliersService', () => {
       expect(result.name).toBe('Andino Updated');
     });
 
+    it('survives accountNumber and accountType into the update payload', async () => {
+      prismaMock.supplier.findFirst
+        .mockResolvedValueOnce({ id: 's1', documentNumber: '900' })
+        .mockResolvedValueOnce(null);
+      prismaMock.supplier.update.mockResolvedValue({
+        id: 's1',
+        name: 'Andino Updated',
+        documentNumber: '900',
+        accountNumber: '0987654321',
+        accountType: 'CHECKING',
+      });
+
+      const dto = {
+        name: 'Andino Updated',
+        accountNumber: '0987654321',
+        accountType: 'CHECKING' as SupplierAccountType,
+      };
+      const result = await service.update('s1', dto, orgId);
+
+      expect(prismaMock.supplier.update).toHaveBeenCalledWith({
+        where: { id: 's1' },
+        data: dto,
+      });
+      expect(result.accountType).toBe('CHECKING');
+    });
+
     it('throws NotFoundException when supplier not in organization', async () => {
       prismaMock.supplier.findFirst.mockResolvedValue(null);
 
@@ -227,6 +283,41 @@ describe('SuppliersService', () => {
       await expect(service.reactivate('s-999', orgId)).rejects.toThrow(
         'Proveedor no encontrado',
       );
+    });
+  });
+
+  describe('accountType field validation', () => {
+    it('accepts SAVINGS and CHECKING as valid enum values on create', async () => {
+      const dto = new CreateSupplierDto();
+      dto.name = 'Andino';
+      dto.documentNumber = '900';
+      dto.accountType = 'SAVINGS';
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts CHECKING on update', async () => {
+      const dto = new UpdateSupplierDto();
+      dto.accountType = 'CHECKING';
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('rejects an arbitrary invalid accountType value (e.g. AHORROS)', async () => {
+      const dto = new CreateSupplierDto();
+      dto.name = 'Andino';
+      dto.documentNumber = '900';
+      dto.accountType = 'AHORROS' as SupplierAccountType;
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'accountType')).toBe(true);
+    });
+
+    it('treats accountNumber and accountType as optional fields', async () => {
+      const dto = new CreateSupplierDto();
+      dto.name = 'Andino';
+      dto.documentNumber = '900';
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
Add optional data-capture fields to Customer (referencia, placaMoto) and Supplier (accountNumber, accountType enum SAVINGS/CHECKING), with two additive nullable migrations. Extend the customer export to 8 columns (headers, rowData, and column widths to avoid PDF out-of-bounds). Update service and export tests.

- Prisma: Customer.referencia/placaMoto, Supplier.accountNumber/accountType, enum SupplierAccountType
- DTOs: customer + supplier create/update
- Export: ExportCustomer + getHeaders/getRowData/getColumnWidths 6->8
- Tests: customers.service, suppliers.service, exports.service (44/44 pass)