### PR TITLE
fix(pos): deduplicate identical paused sales (#74 follow-up)

### DIFF
--- a/frontend/src/hooks/usePausedSales.test.tsx
+++ b/frontend/src/hooks/usePausedSales.test.tsx
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { usePausedSales } from "./usePausedSales";
+import type { CartItem, Product } from "@/types";
+
+function makeProduct(id: string, salePrice: number): Product {
+  return {
+    id,
+    name: `Producto ${id}`,
+    sku: `sku-${id}`,
+    barcode: null,
+    description: null,
+    costPrice: 0,
+    salePrice,
+    taxRate: 0,
+    stock: 10,
+    minStock: 1,
+    imageUrl: null,
+    categoryId: "cat-1",
+    active: true,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    version: 1,
+  };
+}
+
+function makeLine(productId: string, unitPrice: number, qty = 1): CartItem {
+  return {
+    productId,
+    product: makeProduct(productId, unitPrice),
+    quantity: qty,
+    unitPrice,
+    originalUnitPrice: unitPrice,
+    discountAmount: 0,
+    availableStock: 10,
+  };
+}
+
+describe("usePausedSales — deduplicate identical paused sales", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("does not add a duplicate paused sale for the same customer + identical cart", () => {
+    const { result } = renderHook(() => usePausedSales());
+    const cart = [makeLine("p1", 8000)];
+
+    act(() => {
+      result.current.pauseSale(cart, "", 0);
+    });
+    act(() => {
+      result.current.pauseSale(cart, "", 0);
+    });
+
+    expect(result.current.pausedSales).toHaveLength(1);
+  });
+
+  it("keeps distinct carts (different products) separate", () => {
+    const { result } = renderHook(() => usePausedSales());
+
+    act(() => {
+      result.current.pauseSale([makeLine("p1", 8000)], "", 0);
+    });
+    act(() => {
+      result.current.pauseSale([makeLine("p2", 9000)], "", 0);
+    });
+
+    expect(result.current.pausedSales).toHaveLength(2);
+  });
+
+  it("normalizes duplicate paused sales already stored in localStorage on load", () => {
+    const existing = [
+      {
+        id: "a",
+        customerId: "",
+        discountAmount: 0,
+        customerName: "Cliente General",
+        pausedAt: "2026-08-25T16:29:54.000Z",
+        cart: [makeLine("p1", 8000)],
+      },
+      {
+        id: "b",
+        customerId: "",
+        discountAmount: 0,
+        customerName: "Cliente General",
+        pausedAt: "2026-08-25T16:37:24.000Z",
+        cart: [makeLine("p1", 8000)],
+      },
+    ];
+    localStorage.setItem("paused_sales", JSON.stringify(existing));
+
+    const { result } = renderHook(() => usePausedSales());
+
+    expect(result.current.pausedSales).toHaveLength(1);
+    expect(result.current.pausedSales[0].id).toBe("b");
+  });
+
+  it("does not collapse sales for different customers", () => {
+    const { result } = renderHook(() => usePausedSales());
+    const cart = [makeLine("p1", 8000)];
+
+    act(() => {
+      result.current.pauseSale(cart, "customer-1", 0);
+    });
+    act(() => {
+      result.current.pauseSale(cart, "customer-2", 0);
+    });
+
+    expect(result.current.pausedSales).toHaveLength(2);
+  });
+});

--- a/frontend/src/hooks/usePausedSales.ts
+++ b/frontend/src/hooks/usePausedSales.ts
@@ -13,6 +13,26 @@ interface PausedSale {
 
 const PAUSED_SALES_KEY = "paused_sales";
 
+/**
+ * Stable identity of a paused sale's content: same customer + same cart lines
+ * (product, quantity, prices, discount). Used to avoid stacking duplicate
+ * paused sales for the very same order.
+ */
+function pausedSaleSignature(cart: CartItem[], customerId: string | ""): string {
+  const lines = cart
+    .map((item) =>
+      [
+        item.productId,
+        item.quantity,
+        Number(item.unitPrice),
+        Number(item.discountAmount),
+        item.discountPercent ?? 0,
+      ].join("|"),
+    )
+    .sort();
+  return `${customerId}::${lines.join("&")}`;
+}
+
 export function usePausedSales() {
   const [pausedSales, setPausedSales] = useState<PausedSale[]>(() => {
     if (typeof window === "undefined") {
@@ -25,7 +45,21 @@ export function usePausedSales() {
     }
 
     try {
-      return JSON.parse(saved) as PausedSale[];
+      const parsed = JSON.parse(saved) as PausedSale[];
+      // Normalize any duplicate saved entries (identical customer + cart),
+      // keeping the most recently paused one.
+      const seen = new Set<string>();
+      const deduped: PausedSale[] = [];
+      for (const sale of [...parsed].sort(
+        (a, b) => new Date(b.pausedAt).getTime() - new Date(a.pausedAt).getTime(),
+      )) {
+        const sig = pausedSaleSignature(sale.cart, sale.customerId);
+        if (!seen.has(sig)) {
+          seen.add(sig);
+          deduped.push(sale);
+        }
+      }
+      return deduped;
     } catch {
       return [];
     }
@@ -54,7 +88,27 @@ export function usePausedSales() {
       customerName,
     };
 
-    setPausedSales((prev) => [...prev, pausedSale]);
+    setPausedSales((prev) => {
+      const sig = pausedSaleSignature(cart, customerId);
+      const existingIndex = prev.findIndex(
+        (s) => pausedSaleSignature(s.cart, s.customerId) === sig,
+      );
+      // Refresh the existing identical paused sale (new pausedAt) instead of
+      // stacking a duplicate for the very same order.
+      if (existingIndex >= 0) {
+        return prev.map((s, i) =>
+          i === existingIndex
+            ? {
+                ...s,
+                discountAmount,
+                customerName,
+                pausedAt: pausedSale.pausedAt,
+              }
+            : s,
+        );
+      }
+      return [...prev, pausedSale];
+    });
     return pausedSale.id;
   };
 


### PR DESCRIPTION
Fixes duplicate "Ventas Pausadas" entries for the same order (#74).

## What
Pausing the very same order twice (same customer + identical cart) stacked duplicate entries in the paused-sales list, which is confusing when a sale is generated from it.

- `pauseSale` now de-duplicates by a content signature (customer + normalized cart: product, qty, unit price, discount). Re-pausing an identical cart refreshes the existing entry's `pausedAt` instead of appending a copy.
- The initial localStorage load also normalizes any pre-existing duplicate entries, keeping the most recently paused one.
- Distinct carts and different customers are still kept separate.

## Verification
- New `usePausedSales` hook tests: identical cart collapses to one entry, distinct carts stay separate, different customers stay separate, and pre-existing localStorage duplicates are cleaned on load.
- Frontend suite: 48 files / 270 tests green. `tsc --noEmit` clean. ESLint clean on changed files.
- Pre-existing dirty `backend/package.json` left untouched/uncommitted.
