### PR TITLE
feat(ui): unify POS search/scan input and add barcode capture to product modal

### DIFF
--- a/frontend/src/app/inventory/page.tsx
+++ b/frontend/src/app/inventory/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { DashboardLayout } from "@/components/layout/DashboardLayout";
 import {
   useProducts,
@@ -66,6 +66,8 @@ export default function InventoryPage() {
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
   const [formData, setFormData] = useState<Partial<Product>>({});
   const [taxRateInput, setTaxRateInput] = useState("");
+  const barcodeInputRef = useRef<HTMLInputElement | null>(null);
+  const nameInputRef = useRef<HTMLInputElement | null>(null);
 
   const { data, isLoading } = useProducts({
     page: showLowStockOnly || selectedCategory ? 1 : page,
@@ -285,6 +287,33 @@ export default function InventoryPage() {
       return result.imageUrl;
     }
   };
+
+  const handleBarcodeKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== "Enter") return;
+    // "Captura" mode: pressing Enter on a focused barcode field must NOT submit
+    // the form (which would save a product mid-scan). We preventDefault and
+    // advance focus to the Name field instead. Applied on BOTH create and edit
+    // so scanning a code during an edit also respects capture-and-advance; the
+    // auto-focus to barcode itself is create-only (see effect below).
+    e.preventDefault();
+    nameInputRef.current?.focus();
+  };
+
+  // Auto-focus the barcode field when the modal opens to CREATE (editingProduct
+  // === null). When editing an existing product we do NOT steal focus to the
+  // barcode field, leaving the default focus behavior intact. rAF defers to the
+  // next frame so the conditionally-rendered Modal has mounted the field.
+  useEffect(() => {
+    if (!showModal || editingProduct) return;
+    const scheduleFocus =
+      typeof window.requestAnimationFrame === "function"
+        ? window.requestAnimationFrame.bind(window)
+        : (callback: FrameRequestCallback) => window.setTimeout(callback, 0);
+    const frameId = scheduleFocus(() => {
+      barcodeInputRef.current?.focus();
+    });
+    return () => window.cancelAnimationFrame(frameId);
+  }, [showModal, editingProduct]);
 
   const hasFilter =
     selectedCategory || showLowStockOnly || statusFilter !== "active";
@@ -535,6 +564,7 @@ export default function InventoryPage() {
             </div>
             <div className="md:col-span-1 space-y-3 lg:space-y-4">
               <Input
+                ref={nameInputRef}
                 label="Nombre"
                 value={formData.name || ""}
                 onChange={(e) =>
@@ -551,11 +581,13 @@ export default function InventoryPage() {
                 required
               />
               <Input
+                ref={barcodeInputRef}
                 label="Código de Barras"
                 value={formData.barcode || ""}
                 onChange={(e) =>
                   setFormData({ ...formData, barcode: e.target.value })
                 }
+                onKeyDown={handleBarcodeKeyDown}
               />
               <BentoSelect
                 label="Categoría"

--- a/frontend/src/app/pos/page.behavior.test.tsx
+++ b/frontend/src/app/pos/page.behavior.test.tsx
@@ -314,7 +314,7 @@ describe("POS behavior evidence (#19, #18)", () => {
     });
 
     render(<POSPage />);
-    const searchInput = screen.getByPlaceholderText("Buscar por nombre, SKU o código...");
+    const searchInput = screen.getByPlaceholderText("Escanear o buscar por nombre, SKU o código...");
     await userEvent.click(searchInput);
     await userEvent.type(searchInput, "sinresultados");
 
@@ -336,7 +336,7 @@ describe("POS behavior evidence (#19, #18)", () => {
 
     render(<POSPage />);
 
-    const scannerInput = screen.getByPlaceholderText("Escanear codigo de barras o SKU");
+    const scannerInput = screen.getByPlaceholderText("Escanear o buscar por nombre, SKU o código...");
     await userEvent.type(scannerInput, "7701234567890{enter}");
 
     await waitFor(() => {
@@ -360,7 +360,7 @@ describe("POS behavior evidence (#19, #18)", () => {
 
     render(<POSPage />);
 
-    const scannerInput = screen.getByPlaceholderText("Escanear codigo de barras o SKU");
+    const scannerInput = screen.getByPlaceholderText("Escanear o buscar por nombre, SKU o código...");
     await userEvent.type(scannerInput, "NO-EXISTE{enter}");
 
     await waitFor(() => {

--- a/frontend/src/app/pos/page.tsx
+++ b/frontend/src/app/pos/page.tsx
@@ -62,6 +62,19 @@ interface ScanFeedback {
 const FAVORITE_PRODUCTS_KEY = "pos_favorite_product_ids";
 const DEFAULT_SCAN_FEEDBACK: ScanFeedback = { tone: "idle", message: "" };
 
+/**
+ * Heuristic (unified "doble intención" field) to tell a real barcode/SKU code
+ * being scanned from free-text browsing. An exact barcode/SKU lookup only
+ * surfaces the "not found" error when the value actually looks like a compact
+ * code: no whitespace and at most 64 chars. Anything with spaces or longer is
+ * treated as browse intent, so a failed exact lookup silently keeps the grid
+ * filtered by the (already-run) debounced contains search.
+ */
+function isCompactCode(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.length > 0 && trimmed.length <= 64 && !/\s/.test(trimmed);
+}
+
 export default function POSPage() {
   const toast = useToast();
   const [searchQuery, setSearchQuery] = useState("");
@@ -101,7 +114,6 @@ export default function POSPage() {
     null,
   );
   const [showDeletePausedModal, setShowDeletePausedModal] = useState(false);
-  const [scannerCode, setScannerCode] = useState("");
   const [scanFeedback, setScanFeedback] = useState<ScanFeedback>(
     DEFAULT_SCAN_FEEDBACK,
   );
@@ -121,6 +133,15 @@ export default function POSPage() {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
+  }, []);
+
+  // Clear the unified search/scan field: reset both the immediate value and the
+  // debounced grid filter, and cancel any pending debounce so a stalled timer
+  // doesn't re-apply a cleared query.
+  const clearSearchInput = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    setSearchQuery("");
+    setDebouncedSearch("");
   }, []);
 
   const {
@@ -361,7 +382,7 @@ export default function POSPage() {
       return;
     }
 
-    const normalizedCode = scannerCode.trim();
+    const normalizedCode = searchQuery.trim();
 
     if (!normalizedCode) {
       setScanFeedback({
@@ -376,11 +397,19 @@ export default function POSPage() {
       const product = await quickSearchProduct.mutateAsync(normalizedCode);
 
       if (!product) {
-        setScanFeedback({
-          tone: "error",
-          message: "No encontramos un producto con ese código.",
-        });
-        setScannerCode("");
+        // Only surface the "not found" error when the value actually looks
+        // like a compact barcode/SKU. Free-text browse queries keep the grid
+        // filtered by the debounced contains search, with neutral feedback, so
+        // typing the start of a name never interrupts browsing.
+        if (isCompactCode(normalizedCode)) {
+          setScanFeedback({
+            tone: "error",
+            message: "No encontramos un producto con ese código.",
+          });
+          clearSearchInput();
+        } else {
+          setScanFeedback(DEFAULT_SCAN_FEEDBACK);
+        }
         return;
       }
 
@@ -389,7 +418,7 @@ export default function POSPage() {
           tone: "warning",
           message: `${product.name} no tiene stock disponible.`,
         });
-        setScannerCode("");
+        clearSearchInput();
         return;
       }
 
@@ -399,7 +428,7 @@ export default function POSPage() {
           tone: "warning",
           message: `${product.name} ya alcanzó el stock máximo en el carrito.`,
         });
-        setScannerCode("");
+        clearSearchInput();
         return;
       }
 
@@ -408,7 +437,7 @@ export default function POSPage() {
         tone: "success",
         message: `${product.name} agregado al carrito.`,
       });
-      setScannerCode("");
+      clearSearchInput();
     } catch (error) {
       setScanFeedback({
         tone: "error",
@@ -417,17 +446,18 @@ export default function POSPage() {
           "No se pudo procesar el código escaneado.",
         ),
       });
-      setScannerCode("");
+      clearSearchInput();
     } finally {
       focusScannerInput();
     }
   }, [
     addToCart,
     cart,
+    clearSearchInput,
     focusScannerInput,
     isScannerBlocked,
     quickSearchProduct,
-    scannerCode,
+    searchQuery,
   ]);
 
   const handleScannerKeyDown = useCallback(
@@ -620,74 +650,58 @@ export default function POSPage() {
               </div>
             </div>
 
-            {/* Scanner */}
-            <div className="border-b border-primary/20 bg-primary/5 px-4 py-3.5">
-              <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
-                <div className="min-w-0 flex-1">
-                  <p className="mb-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                    Escaner POS
-                  </p>
-                  <div className="flex flex-col gap-2 sm:flex-row">
-                    <Input
-                      ref={scannerInputRef}
-                      placeholder="Escanear codigo de barras o SKU"
-                      value={scannerCode}
-                      onChange={(e) => {
-                        setScannerCode(e.target.value);
-                        if (scanFeedback.message) {
-                          setScanFeedback(DEFAULT_SCAN_FEEDBACK);
-                        }
-                      }}
-                      onKeyDown={handleScannerKeyDown}
-                      disabled={
-                        isScannerBlocked || quickSearchProduct.isPending
+            {/* Unified search & scanner — types to filter the grid, Enter scans/adds */}
+            <div className="flex flex-col gap-2.5 p-4 border-b border-primary/20 bg-background/40">
+              <div className="flex flex-col gap-2.5 sm:flex-row sm:items-center">
+                <div className="relative flex-1 min-w-0">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                  <Input
+                    ref={scannerInputRef}
+                    placeholder="Escanear o buscar por nombre, SKU o código..."
+                    value={searchQuery}
+                    onChange={(e) => {
+                      handleSearchChange(e.target.value);
+                      if (scanFeedback.message) {
+                        setScanFeedback(DEFAULT_SCAN_FEEDBACK);
                       }
-                      className="h-10"
-                    />
-                    <Button
-                      type="button"
-                      size="sm"
-                      onClick={() => void handleScanSubmit()}
-                      disabled={
-                        isScannerBlocked ||
-                        quickSearchProduct.isPending ||
-                        scannerCode.trim().length === 0
-                      }
-                      className="sm:w-auto"
-                    >
-                      Agregar
-                    </Button>
-                  </div>
+                    }}
+                    onKeyDown={handleScannerKeyDown}
+                    disabled={isScannerBlocked || quickSearchProduct.isPending}
+                    className="pl-9 h-9 text-sm"
+                  />
                 </div>
+                <Button
+                  type="button"
+                  variant={showFavoritesOnly ? "primary" : "secondary"}
+                  size="sm"
+                  onClick={() => {
+                    setShowFavoritesOnly((c) => !c);
+                    setCurrentPage(1);
+                  }}
+                  className="shrink-0"
+                >
+                  <Star
+                    className={`w-3.5 h-3.5 ${showFavoritesOnly ? "fill-current" : ""}`}
+                  />
+                  {showFavoritesOnly ? "Favoritos" : "Todos"}
+                </Button>
               </div>
-            </div>
-
-            {/* Search & Filters */}
-            <div className="flex flex-col gap-2.5 sm:flex-row sm:items-center p-4 border-b border-primary/20 bg-background/40">
-              <div className="relative flex-1 min-w-0">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-                <Input
-                  placeholder="Buscar por nombre, SKU o código..."
-                  value={searchQuery}
-                  onChange={(e) => handleSearchChange(e.target.value)}
-                  className="pl-9 h-9 text-sm"
-                />
-              </div>
-              <Button
-                type="button"
-                variant={showFavoritesOnly ? "primary" : "secondary"}
-                size="sm"
-                onClick={() => {
-                  setShowFavoritesOnly((c) => !c);
-                  setCurrentPage(1);
-                }}
-                className="shrink-0"
-              >
-                <Star
-                  className={`w-3.5 h-3.5 ${showFavoritesOnly ? "fill-current" : ""}`}
-                />
-                {showFavoritesOnly ? "Favoritos" : "Todos"}
-              </Button>
+              {scanFeedback.message && (
+                <p
+                  role="status"
+                  className={cn(
+                    "text-xs font-medium",
+                    {
+                      idle: "text-muted-foreground",
+                      success: "text-emerald-600 dark:text-emerald-400",
+                      warning: "text-amber-600 dark:text-amber-400",
+                      error: "text-red-600 dark:text-red-400",
+                    }[scanFeedback.tone],
+                  )}
+                >
+                  {scanFeedback.message}
+                </p>
+              )}
             </div>
 
             {/* Product Grid */}


### PR DESCRIPTION
## Summary

- POS: merge the separate search and scanner inputs into one field that filters the grid while typing and does an exact barcode/SKU lookup on Enter, adding the product to the cart.
- Inventory: barcode field in the product modal captures on Enter (no accidental form submit) and advances focus to the name field; auto-focuses on create only.

## Changes

| File | Change |
| ---- | ------ |
| frontend/src/app/pos/page.tsx | Unified search/scan input (typing filters, Enter adds to cart) with scanner autofocus and feedback preserved |
| frontend/src/app/inventory/page.tsx | Barcode capture mode: Enter preventDefaults and advances to Name; barcode auto-focus on create |
| frontend/src/app/pos/page.behavior.test.tsx | Updated to the unified placeholder |

## Test Plan

- [x] npm run lint
- [x] npx tsc --noEmit
- [x] Frontend test suite (238 passed)