### PR TITLE
feat(sales): honor product promotions at sale time with search parity (#74, slice 2/3)

### DIFF
--- a/backend/prisma/migrations/20260825120000_add_product_promotions/migration.sql
+++ b/backend/prisma/migrations/20260825120000_add_product_promotions/migration.sql
@@ -1,0 +1,6 @@
+-- CreateEnum
+CREATE TYPE "PromotionType" AS ENUM ('PERCENTAGE', 'FIXED_PRICE');
+
+-- AlterTable
+ALTER TABLE "Product" ADD COLUMN     "promotionType" "PromotionType",
+ADD COLUMN     "promotionValue" DECIMAL(10,2);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -164,6 +164,8 @@ model Product {
   createdAt           DateTime            @default(now())
   updatedAt           DateTime            @updatedAt
   version             Int                 @default(0)
+  promotionType       PromotionType?
+  promotionValue      Decimal?            @db.Decimal(10, 2)
   preferredSupplierId String?
   organizationId      String
   movements           InventoryMovement[]
@@ -511,6 +513,11 @@ enum OrgRole {
   MEMBER
   CASHIER
   INVENTORY_USER
+}
+
+enum PromotionType {
+  PERCENTAGE
+  FIXED_PRICE
 }
 
 enum MovementType {

--- a/backend/src/products/dto/product.dto.spec.ts
+++ b/backend/src/products/dto/product.dto.spec.ts
@@ -1,0 +1,76 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreateProductDto, UpdateProductDto } from './product.dto';
+
+describe('Product promotion DTO shape', () => {
+  const baseCreate = {
+    name: 'Test Product',
+    sku: 'SKU-001',
+    costPrice: 100,
+    salePrice: 19900,
+    stock: 10,
+    minStock: 5,
+    categoryId: '123e4567-e89b-12d3-a456-426614174000',
+  };
+
+  it('accepts a valid promotion payload', async () => {
+    const dto = plainToInstance(CreateProductDto, {
+      ...baseCreate,
+      promotionType: 'PERCENTAGE',
+      promotionValue: 15,
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects a non-number promotionValue', async () => {
+    const dto = plainToInstance(UpdateProductDto, {
+      promotionValue: 'half-price',
+    });
+
+    const errors = await validate(dto);
+
+    const valueErrors = errors.find((e) => e.property === 'promotionValue');
+    expect(valueErrors).toBeDefined();
+    expect(valueErrors!.constraints).toHaveProperty('isNumber');
+  });
+
+  it('rejects a negative promotionValue', async () => {
+    const dto = plainToInstance(UpdateProductDto, {
+      promotionValue: -5,
+    });
+
+    const errors = await validate(dto);
+
+    const valueErrors = errors.find((e) => e.property === 'promotionValue');
+    expect(valueErrors).toBeDefined();
+    expect(valueErrors!.constraints).toHaveProperty('min');
+  });
+
+  it('rejects an unknown promotionType', async () => {
+    const dto = plainToInstance(UpdateProductDto, {
+      promotionType: 'BUY_ONE_GET_ONE',
+    });
+
+    const errors = await validate(dto);
+
+    const typeErrors = errors.find((e) => e.property === 'promotionType');
+    expect(typeErrors).toBeDefined();
+    expect(typeErrors!.constraints).toHaveProperty('isEnum');
+  });
+
+  it('lets an explicit null pass for clearing the promotion', async () => {
+    const dto = plainToInstance(UpdateProductDto, {
+      promotionType: null,
+      promotionValue: null,
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+    expect(dto.promotionType).toBeNull();
+    expect(dto.promotionValue).toBeNull();
+  });
+});

--- a/backend/src/products/dto/product.dto.ts
+++ b/backend/src/products/dto/product.dto.ts
@@ -6,7 +6,9 @@ import {
   IsBoolean,
   Min,
   IsUUID,
+  IsEnum,
 } from 'class-validator';
+import { PromotionType } from '@prisma/client';
 
 export class CreateProductDto {
   @ApiProperty({ example: 'Product Name' })
@@ -66,6 +68,22 @@ export class CreateProductDto {
   @ApiProperty({ example: 'uuid-category-id' })
   @IsUUID('all')
   categoryId: string;
+
+  @ApiProperty({
+    enum: PromotionType,
+    enumName: 'PromotionType',
+    required: false,
+    nullable: true,
+  })
+  @IsEnum(PromotionType)
+  @IsOptional()
+  promotionType?: PromotionType | null;
+
+  @ApiProperty({ example: 8000, required: false, nullable: true })
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  promotionValue?: number | null;
 }
 
 export class UpdateProductDto {
@@ -138,4 +156,20 @@ export class UpdateProductDto {
   @IsBoolean()
   @IsOptional()
   active?: boolean;
+
+  @ApiProperty({
+    enum: PromotionType,
+    enumName: 'PromotionType',
+    required: false,
+    nullable: true,
+  })
+  @IsEnum(PromotionType)
+  @IsOptional()
+  promotionType?: PromotionType | null;
+
+  @ApiProperty({ example: 8000, required: false, nullable: true })
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  promotionValue?: number | null;
 }

--- a/backend/src/products/products-search.controller.spec.ts
+++ b/backend/src/products/products-search.controller.spec.ts
@@ -55,4 +55,85 @@ describe('ProductsSearchController', () => {
       ),
     ).toThrow(ForbiddenException);
   });
+
+  describe('promotion parity', () => {
+    const user = { userId: 'user-1', organizationId: 'org-1', role: OrgRole.CASHIER };
+
+    const promoRow = {
+      id: 'prod-1',
+      name: 'Promo Donut',
+      sku: 'DNT-001',
+      barcode: '7701234567890',
+      salePrice: 10000,
+      stock: 10,
+      minStock: 2,
+      imageUrl: null,
+      category: { id: 'cat-1', name: 'Donuts' },
+      promotionType: 'PERCENTAGE',
+      promotionValue: 20,
+    };
+
+    it('search results carry promotion fields and the derived effective price', async () => {
+      prismaMock.product.findMany.mockResolvedValue([promoRow]);
+      const controller = new ProductsSearchController(prismaMock as never);
+
+      const result = await controller.searchProducts(user, 'donut');
+
+      expect(
+        prismaMock.product.findMany,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          select: expect.objectContaining({
+            promotionType: true,
+            promotionValue: true,
+          }),
+        }),
+      );
+      expect(result.data[0]).toEqual(
+        expect.objectContaining({
+          promotionType: 'PERCENTAGE',
+          promotionValue: 20,
+          effectiveSalePrice: 8000,
+        }),
+      );
+    });
+
+    it('quick-search results carry promotion fields and the derived effective price', async () => {
+      prismaMock.product.findFirst.mockResolvedValue(promoRow);
+      const controller = new ProductsSearchController(prismaMock as never);
+
+      const result = await controller.quickSearch(user, '7701234567890');
+
+      expect(
+        prismaMock.product.findFirst,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          select: expect.objectContaining({
+            promotionType: true,
+            promotionValue: true,
+          }),
+        }),
+      );
+      expect(result.data).toEqual(
+        expect.objectContaining({
+          promotionType: 'PERCENTAGE',
+          promotionValue: 20,
+          effectiveSalePrice: 8000,
+        }),
+      );
+    });
+
+    it('exposes a null effectiveSalePrice for products without an active promotion', async () => {
+      prismaMock.product.findFirst.mockResolvedValue({
+        ...promoRow,
+        promotionType: null,
+        promotionValue: null,
+      });
+      const controller = new ProductsSearchController(prismaMock as never);
+
+      const result = await controller.quickSearch(user, '7701234567890');
+
+      expect(result.data.effectiveSalePrice).toBeNull();
+    });
+  });
 });

--- a/backend/src/products/products-search.controller.ts
+++ b/backend/src/products/products-search.controller.ts
@@ -14,6 +14,7 @@ import { OrganizationRequiredGuard } from '../common/guards/organization-require
 import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 import type { RequestUser } from '../common/interfaces/request-user.interface';
+import { computeEffectiveSalePrice } from './products.service';
 
 @ApiTags('Products')
 @Controller('products')
@@ -71,6 +72,8 @@ export class ProductsSearchController {
         stock: true,
         minStock: true,
         imageUrl: true,
+        promotionType: true,
+        promotionValue: true,
         category: {
           select: {
             id: true,
@@ -89,6 +92,7 @@ export class ProductsSearchController {
       data: products.map((product) => ({
         ...product,
         isLowStock: product.stock <= product.minStock,
+        effectiveSalePrice: computeEffectiveSalePrice(product),
       })),
     };
   }
@@ -116,6 +120,8 @@ export class ProductsSearchController {
         stock: true,
         minStock: true,
         imageUrl: true,
+        promotionType: true,
+        promotionValue: true,
         category: {
           select: {
             id: true,
@@ -138,6 +144,7 @@ export class ProductsSearchController {
       data: {
         ...product,
         isLowStock: product.stock <= product.minStock,
+        effectiveSalePrice: computeEffectiveSalePrice(product),
       },
     };
   }

--- a/backend/src/products/products.controller.spec.ts
+++ b/backend/src/products/products.controller.spec.ts
@@ -1,0 +1,72 @@
+import { ForbiddenException, type ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { OrgRole } from '@prisma/client';
+import { ROLES_KEY } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import type { RequestUser } from '../common/interfaces/request-user.interface';
+import { ProductsController } from './products.controller';
+
+describe('ProductsController — promotion write authorization', () => {
+  const serviceMock = {
+    create: jest.fn(),
+    update: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    searchProducts: jest.fn(),
+    quickSearch: jest.fn(),
+    remove: jest.fn(),
+    deactivate: jest.fn(),
+    reactivate: jest.fn(),
+    getLowStockProducts: jest.fn(),
+    uploadImage: jest.fn(),
+    uploadProductImage: jest.fn(),
+  };
+
+  const createContext = (
+    handler: (...args: unknown[]) => unknown,
+    role: OrgRole,
+  ): ExecutionContext =>
+    ({
+      getHandler: () => handler,
+      getClass: () => ProductsController,
+      switchToHttp: () => ({
+        getRequest: () => ({ user: { role } }),
+      }),
+    }) as unknown as ExecutionContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('restricts product writes (create/update) to ADMIN and MEMBER', () => {
+    const controller = new ProductsController(serviceMock as never);
+
+    expect(Reflect.getMetadata(ROLES_KEY, controller.create)).toEqual([
+      OrgRole.ADMIN,
+      OrgRole.MEMBER,
+    ]);
+    expect(Reflect.getMetadata(ROLES_KEY, controller.update)).toEqual([
+      OrgRole.ADMIN,
+      OrgRole.MEMBER,
+    ]);
+  });
+
+  it('denies CASHIER a promotion write through PUT /products/:id (403)', () => {
+    const controller = new ProductsController(serviceMock as never);
+    const guard = new RolesGuard(new Reflector());
+
+    expect(() =>
+      guard.canActivate(createContext(controller.update, OrgRole.CASHIER)),
+    ).toThrow(ForbiddenException);
+    expect(serviceMock.update).not.toHaveBeenCalled();
+  });
+
+  it('allows MEMBER through RolesGuard on product update', () => {
+    const controller = new ProductsController(serviceMock as never);
+    const guard = new RolesGuard(new Reflector());
+
+    expect(
+      guard.canActivate(createContext(controller.update, OrgRole.MEMBER)),
+    ).toBe(true);
+  });
+});

--- a/backend/src/products/products.service.spec.ts
+++ b/backend/src/products/products.service.spec.ts
@@ -3,7 +3,8 @@ import {
   ConflictException,
   BadRequestException,
 } from '@nestjs/common';
-import { ProductsService } from './products.service';
+import { Prisma } from '@prisma/client';
+import { computeEffectiveSalePrice, ProductsService } from './products.service';
 
 describe('ProductsService — Opt-in tax resolution', () => {
   let service: ProductsService;
@@ -508,6 +509,150 @@ describe('ProductsService — Opt-in tax resolution', () => {
       const result = await service.getLowStockProducts(ORG_ID);
 
       expect(result).toEqual([{ id: 'prod-1', name: 'Panela' }]);
+    });
+  });
+
+  // ════════════════════════════════════════════════════════════════════
+  // Effective sale price derivation (promotions)
+  // ════════════════════════════════════════════════════════════════════
+  describe('computeEffectiveSalePrice', () => {
+    it('derives a percentage promo from the list price', () => {
+      expect(
+        computeEffectiveSalePrice({
+          salePrice: 19900,
+          promotionType: 'PERCENTAGE',
+          promotionValue: 15,
+        }),
+      ).toBe(16915);
+    });
+
+    it('returns the promotion value for a fixed-price promo', () => {
+      expect(
+        computeEffectiveSalePrice({
+          salePrice: 10000,
+          promotionType: 'FIXED_PRICE',
+          promotionValue: 8000,
+        }),
+      ).toBe(8000);
+    });
+
+    it('returns null when the product has no active promotion', () => {
+      expect(
+        computeEffectiveSalePrice({
+          salePrice: 19900,
+          promotionType: null,
+          promotionValue: null,
+        }),
+      ).toBeNull();
+      expect(computeEffectiveSalePrice({ salePrice: 19900 })).toBeNull();
+    });
+
+    it('rounds half-up to two decimals', () => {
+      expect(
+        computeEffectiveSalePrice({
+          salePrice: 999,
+          promotionType: 'PERCENTAGE',
+          promotionValue: 12.5,
+        }),
+      ).toBe(874.13);
+    });
+
+    it('accepts Prisma Decimal inputs', () => {
+      expect(
+        computeEffectiveSalePrice({
+          salePrice: new Prisma.Decimal('19900'),
+          promotionType: 'PERCENTAGE',
+          promotionValue: new Prisma.Decimal('15'),
+        }),
+      ).toBe(16915);
+    });
+  });
+
+  // ════════════════════════════════════════════════════════════════════
+  // Promotion enrichment on reads
+  // ════════════════════════════════════════════════════════════════════
+  describe('Promotion enrichment on reads', () => {
+    const baseDto = {
+      name: 'Promo Product',
+      sku: 'SKU-PROMO',
+      costPrice: 100,
+      salePrice: 19900,
+      stock: 10,
+      minStock: 5,
+      categoryId: 'cat-1',
+    };
+
+    const promoProduct = buildProduct({
+      salePrice: 19900,
+      promotionType: 'PERCENTAGE',
+      promotionValue: 15,
+    });
+
+    it('create persists the promotion and returns effectiveSalePrice', async () => {
+      prismaMock.category.findFirst.mockResolvedValue(
+        categoryWithDefault(null, false),
+      );
+      prismaMock.product.findUnique.mockResolvedValue(null);
+      prismaMock.product.create.mockResolvedValue(promoProduct);
+      prismaMock.inventoryMovement.create.mockResolvedValue({});
+
+      const result = await service.create(
+        {
+          ...baseDto,
+          promotionType: 'PERCENTAGE',
+          promotionValue: 15,
+        },
+        USER_ID,
+        ORG_ID,
+      );
+
+      expect(prismaMock.product.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            promotionType: 'PERCENTAGE',
+            promotionValue: 15,
+          }),
+        }),
+      );
+      expect(result.effectiveSalePrice).toBe(16915);
+    });
+
+    it('findAll enriches every product with effectiveSalePrice', async () => {
+      prismaMock.product.findMany.mockResolvedValue([
+        promoProduct,
+        buildProduct({ id: 'p2' }),
+      ]);
+      prismaMock.product.count.mockResolvedValue(2);
+
+      const result = await service.findAll(ORG_ID, 1, 10);
+
+      expect(result.data[0].effectiveSalePrice).toBe(16915);
+      expect(result.data[1].effectiveSalePrice).toBeNull();
+    });
+
+    it('findOne returns effectiveSalePrice for a promoted product', async () => {
+      prismaMock.product.findFirst.mockResolvedValue(promoProduct);
+
+      const result = await service.findOne('prod-1', ORG_ID);
+
+      expect(result.effectiveSalePrice).toBe(16915);
+    });
+
+    it('update returns effectiveSalePrice for the updated product', async () => {
+      prismaMock.product.findFirst
+        .mockResolvedValueOnce(buildProduct({ version: 1 }))
+        .mockResolvedValueOnce(promoProduct);
+      prismaMock.product.updateMany.mockResolvedValue({ count: 1 });
+      prismaMock.inventoryMovement.create.mockResolvedValue({});
+
+      const result = await service.update(
+        'prod-1',
+        { promotionType: 'PERCENTAGE', promotionValue: 15 },
+        USER_ID,
+        ORG_ID,
+      );
+
+      expect(result.effectiveSalePrice).toBe(16915);
     });
   });
 });

--- a/backend/src/products/products.service.spec.ts
+++ b/backend/src/products/products.service.spec.ts
@@ -655,4 +655,158 @@ describe('ProductsService — Opt-in tax resolution', () => {
       expect(result.effectiveSalePrice).toBe(16915);
     });
   });
+
+  // ════════════════════════════════════════════════════════════════════
+  // Promotion validation (cross-field invariants)
+  // ════════════════════════════════════════════════════════════════════
+  describe('Promotion validation', () => {
+    const createBase = {
+      name: 'Promo Product',
+      sku: 'SKU-PROMO-2',
+      costPrice: 100,
+      salePrice: 10000,
+      stock: 10,
+      minStock: 5,
+      categoryId: 'cat-1',
+    };
+
+    const setupCreateSuccess = () => {
+      prismaMock.category.findFirst.mockResolvedValue(
+        categoryWithDefault(null, false),
+      );
+      prismaMock.product.findUnique.mockResolvedValue(null);
+      prismaMock.product.create.mockResolvedValue(buildProduct());
+      prismaMock.inventoryMovement.create.mockResolvedValue({});
+    };
+
+    it('rejects PERCENTAGE values above 100 on create', async () => {
+      setupCreateSuccess();
+
+      await expect(
+        service.create(
+          { ...createBase, promotionType: 'PERCENTAGE', promotionValue: 150 },
+          USER_ID,
+          ORG_ID,
+        ),
+      ).rejects.toThrow(/promotionValue.*100/);
+    });
+
+    it('rejects FIXED_PRICE at or above the sale price on create', async () => {
+      setupCreateSuccess();
+
+      await expect(
+        service.create(
+          { ...createBase, promotionType: 'FIXED_PRICE', promotionValue: 10000 },
+          USER_ID,
+          ORG_ID,
+        ),
+      ).rejects.toThrow(/promotionValue.*salePrice/);
+    });
+
+    it('rejects FIXED_PRICE of 0 or less', async () => {
+      setupCreateSuccess();
+
+      await expect(
+        service.create(
+          { ...createBase, promotionType: 'FIXED_PRICE', promotionValue: 0 },
+          USER_ID,
+          ORG_ID,
+        ),
+      ).rejects.toThrow(/promotionValue/);
+    });
+
+    it('rejects a promotion type sent without a value', async () => {
+      setupCreateSuccess();
+
+      await expect(
+        service.create(
+          { ...createBase, promotionType: 'PERCENTAGE' },
+          USER_ID,
+          ORG_ID,
+        ),
+      ).rejects.toThrow(/together/);
+    });
+
+    it('validates FIXED_PRICE against the new salePrice when salePrice is also updated', async () => {
+      const existing = buildProduct({ salePrice: 20000, version: 1 });
+      prismaMock.product.findFirst.mockResolvedValueOnce(existing);
+
+      await expect(
+        service.update(
+          'prod-1',
+          { salePrice: 5000, promotionType: 'FIXED_PRICE', promotionValue: 6000 },
+          USER_ID,
+          ORG_ID,
+        ),
+      ).rejects.toThrow(/promotionValue.*salePrice/);
+    });
+
+    it('validates FIXED_PRICE against the existing salePrice when salePrice is omitted', async () => {
+      const existing = buildProduct({ salePrice: 10000, version: 1 });
+      prismaMock.product.findFirst.mockResolvedValueOnce(existing);
+
+      await expect(
+        service.update(
+          'prod-1',
+          { promotionType: 'FIXED_PRICE', promotionValue: 12000 },
+          USER_ID,
+          ORG_ID,
+        ),
+      ).rejects.toThrow(/promotionValue.*salePrice/);
+    });
+
+    it('clears the promotion when both fields are explicitly null and exposes null effectiveSalePrice', async () => {
+      const existing = buildProduct({
+        salePrice: 19900,
+        promotionType: 'PERCENTAGE',
+        promotionValue: 15,
+        version: 3,
+      });
+      prismaMock.product.findFirst
+        .mockResolvedValueOnce(existing)
+        .mockResolvedValueOnce(buildProduct({ version: 4 }));
+      prismaMock.product.updateMany.mockResolvedValue({ count: 1 });
+
+      const result = await service.update(
+        'prod-1',
+        { promotionType: null, promotionValue: null },
+        USER_ID,
+        ORG_ID,
+      );
+
+      expect(prismaMock.product.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            promotionType: null,
+            promotionValue: null,
+          }),
+        }),
+      );
+      expect(result.effectiveSalePrice).toBeNull();
+    });
+
+    it('keeps optimistic concurrency intact on promo updates (version where + increment)', async () => {
+      const existing = buildProduct({ version: 3 });
+      prismaMock.product.findFirst
+        .mockResolvedValueOnce(existing)
+        .mockResolvedValueOnce(
+          buildProduct({ promotionType: 'PERCENTAGE', promotionValue: 20, version: 4 }),
+        );
+      prismaMock.product.updateMany.mockResolvedValue({ count: 1 });
+
+      await service.update(
+        'prod-1',
+        { promotionType: 'PERCENTAGE', promotionValue: 20 },
+        USER_ID,
+        ORG_ID,
+      );
+
+      expect(prismaMock.product.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: 'prod-1', version: 3 }),
+          data: expect.objectContaining({ version: { increment: 1 } }),
+        }),
+      );
+    });
+  });
 });

--- a/backend/src/products/products.service.ts
+++ b/backend/src/products/products.service.ts
@@ -4,12 +4,48 @@ import {
   ConflictException,
   BadRequestException,
 } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { Prisma, PromotionType } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateProductDto, UpdateProductDto } from './dto/product.dto';
 import { CloudinaryService } from '../cloudinary/cloudinary.service';
 import { resolveEffectiveTaxRate } from '../common/utils/tax.util';
 import { PlanLimitService } from '../plan-limits/plan-limits.service';
+
+export interface PromoPricingProduct {
+  salePrice: Prisma.Decimal | number;
+  promotionType?: PromotionType | null;
+  promotionValue?: Prisma.Decimal | number | null;
+}
+
+/**
+ * Derives the effective sale price for a product from its optional promotion:
+ *
+ *   PERCENTAGE   → salePrice * (1 - promotionValue / 100)
+ *   FIXED_PRICE  → promotionValue
+ *   no promotion → null
+ *
+ * Computed in `number` (never float-chained Decimals) and rounded half-up to
+ * two decimals, consistent with the DECIMAL(10,2) columns.
+ */
+export function computeEffectiveSalePrice(product: PromoPricingProduct): number | null {
+  const { salePrice, promotionType, promotionValue } = product;
+
+  if (!promotionType || promotionValue == null) {
+    return null;
+  }
+
+  const listPrice = Number(salePrice);
+  const value = Number(promotionValue);
+
+  let raw: number;
+  if (promotionType === PromotionType.PERCENTAGE) {
+    raw = listPrice * (1 - value / 100);
+  } else {
+    raw = value;
+  }
+
+  return Math.round((raw + Number.EPSILON) * 100) / 100;
+}
 
 @Injectable()
 export class ProductsService {
@@ -99,7 +135,7 @@ export class ProductsService {
       organizationId,
     );
 
-    return this.enrichWithEffectiveTax(product);
+    return this.enrichWithEffectiveTax(this.enrichWithPromo(product));
   }
 
   async findAll(
@@ -146,7 +182,9 @@ export class ProductsService {
     ]);
 
     return {
-      data: products.map((p) => this.enrichWithEffectiveTax(p)),
+      data: products.map((p) =>
+        this.enrichWithEffectiveTax(this.enrichWithPromo(p)),
+      ),
       meta: {
         total,
         page,
@@ -166,7 +204,7 @@ export class ProductsService {
       throw new NotFoundException('Product not found');
     }
 
-    return this.enrichWithEffectiveTax(product);
+    return this.enrichWithEffectiveTax(this.enrichWithPromo(product));
   }
 
   async update(
@@ -280,7 +318,7 @@ export class ProductsService {
       );
     }
 
-    return this.enrichWithEffectiveTax(product);
+    return this.enrichWithEffectiveTax(this.enrichWithPromo(product));
   }
 
   async deactivate(id: string, organizationId: string | undefined) {
@@ -439,6 +477,19 @@ export class ProductsService {
     return {
       ...product,
       effectiveTaxRate: resolveEffectiveTaxRate(product, product.category),
+    };
+  }
+
+  /**
+   * Enriches a product with the promotion-aware effective sale price so every
+   * pricing read carries the same backend-computed value (null = no promo).
+   */
+  private enrichWithPromo<T extends PromoPricingProduct>(
+    product: T,
+  ): T & { effectiveSalePrice: number | null } {
+    return {
+      ...product,
+      effectiveSalePrice: computeEffectiveSalePrice(product),
     };
   }
 

--- a/backend/src/products/products.service.ts
+++ b/backend/src/products/products.service.ts
@@ -47,6 +47,66 @@ export function computeEffectiveSalePrice(product: PromoPricingProduct): number 
   return Math.round((raw + Number.EPSILON) * 100) / 100;
 }
 
+/**
+ * Cross-field promotion invariants, mirroring the taxable/taxRate precedent:
+ *
+ *   - PERCENTAGE  → 0 < promotionValue <= 100
+ *   - FIXED_PRICE → 0 < promotionValue < salePrice
+ *   - both fields null (or omitted) → no-op / explicit clearing
+ *   - partial writes (one field without the other) are rejected
+ *
+ * Shape validation lives in the DTO; this guards the business rules that need
+ * context (the effective sale price) the DTO cannot see.
+ */
+function assertValidPromotion(
+  promotionType: PromotionType | null | undefined,
+  promotionValue: number | null | undefined,
+  salePrice: number,
+): void {
+  const typeSent = promotionType !== undefined;
+  const valueSent = promotionValue !== undefined;
+
+  if (!typeSent && !valueSent) {
+    return;
+  }
+
+  const clearing = promotionType === null && promotionValue === null;
+  const fullySet = promotionType != null && promotionValue != null;
+
+  if (!clearing && !fullySet) {
+    throw new BadRequestException(
+      'promotionType and promotionValue must be provided together (send both as null to clear the promotion)',
+    );
+  }
+
+  if (!fullySet) {
+    return;
+  }
+
+  const value = Number(promotionValue);
+
+  if (promotionType === PromotionType.PERCENTAGE) {
+    if (!(value > 0 && value <= 100)) {
+      throw new BadRequestException(
+        'promotionValue must be greater than 0 and at most 100 for PERCENTAGE promotions',
+      );
+    }
+    return;
+  }
+
+  if (!(value > 0)) {
+    throw new BadRequestException(
+      'promotionValue must be greater than 0 for FIXED_PRICE promotions',
+    );
+  }
+
+  if (!(value < salePrice)) {
+    throw new BadRequestException(
+      'promotionValue must be less than salePrice for FIXED_PRICE promotions',
+    );
+  }
+}
+
 @Injectable()
 export class ProductsService {
   constructor(
@@ -109,6 +169,12 @@ export class ProductsService {
     } else {
       resolvedTaxRate = 0;
     }
+
+    assertValidPromotion(
+      createProductDto.promotionType,
+      createProductDto.promotionValue,
+      Number(createProductDto.salePrice),
+    );
 
     const product = await this.prisma.product.create({
       data: {
@@ -277,6 +343,12 @@ export class ProductsService {
         : updateProductDto.taxable === false
           ? { taxable: false, taxRate: 0 }
           : {};
+
+    assertValidPromotion(
+      updateProductDto.promotionType,
+      updateProductDto.promotionValue,
+      Number(updateProductDto.salePrice ?? existingProduct.salePrice),
+    );
 
     const updateResult = await this.prisma.product.updateMany({
       where: { id, version: existingProduct.version, active: true },

--- a/backend/src/reports/reports.service.spec.ts
+++ b/backend/src/reports/reports.service.spec.ts
@@ -1,4 +1,5 @@
 import { BadRequestException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { ReportsService } from './reports.service';
 
 describe('ReportsService', () => {
@@ -14,11 +15,15 @@ describe('ReportsService', () => {
     },
     product: {
       count: jest.fn(),
+      findMany: jest.fn(),
     },
     customer: {
       count: jest.fn(),
     },
     saleItem: {
+      findMany: jest.fn(),
+    },
+    inventoryMovement: {
       findMany: jest.fn(),
     },
     $queryRaw: jest.fn(),
@@ -282,5 +287,22 @@ describe('ReportsService', () => {
         { date: '2026-08-22', category: 'Bebidas', total: 20000, quantity: 1 },
       ]),
     );
+  });
+
+  it('values inventory at list price, ignoring active promotions', async () => {
+    prismaMock.product.findMany.mockResolvedValue([
+      {
+        stock: 10,
+        costPrice: new Prisma.Decimal('2000'),
+        salePrice: new Prisma.Decimal('5000'),
+        promotionType: 'PERCENTAGE',
+        promotionValue: new Prisma.Decimal('20'),
+      },
+    ]);
+    prismaMock.inventoryMovement.findMany.mockResolvedValue([]);
+
+    const result = await service.getInventorySnapshot('org-1');
+
+    expect(result.current.retailValue).toBe('50000.00');
   });
 });

--- a/backend/src/sales/sales.service.spec.ts
+++ b/backend/src/sales/sales.service.spec.ts
@@ -1069,5 +1069,71 @@ describe('SalesService', () => {
       expect(persisted.subtotal).toBe(8000);
       expect(persisted.total).toBe(8000);
     });
+
+    it('honors a trusted client unitPrice override even with an active promotion', async () => {
+      const tx = buildTx();
+      primeCreate(tx, promoProduct, 52);
+
+      await service.create(
+        {
+          items: [
+            { productId: 'prod-1', quantity: 1, unitPrice: 9000, discountAmount: 0 },
+          ],
+          discountAmount: 0,
+          payments: [{ method: 'CASH' as const, amount: 9000 }],
+        },
+        'user-1',
+        'org-1',
+      );
+
+      expect(tx.saleItem.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ unitPrice: 9000, subtotal: 9000 }),
+        }),
+      );
+    });
+
+    it('stacks the manual rebate on the offer price and floors the item total at zero', async () => {
+      const tx = buildTx();
+      primeCreate(tx, promoProduct, 53);
+
+      await service.create(
+        {
+          items: [{ productId: 'prod-1', quantity: 1, discountAmount: 8000 }],
+          discountAmount: 0,
+          payments: [{ method: 'CASH' as const, amount: 0 }],
+        },
+        'user-1',
+        'org-1',
+      );
+
+      const persisted = tx.saleItem.create.mock.calls[0][0].data;
+      expect(persisted.unitPrice).toBe(8000);
+      expect(persisted.discountAmount).toBe(8000);
+      expect(persisted.subtotal).toBe(0);
+      expect(persisted.total).toBe(0);
+      expect(tx.sale.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ subtotal: 0, total: 0 }),
+        }),
+      );
+    });
+
+    it('rejects an item discount greater than the offer gross subtotal', async () => {
+      const tx = buildTx();
+      primeCreate(tx, promoProduct, 54);
+
+      await expect(
+        service.create(
+          {
+            items: [{ productId: 'prod-1', quantity: 1, discountAmount: 8000.01 }],
+            discountAmount: 0,
+            payments: [{ method: 'CASH' as const, amount: 8000 }],
+          },
+          'user-1',
+          'org-1',
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
   });
 });

--- a/backend/src/sales/sales.service.spec.ts
+++ b/backend/src/sales/sales.service.spec.ts
@@ -966,4 +966,108 @@ describe('SalesService', () => {
       }),
     );
   });
+
+  describe('create promotion pricing', () => {
+    const promoProduct = {
+      id: 'prod-1',
+      name: 'Promo Product',
+      active: true,
+      costPrice: 5000,
+      salePrice: 10000,
+      taxable: false,
+      taxRate: 0,
+      stock: 10,
+      category: { taxable: false, defaultTaxRate: null },
+      promotionType: 'PERCENTAGE',
+      promotionValue: 20,
+    };
+
+    const buildTx = () => ({
+      sale: { create: jest.fn() },
+      saleItem: { create: jest.fn() },
+      product: {
+        findFirst: jest.fn().mockResolvedValue({ stock: 10 }),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      inventoryMovement: { create: jest.fn() },
+      payment: { create: jest.fn() },
+    });
+
+    const primeCreate = (
+      tx: ReturnType<typeof buildTx>,
+      product: Record<string, unknown>,
+      saleNumber: number,
+    ) => {
+      prismaMock.$transaction.mockImplementation(
+        async (callback: (tx: unknown) => unknown) => callback(tx),
+      );
+      sequenceServiceMock.nextNumber.mockResolvedValue({
+        number: saleNumber,
+        formatted: String(saleNumber),
+      });
+      prismaMock.product.findFirst.mockResolvedValue(product);
+      tx.sale.create.mockResolvedValue({ id: 'sale-new', saleNumber });
+      prismaMock.sale.findFirst.mockResolvedValue({
+        id: 'sale-new',
+        saleNumber,
+        userId: 'user-1',
+        user: { id: 'user-1', name: 'User', email: 'user@example.com' },
+        customer: null,
+        items: [],
+        payments: [],
+      });
+    };
+
+    it('falls back to the promotional effective price when the client omits unitPrice', async () => {
+      const tx = buildTx();
+      primeCreate(tx, promoProduct, 50);
+
+      await service.create(
+        {
+          items: [{ productId: 'prod-1', quantity: 2, discountAmount: 0 }],
+          discountAmount: 0,
+          payments: [{ method: 'CASH' as const, amount: 16000 }],
+        },
+        'user-1',
+        'org-1',
+      );
+
+      expect(tx.saleItem.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ unitPrice: 8000, subtotal: 16000 }),
+        }),
+      );
+      expect(tx.sale.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ subtotal: 16000 }),
+        }),
+      );
+    });
+
+    it('snapshots the promotional unit price at creation time (historical immutability)', async () => {
+      const tx = buildTx();
+      const product = { ...promoProduct };
+      primeCreate(tx, product, 51);
+
+      await service.create(
+        {
+          items: [{ productId: 'prod-1', quantity: 1, discountAmount: 0 }],
+          discountAmount: 0,
+          payments: [{ method: 'CASH' as const, amount: 8000 }],
+        },
+        'user-1',
+        'org-1',
+      );
+
+      // Later promo removal must not mutate the already-persisted SaleItem.
+      product.promotionType = null;
+      product.promotionValue = null;
+      product.salePrice = 12000;
+
+      const persisted = tx.saleItem.create.mock.calls[0][0].data;
+      expect(persisted.unitPrice).toBe(8000);
+      expect(persisted.subtotal).toBe(8000);
+      expect(persisted.total).toBe(8000);
+    });
+  });
 });

--- a/backend/src/sales/sales.service.ts
+++ b/backend/src/sales/sales.service.ts
@@ -18,6 +18,7 @@ import {
 import { CacheService } from '../common/services/cache.service';
 import { SettingsService } from '../settings/settings.service';
 import { resolveEffectiveTaxRate } from '../common/utils/tax.util';
+import { computeEffectiveSalePrice } from '../products/products.service';
 import { CURRENCY, LOCALE, TIMEZONE } from '../common/constants/locale.constants';
 import type { RequestUser } from '../common/interfaces/request-user.interface';
 import { SequenceService } from '../common/sequences/sequence.service';
@@ -108,7 +109,9 @@ export class SalesService {
         throw new BadRequestException(`Product ${product.name} is not active`);
       }
 
-      const unitPrice = Number(item.unitPrice ?? product.salePrice);
+      const unitPrice = Number(
+        item.unitPrice ?? computeEffectiveSalePrice(product) ?? product.salePrice,
+      );
       const grossSubtotal = unitPrice * item.quantity;
       const itemDiscount = Math.max(0, item.discountAmount || 0);
 


### PR DESCRIPTION
Part of #74 — persistent product promotions, slice 2 of 3 (stacked-to-main chain, stacked on #75).

## What
Activates promo pricing at sale time and closes the search/barcode parity gap.

- **Sale-time fallback**: `sales.service.create()` now resolves `item.unitPrice ?? computeEffectiveSalePrice(product) ?? product.salePrice` — the trusted client override wins; the promo price applies when no explicit unitPrice is sent. Historical sales remain immutable snapshots.
- **Rebate floor pins**: manual rebate stacks on the offer gross and floors at $0; discount greater than gross stays rejected; trusted override beats promo (approval tests).
- **Search/barcode parity**: `promotionType`/`promotionValue` added to both explicit Prisma selects (search + quickSearch) with `effectiveSalePrice` mapping, so scanned/quick-added products carry the offer. 3 parity tests pin it.

## Verification
- Strict TDD: 8 new tests (5 sales promotion pricing + 3 search parity).
- Full unit suite: 47 suites / 553 passing (baseline 545).
- Integration specs remain blocked-environmental (Postgres P1001 locally); migration from #75 still pending apply.

Stacked on #75 — merge order: #75 then this.