### PR TITLE
feat(categories): browse products by category and remove tasks quick-add

### DIFF
--- a/frontend/src/app/categories/page.tsx
+++ b/frontend/src/app/categories/page.tsx
@@ -16,6 +16,7 @@ import type {
 import { Input } from "@/components/ui/Input";
 import { Button } from "@/components/ui/Button";
 import { Modal } from "@/components/ui/Modal";
+import { CategoryProductsModal } from "@/components/categories/CategoryProductsModal";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { Pagination } from "@/components/ui/Pagination";
 import { LoadingState } from "@/components/ui/LoadingState";
@@ -51,6 +52,7 @@ export default function CategoriesPage() {
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [categoryToDelete, setCategoryToDelete] = useState<string | null>(null);
   const [editingCategory, setEditingCategory] = useState<Category | null>(null);
+  const [productsCategory, setProductsCategory] = useState<Category | null>(null);
   const [formData, setFormData] = useState<CategoryPayload>({});
   const [defaultTaxRateInput, setDefaultTaxRateInput] = useState("");
 
@@ -244,7 +246,15 @@ export default function CategoriesPage() {
 
                     {/* Tax rate & Product count */}
                     <div className="flex items-center justify-between mt-2.5 pt-2.5 border-t border-border/40">
-                      <div className="flex items-center gap-1.5">
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setProductsCategory(category);
+                        }}
+                        className="inline-flex items-center gap-1.5 rounded-lg px-2 py-1 -ml-2 text-left transition-colors hover:bg-primary/10 hover:text-primary"
+                        aria-label={`Ver productos de ${category.name}`}
+                      >
                         <Package className="w-3.5 h-3.5 text-muted-foreground/60" />
                         <span
                           className={cn(
@@ -259,7 +269,7 @@ export default function CategoriesPage() {
                             ? "producto"
                             : "productos"}
                         </span>
-                      </div>
+                      </button>
                       {category.defaultTaxRate != null ? (
                         <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-md text-[10px] font-semibold bg-primary/10 text-primary border border-primary/20">
                           <Percent className="w-2.5 h-2.5" />
@@ -358,6 +368,11 @@ export default function CategoriesPage() {
         message="¿Estás seguro? Esta acción no se puede deshacer."
         confirmText="Eliminar"
         cancelText="Cancelar"
+      />
+
+      <CategoryProductsModal
+        category={productsCategory}
+        onClose={() => setProductsCategory(null)}
       />
     </DashboardLayout>
   );

--- a/frontend/src/app/tasks/page.tsx
+++ b/frontend/src/app/tasks/page.tsx
@@ -91,7 +91,6 @@ export default function TasksPage() {
   const [selectedAssigneeId, setSelectedAssigneeId] = useState<string>("ALL");
 
   // Selection & Forms
-  const [taskInput, setTaskInput] = useState("");
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [pendingDeletedTaskIds, setPendingDeletedTaskIds] = useState<string[]>([]);
   const [isEditingTask, setIsEditingTask] = useState(false);
@@ -224,20 +223,6 @@ export default function TasksPage() {
       await updateTaskStatus.mutateAsync({ id: taskId, status });
     } catch (error) {
       toast.error(getApiErrorMessage(error, "No se pudo actualizar la tarea"));
-    }
-  };
-
-  const handleQuickAddTask = async () => {
-    const trimmed = taskInput.trim();
-    if (!trimmed) return;
-
-    try {
-      const created = await createTask.mutateAsync({ title: trimmed });
-      setSelectedTaskId(created.id);
-      setTaskInput("");
-      toast.success("Tarea agregada");
-    } catch (error) {
-      toast.error(getApiErrorMessage(error, "No se pudo crear la tarea"));
     }
   };
 
@@ -573,29 +558,8 @@ export default function TasksPage() {
 
         {/* Main Content: Split Master-Detail */}
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 items-start">
-          {/* Left Column: Quick Add + Task List (7 cols) */}
+          {/* Left Column: Task List (7 cols) */}
           <div className="lg:col-span-7 space-y-4">
-            {/* Quick Add Bar */}
-            <form
-              className="flex items-center gap-2"
-              onSubmit={(e) => {
-                e.preventDefault();
-                handleQuickAddTask();
-              }}
-            >
-              <input
-                value={taskInput}
-                onChange={(e) => setTaskInput(e.target.value)}
-                placeholder="Agregar nueva tarea rápida (presiona Enter)..."
-                className="h-10 min-w-0 flex-1 rounded-2xl border border-border/70 bg-card px-4 text-xs sm:text-sm text-foreground placeholder:text-muted-foreground/60 focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all shadow-xs"
-                maxLength={120}
-              />
-              <Button type="submit" disabled={createTask.isPending || !taskInput.trim()} size="sm">
-                <Plus className="h-4 w-4 mr-1" />
-                {createTask.isPending ? "Guardando" : "Agregar"}
-              </Button>
-            </form>
-
             {/* Task List Card */}
             <Card className="overflow-hidden border-border/80 bg-card shadow-xs">
               <div className="border-b border-border/60 px-4 py-3 flex items-center justify-between">

--- a/frontend/src/components/categories/CategoryProductsModal.tsx
+++ b/frontend/src/components/categories/CategoryProductsModal.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import Image from "next/image";
+import { useProducts } from "@/hooks/useProducts";
+import { Modal } from "@/components/ui/Modal";
+import { LoadingState } from "@/components/ui/LoadingState";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { cn, formatCurrency } from "@/lib/utils";
+import { Package, PackageX } from "lucide-react";
+import type { Category, Product } from "@/types";
+
+interface CategoryProductsModalProps {
+  category: Category | null;
+  onClose: () => void;
+}
+
+function StockBadge({ product }: { product: Product }) {
+  const isOutOfStock = product.stock === 0;
+  const isLowStock = product.stock > 0 && product.stock <= product.minStock;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center px-2 py-0.5 rounded-md font-mono text-[10px] font-bold border shrink-0",
+        isOutOfStock
+          ? "bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/20"
+          : isLowStock
+            ? "bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-500/20"
+            : "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 border-emerald-500/20",
+      )}
+    >
+      {product.stock} uds.
+    </span>
+  );
+}
+
+function ProductRow({ product }: { product: Product }) {
+  const isInactive = product.active === false;
+
+  return (
+    <li
+      className={cn(
+        "flex items-center gap-3 rounded-xl border border-border/50 bg-card p-2.5 transition-colors hover:border-primary/30",
+        isInactive && "opacity-60",
+      )}
+    >
+      {/* Thumbnail */}
+      <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-lg border border-border/40 bg-muted/20">
+        {product.imageUrl ? (
+          <Image
+            src={product.imageUrl}
+            alt={product.name}
+            fill
+            sizes="48px"
+            className="object-cover"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center">
+            <Package className="h-5 w-5 text-muted-foreground/30" />
+          </div>
+        )}
+      </div>
+
+      {/* Info */}
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <p className="truncate text-[13px] font-semibold text-foreground">
+          {product.name}
+        </p>
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[10px] font-medium text-muted-foreground">
+            {product.sku}
+          </span>
+          {isInactive && (
+            <span className="font-mono text-[10px] font-semibold text-muted-foreground">
+              · Inactivo
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Price + stock */}
+      <div className="flex shrink-0 items-center gap-2.5">
+        <span className="font-mono text-[13px] font-bold text-foreground">
+          {formatCurrency(product.salePrice)}
+        </span>
+        <StockBadge product={product} />
+      </div>
+    </li>
+  );
+}
+
+export function CategoryProductsModal({
+  category,
+  onClose,
+}: CategoryProductsModalProps) {
+  const { data, isLoading, isError } = useProducts({
+    categoryId: category?.id,
+    limit: 200,
+    status: "all",
+    enabled: !!category?.id,
+  });
+
+  const products = data?.data ?? [];
+  const total = data?.meta?.total ?? 0;
+
+  return (
+    <Modal
+      isOpen={!!category}
+      onClose={onClose}
+      title={category ? `Productos · ${category.name}` : ""}
+      size="md"
+    >
+      {isLoading ? (
+        <LoadingState
+          icon={<Package className="w-4 h-4 text-primary/50" />}
+          message="Cargando productos..."
+        />
+      ) : isError ? (
+        <EmptyState
+          icon={<PackageX className="w-6 h-6 text-muted-foreground/30" />}
+          title="No se pudieron cargar los productos"
+          subtitle="Intenta de nuevo más tarde"
+        />
+      ) : products.length === 0 ? (
+        <EmptyState
+          icon={<PackageX className="w-6 h-6 text-muted-foreground/30" />}
+          title="No hay productos en esta categoría"
+          subtitle={total === 0 ? "Aún no se han asignado productos" : undefined}
+        />
+      ) : (
+        <>
+          {/* Count header */}
+          <div className="mb-3 flex items-center justify-between">
+            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-primary/10 text-primary border border-primary/20">
+              {total} {total === 1 ? "producto" : "productos"}
+            </span>
+            <span className="text-[11px] text-muted-foreground">
+              Desplázate para ver todos
+            </span>
+          </div>
+
+          {/* Scrollable list */}
+          <ul className="flex max-h-[55vh] flex-col gap-2 overflow-y-auto scrollbar-app pr-1">
+            {products.map((product) => (
+              <ProductRow key={product.id} product={product} />
+            ))}
+          </ul>
+        </>
+      )}
+    </Modal>
+  );
+}

--- a/frontend/src/hooks/useProducts.ts
+++ b/frontend/src/hooks/useProducts.ts
@@ -15,13 +15,16 @@ export function useProducts(params?: {
   search?: string;
   categoryId?: string;
   status?: "active" | "inactive" | "all";
+  enabled?: boolean;
 }) {
+  const { enabled = true, ...rest } = params ?? {};
   return useQuery({
-    queryKey: ["products", params],
+    queryKey: ["products", rest],
     queryFn: () =>
-      api.get<PaginatedResponse<Product>>("/products", params).then(
+      api.get<PaginatedResponse<Product>>("/products", rest).then(
         (res) => res.data
       ),
+    enabled,
     placeholderData: keepPreviousData,
   });
 }


### PR DESCRIPTION
## Summary

- Añade un modal que muestra los productos de una categoría desde un tag clickeable en la tarjeta de Categorías.
- Elimina la barra de 'agregar tarea rápida' en Tareas, reemplazada por el modal completo de 'Nueva tarea' (fix fuera de scope).

## Changes

| File | Change |
|------|--------|
| \rontend/src/components/categories/CategoryProductsModal.tsx\ | (nuevo) Modal que lista productos por categoría con scroll y badge de stock |
| \rontend/src/app/categories/page.tsx\ | Conecta el modal y convierte el contador de productos en tag clickeable |
| \rontend/src/hooks/useProducts.ts\ | Agrega param \enabled\ (default true) para usar \categoryId\ sin disparar la query |
| \rontend/src/app/tasks/page.tsx\ | Elimina el input y handler de quick-add de tareas |

## Test Plan

- [x] \
pm run build\ en frontend pasa sin errores
- [x] ESLint y \	sc --noEmit\ limpios
- [x] Se conserva el botón 'Nueva tarea' con su modal completo
