### PR TITLE
fix(pos): offer tag only when a product is actually on promotion (#74 follow-up)

### DIFF
--- a/frontend/src/app/pos/page.behavior.test.tsx
+++ b/frontend/src/app/pos/page.behavior.test.tsx
@@ -380,6 +380,29 @@ describe("POS behavior evidence (#19, #18)", () => {
     expect(screen.getByTestId("original-unit-price")).toBeTruthy();
   });
 
+  it("does NOT show the OFERTA badge for a product without an active promotion", async () => {
+    useProductsMock.mockReturnValue({
+      data: {
+        data: [
+          makeProduct("1", "Sin Oferta", {
+            salePrice: "6900" as unknown as number,
+            effectiveSalePrice: null,
+          }),
+        ],
+        meta: { total: 1, page: 1, limit: 20, totalPages: 1 },
+      },
+      isLoading: false,
+      isFetching: false,
+    });
+
+    render(<POSPage />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Sin Oferta" }));
+
+    expect(screen.queryByText(/^Oferta -/)).toBeNull();
+    expect(screen.queryByTestId("original-unit-price")).toBeNull();
+  });
+
   it("shows scanner feedback when the scanned code is not found", async () => {
     useProductsMock.mockReturnValue({
       data: {

--- a/frontend/src/app/pos/page.tsx
+++ b/frontend/src/app/pos/page.tsx
@@ -56,17 +56,18 @@ const POS_PAGE_SIZE = 20;
  * line is not on offer.
  */
 function cartItemOffer(item: CartItem) {
-  // salePrice can arrive as a Decimal string over HTTP while effectiveSalePrice
-  // is a number; normalize both so the offer is detected regardless.
-  const price = Number(item.product?.effectiveSalePrice);
+  // effectiveSalePrice is null/undefined when there is NO active promotion;
+  // Number(null) would be 0, so guard the presence explicitly to avoid a
+  // bogus "-100%" offer. salePrice may arrive as a Decimal string.
+  const price = item.product?.effectiveSalePrice;
   const listPrice = Number(item.product?.salePrice);
-  if (!Number.isFinite(price) || !Number.isFinite(listPrice)) return null;
-  if (price === listPrice || price >= listPrice) return null;
+  if (typeof price !== "number" || !Number.isFinite(listPrice)) return null;
+  if (price <= 0 || price >= listPrice) return null;
   const percent = Math.max(
     0,
     Math.round(100 - (price / listPrice) * 100),
   );
-  return { percent };
+  return percent > 0 ? { percent } : null;
 }
 
 interface PaymentMethod {


### PR DESCRIPTION
Fixes a regression from #79 on the product promotions feature (#74).

## What
Products WITHOUT an active promotion were incorrectly showing `Oferta -100%` in the POS cart (e.g. "Cuaderno 100h", "Mouse Inalámbrico").

Root cause: `effectiveSalePrice` is `null` for products with no promotion, but the cart offer detector coerced it with `Number(null) -> 0`, so `0 / salePrice` produced a `-100%` discount that fooled the detector. The ProductCard was already correct because its `hasPromo` requires `typeof effectiveSalePrice === "number"`.

- `cartItemOffer` now requires `effectiveSalePrice` to be an actual positive number; `null`/`undefined` are never treated as a $0 offer. It also rejects `effective >= list` and non-positive discounts.
- Added a regression test proving a product with `effectiveSalePrice: null` shows no OFERTA badge and no strikethrough in the cart.

## Verification
- New regression test passes; frontend suite 47 files / 266 tests green.
- `tsc --noEmit` clean; ESLint clean on changed files.
- Pre-existing dirty `backend/package.json` left untouched/uncommitted.
