### PR TITLE
fix(ui): center EmptyState across full grid width

### DIFF
--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -10,7 +10,12 @@ interface EmptyStateProps {
 
 export function EmptyState({ icon, title, subtitle, className }: EmptyStateProps) {
   return (
-    <div className={cn("flex flex-col items-center justify-center min-h-[200px] text-center", className)}>
+    <div
+      className={cn(
+        "flex w-full flex-col items-center justify-center col-span-full min-h-[200px] text-center",
+        className,
+      )}
+    >
       <div className="w-12 h-12 rounded-xl bg-muted flex items-center justify-center mb-3">
         {icon}
       </div>


### PR DESCRIPTION
## Summary

The \EmptyState\ component is used as a lone child of CSS grids in 20+ pages (products, POS, categories, suppliers, customers, etc.). When rendered as the only grid item it occupied a single cell (1 of 2-5 columns), so its centered icon/title appeared left-aligned instead of centered on the page.

This PR makes it span every grid column and center itself consistently. \w-full\ and \col-span-full\ are inert in block/table/flex contexts, so non-grid usages (table rows, flex cards) are unaffected.

## Changes

| File | Change |
| ---- | ------ |
| frontend/src/components/ui/EmptyState.tsx | Added \w-full\ and \col-span-full\ so EmptyState spans the full grid width and centers its icon/title |

## Test Plan

- [x] npx tsc --noEmit
- [x] npm run test (238 passed)

Follow-up note: this commit fixes the centering reported after PR #68 was merged; it is cherry-picked onto master via a fresh branch because the original branch was already merged.