### PR TITLE
fix(inventory): setting tax to 0 saves; puntedado fixed-price offer (#74)

### DIFF
--- a/frontend/src/app/inventory/page.tsx
+++ b/frontend/src/app/inventory/page.tsx
@@ -38,7 +38,7 @@ import type { Product } from "@/types";
 import { useToast } from "@/contexts/ToastContext";
 import { useAuth } from "@/contexts/AuthContext";
 import { getApiErrorMessage } from "@/lib/api";
-import { cn } from "@/lib/utils";
+import { cn, resolveTaxFields } from "@/lib/utils";
 
 export default function InventoryPage() {
   const toast = useToast();
@@ -235,6 +235,11 @@ export default function InventoryPage() {
       toast.error("Ingresa una tasa de impuesto valida");
       return;
     }
+    // Tax is opt-in: a positive rate keeps the product taxable, while 0 or an
+    // empty field marks it NOT taxable (rate forced to 0 server-side). Sending
+    // taxable:true with a 0 rate would be rejected by the backend, silently
+    // keeping the old rate — so derive taxable from the entered rate.
+    const taxData = resolveTaxFields(taxRateInput);
     // Promotion: empty type = no offer (explicit nulls clear it server-side);
     // a selected type requires a positive value.
     const hasPromotion = promotionTypeInput !== "";
@@ -272,7 +277,7 @@ export default function InventoryPage() {
         const cleanedData = {
           ...updateData,
           ...(normalizedCategoryId ? { categoryId: normalizedCategoryId } : {}),
-          ...(hasExplicitTaxRate ? { taxRate: parsedTaxRate } : {}),
+          ...taxData,
           costPrice: updateData.costPrice ?? 0,
           salePrice: updateData.salePrice ?? 0,
           stock: updateData.stock ?? 0,
@@ -295,7 +300,7 @@ export default function InventoryPage() {
         const cleanedFormData = {
           ...formData,
           categoryId: normalizedCategoryId,
-          ...(hasExplicitTaxRate ? { taxRate: parsedTaxRate } : {}),
+          ...taxData,
           costPrice: formData.costPrice ?? 0,
           salePrice: formData.salePrice ?? 0,
           stock: formData.stock ?? 0,
@@ -725,17 +730,28 @@ export default function InventoryPage() {
                   />
                   {promotionTypeInput !== "" && (
                     <>
-                      <Input
-                        type="number"
-                        step="0.01"
-                        min="0"
-                        placeholder="Valor"
-                        value={promotionValueInput}
-                        onChange={(e) =>
-                          setPromotionValueInput(e.target.value)
-                        }
-                        className="w-full"
-                      />
+                      {promotionTypeInput === "FIXED_PRICE" ? (
+                        <CurrencyInput
+                          placeholder="Valor"
+                          value={promotionValueInput}
+                          onChange={(value) =>
+                            setPromotionValueInput(String(value))
+                          }
+                          className="w-full"
+                        />
+                      ) : (
+                        <Input
+                          type="number"
+                          step="0.01"
+                          min="0"
+                          placeholder="Valor"
+                          value={promotionValueInput}
+                          onChange={(e) =>
+                            setPromotionValueInput(e.target.value)
+                          }
+                          className="w-full"
+                        />
+                      )}
                       <Button
                         type="button"
                         variant="secondary"

--- a/frontend/src/lib/taxFields.test.ts
+++ b/frontend/src/lib/taxFields.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { resolveTaxFields } from "./utils";
+
+describe("resolveTaxFields", () => {
+  it("keeps a product taxable with a positive entered rate", () => {
+    expect(resolveTaxFields("19")).toEqual({ taxable: true, taxRate: 19 });
+    expect(resolveTaxFields("19.5")).toEqual({ taxable: true, taxRate: 19.5 });
+  });
+
+  it("marks the product NOT taxable when 0 is entered", () => {
+    expect(resolveTaxFields("0")).toEqual({ taxable: false, taxRate: 0 });
+    expect(resolveTaxFields("0.0")).toEqual({ taxable: false, taxRate: 0 });
+  });
+
+  it("marks the product NOT taxable when the field is empty", () => {
+    expect(resolveTaxFields("")).toEqual({ taxable: false, taxRate: 0 });
+    expect(resolveTaxFields("   ")).toEqual({ taxable: false, taxRate: 0 });
+  });
+
+  it("does not send taxable:true with a 0 rate for a non-numeric value", () => {
+    // NaN falls through to non-taxable rather than a rejected taxable:true+0.
+    expect(resolveTaxFields("abc")).toEqual({ taxable: false, taxRate: 0 });
+  });
+});

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -100,3 +100,24 @@ export function safeRemoveItem(key: string): void {
     // Silently fail
   }
 }
+
+/**
+ * Derives the opt-in tax fields for a product from the entered tax-rate input.
+ * A positive rate keeps the product taxable; 0 or an empty field marks it NOT
+ * taxable (the backend forces the stored rate to 0). This prevents sending
+ * `taxable: true` with a 0 rate, which the backend rejects and would silently
+ * leave the old rate in place.
+ */
+export function resolveTaxFields(
+  taxRateInput: string,
+): { taxable: boolean; taxRate: number } {
+  const trimmed = taxRateInput.trim();
+  if (trimmed === "") {
+    return { taxable: false, taxRate: 0 };
+  }
+  const value = Number(trimmed);
+  if (value > 0) {
+    return { taxable: true, taxRate: value };
+  }
+  return { taxable: false, taxRate: 0 };
+}


### PR DESCRIPTION
Two product-form fixes (#74).

## 1. Setting the product tax to 0 now actually saves
Setting a product's tax to 0 silently kept the old rate (e.g. 19). The form kept `taxable: true` from the product and sent it together with `taxRate: 0`; the backend's opt-in invariant (`taxable` requires a rate > 0) rejected the update, so the rate never changed.

Fix: the tax fields are now derived from the entered rate — a positive rate keeps the product taxable, while 0 or an empty field marks it **not taxable** (rate forced to 0 server-side), matching the create flow. Both create and edit paths send an explicit, consistent `taxable` + `taxRate`.

## 2. Fixed-price offer value is thousand-separated while typing
The "Precio fijo" (FIXED_PRICE) offer value now uses `CurrencyInput`, so it formats thousands with dots (e.g. `1.250.000`) as you type — just like cost price and sale price. PERCENTAGE offers keep a plain numeric input.

## Verification
- New `resolveTaxFields` pure helper in `lib/utils` + unit tests (positive rate → taxable, 0/empty → not taxable, non-numeric → not taxable).
- Frontend suite: 49 files / 274 tests green. `tsc --noEmit` clean. ESLint clean on changed files.
- Pre-existing dirty `backend/package.json` left untouched/uncommitted.
