### PR TITLE
fix(pos): show product offers clearly in card and cart (#74 follow-up)

### DIFF
--- a/frontend/src/app/pos/page.tsx
+++ b/frontend/src/app/pos/page.tsx
@@ -49,6 +49,24 @@ import { api, getApiErrorMessage } from "@/lib/api";
 
 const POS_PAGE_SIZE = 20;
 
+/**
+ * Detect whether a cart line is carrying an active product promotion based on
+ * the product's backend-computed effectiveSalePrice (not on a manual price
+ * override). Returns the approximate whole-percent discount, or null when the
+ * line is not on offer.
+ */
+function cartItemOffer(item: CartItem) {
+  const price = item.product?.effectiveSalePrice;
+  const listPrice = item.product?.salePrice;
+  if (typeof price !== "number" || typeof listPrice !== "number") return null;
+  if (price === listPrice) return null;
+  const percent = Math.max(
+    0,
+    Math.round(100 - (price / listPrice) * 100),
+  );
+  return { percent };
+}
+
 interface PaymentMethod {
   type: "CASH" | "CARD" | "TRANSFER";
   amount: number;
@@ -831,12 +849,25 @@ export default function POSPage() {
                       <p className="text-xs font-semibold text-foreground line-clamp-1 mb-1">
                         {item.product.name}
                       </p>
-                      <p className="text-xs text-muted-foreground mb-1.5">
+                      <p className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs text-muted-foreground mb-1.5">
+                        {cartItemOffer(item) && (
+                          <span className="inline-flex shrink-0 items-center gap-1">
+                            <Badge
+                              variant="danger"
+                              className="px-1.5 py-0 text-[9px] font-mono uppercase shrink-0"
+                            >
+                              Oferta
+                            </Badge>
+                            <span className="font-mono text-[10px] font-bold text-danger dark:text-red-400">
+                              -{cartItemOffer(item)!.percent}%
+                            </span>
+                          </span>
+                        )}
                         {typeof item.originalUnitPrice === "number" &&
                           item.unitPrice !== item.originalUnitPrice && (
                             <s
                               data-testid="original-unit-price"
-                              className="mr-1 text-muted-foreground/60 line-through"
+                              className="text-muted-foreground/60 line-through"
                             >
                               {formatCurrency(item.originalUnitPrice)}
                             </s>

--- a/frontend/src/components/products/ProductCard.tsx
+++ b/frontend/src/components/products/ProductCard.tsx
@@ -94,6 +94,16 @@ function DualMetrics({ product }: { product: ProductCardData }) {
     typeof product.effectiveSalePrice === "number" &&
     product.effectiveSalePrice !== product.salePrice;
 
+  // Approximate discount as a whole percentage (rounded) of the list price.
+  const discountPercent = hasPromo
+    ? Math.max(
+        0,
+        Math.round(
+          100 - (Number(product.effectiveSalePrice) / product.salePrice) * 100,
+        ),
+      )
+    : 0;
+
   const stockBadgeClass = isOutOfStock
     ? "bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/20"
     : isLowStock
@@ -101,41 +111,56 @@ function DualMetrics({ product }: { product: ProductCardData }) {
       : "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 border-emerald-500/20";
 
   return (
-    <div className="flex items-center justify-between gap-2 rounded-xl border border-border/50 bg-muted/30 px-2.5 py-2">
-      <div className="flex flex-col min-w-0">
-        <span className="font-mono text-[9px] font-bold uppercase tracking-wider text-muted-foreground flex items-center gap-1.5">
+    <div className="flex items-start justify-between gap-2 rounded-xl border border-border/50 bg-muted/30 px-2.5 py-2">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="font-mono text-[9px] font-bold uppercase tracking-wider text-muted-foreground">
           Precio
-          {hasPromo && (
-            <Badge variant="danger" className="text-[9px] px-1.5 py-0 font-mono uppercase">
-              Oferta
-            </Badge>
-          )}
         </span>
-        <span className="font-mono text-[13px] sm:text-[14px] font-extrabold text-foreground tracking-tight truncate">
-          {hasPromo ? (
-            <>
+
+        {hasPromo ? (
+          <>
+            {/* Promo price — prominent, never truncated */}
+            <span
+              data-testid="offer-effective-price"
+              className="font-mono text-[15px] font-extrabold leading-none tracking-tight text-foreground"
+            >
+              {formatCurrency(product.effectiveSalePrice as number)}
+            </span>
+            {/* OFERTA badge + struck-through list price + discount approx (wrap-safe, no cut/overlap) */}
+            <span className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+              <Badge
+                variant="danger"
+                className="shrink-0 text-[9px] px-1.5 py-0 font-mono uppercase"
+              >
+                Oferta
+              </Badge>
               <s
                 data-testid="offer-list-price"
-                className="mr-1 text-[11px] font-semibold text-muted-foreground line-through"
+                className="font-mono text-[11px] font-semibold text-muted-foreground line-through"
               >
                 {formatCurrency(product.salePrice)}
               </s>
-              <span data-testid="offer-effective-price">
-                {formatCurrency(product.effectiveSalePrice as number)}
-              </span>
-            </>
-          ) : (
-            formatCurrency(product.salePrice)
-          )}
-        </span>
+              {discountPercent > 0 && (
+                <span className="shrink-0 font-mono text-[10px] font-bold text-danger dark:text-red-400">
+                  -{discountPercent}%
+                </span>
+              )}
+            </span>
+          </>
+        ) : (
+          <span className="font-mono text-[14px] font-extrabold leading-none tracking-tight text-foreground">
+            {formatCurrency(product.salePrice)}
+          </span>
+        )}
       </div>
-      <div className="flex flex-col items-end shrink-0">
-        <span className="font-mono text-[9px] font-bold uppercase tracking-wider text-muted-foreground mb-0.5">
+
+      <div className="flex shrink-0 flex-col items-end gap-1">
+        <span className="font-mono text-[9px] font-bold uppercase tracking-wider text-muted-foreground">
           Stock
         </span>
         <span
           className={cn(
-            "inline-flex items-center font-mono text-[11px] font-bold px-2 py-0.5 rounded-md border",
+            "inline-flex shrink-0 items-center font-mono text-[11px] font-bold px-2 py-0.5 rounded-md border",
             stockBadgeClass,
           )}
         >


### PR DESCRIPTION
Follow-up UI polish for the product promotions feature (#74).

## What
Addresses 3 visual/UX issues found after the promo PRs merged:

1. **Product card offer price was truncated/hard to read.** The promo price now renders prominently (larger, never truncated) above the struck-through list price, which sits beside the OFERTA badge, along with an approximate discount percentage (e.g. `-30%`). Stock stays with its units on the right.
2. **POS cart didn't identify offers.** Each cart line for a product carrying an active promotion now shows an OFERTA badge plus the approximate `%` discount, so you can see at a glance which items are on offer at sale time.
3. **Badges got cut/overlapped/stacked.** Tags are now `shrink-0` and the price rows wrap instead of truncating, so nothing is cropped or piled up at any card width.

No production logic changed: promo detection rides the backend-computed `effectiveSalePrice`, so a manual cashier price override is *not* mislabeled as an offer.

## Verification
- Frontend suite: 47 files / 263 tests passing (39 targeted ProductCard + POS behavior first).
- `tsc --noEmit` clean; ESLint clean on both changed files.
- Pre-existing dirty `backend/package.json` left untouched/uncommitted.