### PR TITLE
perf(images): delegate delivery transforms to Cloudinary with custom next/image loader

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -32,6 +32,13 @@ const nextConfig: NextConfig = {
     optimizePackageImports: ["lucide-react", "@tanstack/react-query"],
   },
   images: {
+    // Custom Cloudinary loader: the backend stores the original Cloudinary URL
+    // (no width/format/quality transforms), so pushing all delivery transforms
+    // to Cloudinary's edge CDN and bypassing the Next.js optimizer avoids
+    // re-transcoding every image on a single Next server. See
+    // src/lib/image-loader.ts for the transform chain.
+    loader: "custom",
+    loaderFile: "./src/lib/image-loader.ts",
     remotePatterns: [
       {
         protocol: "https",

--- a/frontend/src/lib/image-loader.ts
+++ b/frontend/src/lib/image-loader.ts
@@ -1,0 +1,56 @@
+"use client";
+
+/**
+ * Custom loader for next/image that delegates ALL delivery transformations to
+ * Cloudinary's edge CDN and bypasses the Next.js image optimizer entirely.
+ *
+ * Why: the backend stores the original Cloudinary URL (without width/quality
+ * transforms), so with the default loader every image is fetched full-size and
+ * re-transcoded by the Next server on first request — a single-node CPU
+ * bottleneck that scales badly once there are many product images. With this
+ * loader the browser requests the exact width + WebP/AVIF straight from the
+ * Cloudinary CDN, so there is no server-side transcode and no growing origin
+ * image cache.
+ *
+ * Non-Cloudinary URLs (same-origin /uploads/... local fallback, or data: URIs
+ * in the upload preview) are returned untouched so nothing breaks.
+ */
+
+const CLOUDINARY_HOST = "https://res.cloudinary.com/";
+const CLOUDINARY_DELIVERY_MARKER = "/image/upload/";
+
+type ImageLoaderProps = {
+  src: string;
+  width: number;
+  quality?: number | string;
+};
+
+export default function imageLoader({
+  src,
+  width,
+  quality,
+}: ImageLoaderProps): string {
+  // Only rewrite real Cloudinary delivery URLs; leave local/data assets alone.
+  if (
+    !src.startsWith(CLOUDINARY_HOST) ||
+    !src.includes(CLOUDINARY_DELIVERY_MARKER)
+  ) {
+    return src;
+  }
+
+  const transforms = [
+    "f_auto", // let Cloudinary negotiate the best format (WebP/AVIF) per browser
+    "c_limit", // keep aspect ratio; only downscale (never upscale or crop)
+    `w_${Math.round(width)}`, // resize to the width next/image asked for
+    // next/image passes quality=75 by default; map the framework default (and
+    // "auto") to Cloudinary's content-aware q_auto, but honor an explicit value.
+    quality === "auto" || quality == null || quality === 75
+      ? "q_auto"
+      : `q_${quality}`,
+  ].join(",");
+
+  return src.replace(
+    CLOUDINARY_DELIVERY_MARKER,
+    `${CLOUDINARY_DELIVERY_MARKER}${transforms}/`,
+  );
+}


### PR DESCRIPTION
## Resumen
- Agrega un custom image loader (`frontend/src/lib/image-loader.ts`) que delega **todas** las transformaciones de entrega a Cloudinary y bypasea por completo el optimizador de Next.
- Configura en `next.config.ts`: `images.loader: 'custom'` + `loaderFile`.
- Resultado: el navegador pide al CDN de Cloudinary el ancho exacto + formato WebP/AVIF (`f_auto,c_limit,w_<w>,q_auto`), eliminando la re-transcodificación en el servidor — que era un cuello de botella de CPU en un solo nodo y crecía con la cantidad de productos con imagen.

## Archivos
| Archivo | Cambio |
|---------|--------|
| `frontend/next.config.ts` | Define `images.loader: 'custom'` y `loaderFile` apuntando al loader |
| `frontend/src/lib/image-loader.ts` | Nuevo custom loader con la cadena de transformación de Cloudinary |

## Test plan
- [x] `npm run build` compila sin errores (Next 16.1.3, TypeScript OK)
- [x] ESLint limpio sobre el loader
- [x] Transform probado con URLs Cloudinary, locales (`/uploads/...`) y `data:` — pasan intactas las locales/data
