### PR TITLE
fix(pos): show product offers in the cart and tidy the offer tag (#74 follow-up)

### DIFF
--- a/frontend/src/app/pos/page.behavior.test.tsx
+++ b/frontend/src/app/pos/page.behavior.test.tsx
@@ -355,6 +355,31 @@ describe("POS behavior evidence (#19, #18)", () => {
     expect(screen.getByText("1 en carrito")).toBeTruthy();
   });
 
+  it("shows the OFERTA badge and struck list price in the cart for a promoted product (Decimal-string salePrice)", async () => {
+    useProductsMock.mockReturnValue({
+      data: {
+        data: [
+          makeProduct("1", "Promo Product", {
+            salePrice: "10000" as unknown as number,
+            effectiveSalePrice: 8000,
+            promotionType: "PERCENTAGE",
+            promotionValue: 20,
+          }),
+        ],
+        meta: { total: 1, page: 1, limit: 20, totalPages: 1 },
+      },
+      isLoading: false,
+      isFetching: false,
+    });
+
+    render(<POSPage />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Promo Product" }));
+
+    expect(screen.getByText(/Oferta -20%/)).toBeTruthy();
+    expect(screen.getByTestId("original-unit-price")).toBeTruthy();
+  });
+
   it("shows scanner feedback when the scanned code is not found", async () => {
     useProductsMock.mockReturnValue({
       data: {

--- a/frontend/src/app/pos/page.tsx
+++ b/frontend/src/app/pos/page.tsx
@@ -56,10 +56,12 @@ const POS_PAGE_SIZE = 20;
  * line is not on offer.
  */
 function cartItemOffer(item: CartItem) {
-  const price = item.product?.effectiveSalePrice;
-  const listPrice = item.product?.salePrice;
-  if (typeof price !== "number" || typeof listPrice !== "number") return null;
-  if (price === listPrice) return null;
+  // salePrice can arrive as a Decimal string over HTTP while effectiveSalePrice
+  // is a number; normalize both so the offer is detected regardless.
+  const price = Number(item.product?.effectiveSalePrice);
+  const listPrice = Number(item.product?.salePrice);
+  if (!Number.isFinite(price) || !Number.isFinite(listPrice)) return null;
+  if (price === listPrice || price >= listPrice) return null;
   const percent = Math.max(
     0,
     Math.round(100 - (price / listPrice) * 100),
@@ -267,9 +269,11 @@ export default function POSPage() {
           product,
           quantity: Math.min(quantity, product.stock),
           // Promotional price wins when present; list price stays snapshotted
-          // as originalUnitPrice so the cart can strike it through.
-          unitPrice: product.effectiveSalePrice ?? product.salePrice,
-          originalUnitPrice: product.salePrice,
+          // as originalUnitPrice so the cart can strike it through. Prices are
+          // normalized to numbers because salePrice can arrive as a Decimal
+          // string over HTTP while effectiveSalePrice is a number.
+          unitPrice: Number(product.effectiveSalePrice ?? product.salePrice),
+          originalUnitPrice: Number(product.salePrice),
           discountAmount: 0,
           availableStock: product.stock,
         },
@@ -851,25 +855,20 @@ export default function POSPage() {
                       </p>
                       <p className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs text-muted-foreground mb-1.5">
                         {cartItemOffer(item) && (
-                          <span className="inline-flex shrink-0 items-center gap-1">
-                            <Badge
-                              variant="danger"
-                              className="px-1.5 py-0 text-[9px] font-mono uppercase shrink-0"
-                            >
-                              Oferta
-                            </Badge>
-                            <span className="font-mono text-[10px] font-bold text-danger dark:text-red-400">
-                              -{cartItemOffer(item)!.percent}%
-                            </span>
-                          </span>
+                          <Badge
+                            variant="danger"
+                            className="shrink-0 text-[9px] px-1.5 py-0 font-mono uppercase"
+                          >
+                            Oferta -{cartItemOffer(item)!.percent}%
+                          </Badge>
                         )}
-                        {typeof item.originalUnitPrice === "number" &&
-                          item.unitPrice !== item.originalUnitPrice && (
+                        {Number.isFinite(Number(item.originalUnitPrice)) &&
+                          Number(item.unitPrice) !== Number(item.originalUnitPrice) && (
                             <s
                               data-testid="original-unit-price"
                               className="text-muted-foreground/60 line-through"
                             >
-                              {formatCurrency(item.originalUnitPrice)}
+                              {formatCurrency(Number(item.originalUnitPrice))}
                             </s>
                           )}
                         <span data-testid="line-unit-price">

--- a/frontend/src/components/products/ProductCard.inventory.test.tsx
+++ b/frontend/src/components/products/ProductCard.inventory.test.tsx
@@ -203,11 +203,37 @@ describe("ProductCard — offer badge and strikethrough (#74)", () => {
       />,
     );
 
-    expect(screen.getByText("Oferta")).toBeInTheDocument();
+    expect(screen.getByText(/Oferta/)).toBeInTheDocument();
+    // The tag carries the approximate discount %.
+    expect(screen.getByText(/Oferta/).textContent).toContain("-20%");
 
     const listPrice = screen.getByTestId("offer-list-price");
     expect(listPrice).toHaveClass("line-through");
     expect(listPrice.textContent).toContain(formatCurrency(10000));
+    expect(screen.getByTestId("offer-effective-price").textContent).toContain(
+      formatCurrency(8000),
+    );
+  });
+
+  it("detects the offer even when salePrice arrives as a numeric string (Decimal)", () => {
+    render(
+      <ProductCard
+        product={{
+          ...baseProduct,
+          salePrice: "10000" as unknown as number,
+          effectiveSalePrice: 8000,
+          promotionType: "PERCENTAGE",
+          promotionValue: 20,
+        }}
+        mode="inventory"
+      />,
+    );
+
+    expect(screen.getByText(/Oferta/)).toBeInTheDocument();
+    expect(screen.getByText(/Oferta/).textContent).toContain("-20%");
+    expect(screen.getByTestId("offer-list-price").textContent).toContain(
+      formatCurrency(10000),
+    );
     expect(screen.getByTestId("offer-effective-price").textContent).toContain(
       formatCurrency(8000),
     );
@@ -221,7 +247,7 @@ describe("ProductCard — offer badge and strikethrough (#74)", () => {
       />,
     );
 
-    expect(screen.queryByText("Oferta")).toBeNull();
+    expect(screen.queryByText(/Oferta/)).toBeNull();
     expect(screen.queryByTestId("offer-list-price")).toBeNull();
     expect(screen.queryByTestId("offer-effective-price")).toBeNull();
   });
@@ -241,7 +267,8 @@ describe("ProductCard — offer badge and strikethrough (#74)", () => {
       />,
     );
 
-    expect(screen.getByText("Oferta")).toBeInTheDocument();
+    expect(screen.getByText(/Oferta/)).toBeInTheDocument();
+    expect(screen.getByText(/Oferta/).textContent).toContain("-15%");
     expect(screen.getByTestId("offer-list-price").textContent).toContain(
       formatCurrency(19900),
     );

--- a/frontend/src/components/products/ProductCard.tsx
+++ b/frontend/src/components/products/ProductCard.tsx
@@ -92,14 +92,16 @@ function DualMetrics({ product }: { product: ProductCardData }) {
 
   const hasPromo =
     typeof product.effectiveSalePrice === "number" &&
-    product.effectiveSalePrice !== product.salePrice;
+    Number(product.effectiveSalePrice) !== Number(product.salePrice);
 
   // Approximate discount as a whole percentage (rounded) of the list price.
   const discountPercent = hasPromo
     ? Math.max(
         0,
         Math.round(
-          100 - (Number(product.effectiveSalePrice) / product.salePrice) * 100,
+          100 -
+            (Number(product.effectiveSalePrice) / Number(product.salePrice)) *
+              100,
         ),
       )
     : 0;
@@ -124,32 +126,26 @@ function DualMetrics({ product }: { product: ProductCardData }) {
               data-testid="offer-effective-price"
               className="font-mono text-[15px] font-extrabold leading-none tracking-tight text-foreground"
             >
-              {formatCurrency(product.effectiveSalePrice as number)}
+              {formatCurrency(Number(product.effectiveSalePrice))}
             </span>
-            {/* OFERTA badge + struck-through list price + discount approx (wrap-safe, no cut/overlap) */}
-            <span className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
-              <Badge
-                variant="danger"
-                className="shrink-0 text-[9px] px-1.5 py-0 font-mono uppercase"
-              >
-                Oferta
-              </Badge>
-              <s
-                data-testid="offer-list-price"
-                className="font-mono text-[11px] font-semibold text-muted-foreground line-through"
-              >
-                {formatCurrency(product.salePrice)}
-              </s>
-              {discountPercent > 0 && (
-                <span className="shrink-0 font-mono text-[10px] font-bold text-danger dark:text-red-400">
-                  -{discountPercent}%
-                </span>
-              )}
-            </span>
+            {/* OFERTA tag carries the discount %, and the original list price is
+                struck through BELOW the offer price (no cut/overlap/stack). */}
+            <Badge
+              variant="danger"
+              className="shrink-0 w-fit text-[9px] px-1.5 py-0 font-mono uppercase"
+            >
+              Oferta{discountPercent > 0 ? ` -${discountPercent}%` : ""}
+            </Badge>
+            <s
+              data-testid="offer-list-price"
+              className="font-mono text-[11px] font-semibold text-muted-foreground line-through"
+            >
+              {formatCurrency(Number(product.salePrice))}
+            </s>
           </>
         ) : (
           <span className="font-mono text-[14px] font-extrabold leading-none tracking-tight text-foreground">
-            {formatCurrency(product.salePrice)}
+            {formatCurrency(Number(product.salePrice))}
           </span>
         )}
       </div>


### PR DESCRIPTION
Follow-up to #78 for the product promotions feature (#74).

## What
1. **Cart now shows the offer.** The OFERTA badge and the struck-through original price never rendered in the POS cart. Root cause: `salePrice` arrives as a Decimal **string** over HTTP while `effectiveSalePrice` is a **number**, and the cart helpers bailed out on the non-numeric type. Now `addToCart` normalizes prices with `Number()`, `cartItemOffer` coerces both, and the struck price tolerates paused-sale data. So each promoted line in the cart shows `Oferta -20%` + struck list price.
2. **OFERTA tag carries the % and the struck price sits below the offer price** (per your feedback). The card now renders: offer price, then the `Oferta -X%` tag, then the struck original list price — nothing cut, overlapped or stacked.

No production logic change: promo detection rides the backend-computed `effectiveSalePrice` (a manual cashier price override is not mislabeled as an offer).

## Verification
- New regression tests prove a Decimal-string `salePrice` still shows the OFERTA badge + strikethrough in **both** the card and the cart.
- Frontend suite: 47 files / 265 tests passing. `tsc --noEmit` clean. ESLint clean on changed files.
- Pre-existing dirty `backend/package.json` left untouched/uncommitted.