### PR TITLE
feat(imports): multi-sheet importer engine (slice 1 — contract, column detection, validators)

### DIFF
--- a/backend/src/imports/engine/import-sheet-handler.interface.ts
+++ b/backend/src/imports/engine/import-sheet-handler.interface.ts
@@ -1,0 +1,90 @@
+import type { SheetColumnDetectionResult } from '../helpers/column-detector';
+import type { PrismaService } from '../../prisma/prisma.service';
+import type { PlanLimitService } from '../../plan-limits/plan-limits.service';
+
+/**
+ * Identifies one of the four importable entity sheets processed by the
+ * multi-sheet importer.
+ */
+export type SheetId = 'productos' | 'clientes' | 'proveedores' | 'usuarios';
+
+/**
+ * Lifecycle sub-status of a single sheet inside an import job.
+ *
+ * `REJECTED` is used when a sheet fails a hard, sheet-level check (e.g. a
+ * missing required column or a plan-limit breach) while sibling sheets keep
+ * processing.
+ */
+export type SheetStatus =
+  | 'PENDING'
+  | 'PROCESSING'
+  | 'COMPLETED'
+  | 'REJECTED'
+  | 'FAILED';
+
+/**
+ * A raw worksheet row: its 1-based row index plus its key-value cells
+ * (normalized column header -> raw cell value).
+ */
+export interface ParsedFileRow {
+  rowIndex: number;
+  rawData: Record<string, string>;
+}
+
+/** A per-row validation failure surfaced to the import report. */
+export interface RowError {
+  errorCode: string;
+  message: string;
+  field?: string;
+  mappedData: Record<string, unknown>;
+}
+
+/** A reported row error carrying its originating sheet and retry state. */
+export interface ImportRowError extends RowError {
+  rowIndex: number;
+  sheetId: SheetId;
+  editableFields: string[];
+  retried: boolean;
+  retriedSuccess?: boolean;
+}
+
+/** Per-sheet counters and sub-status tracked on an import job. */
+export interface ImportSheetStatus {
+  sheetId: SheetId;
+  status: SheetStatus;
+  totalRows: number;
+  processedRows: number;
+  imported: number;
+  skipped: number;
+  errors: number;
+  warnings: number;
+  missingRequiredFields?: string[];
+  planLimitRejected?: boolean;
+}
+
+/** Runtime context handed to a handler while processing a sheet row. */
+export interface SheetRowContext {
+  organizationId: string;
+  userId: string;
+  prisma: PrismaService;
+  planLimits: PlanLimitService;
+  existingKeys: Set<string>;
+}
+
+/** Result of {@link ImportSheetHandler.validateRow}. */
+export type ValidationResult =
+  | { ok: true; data: Record<string, unknown> }
+  | { ok: false; error: RowError };
+
+/**
+ * A per-entity sheet importer: column detection, per-row validation and row
+ * creation, all scoped to the JWT organization.
+ */
+export interface ImportSheetHandler {
+  sheetId: SheetId;
+  requiredFields: string[];
+  editableFields: string[];
+  detectColumns(headers: string[]): SheetColumnDetectionResult;
+  validateRow(row: ParsedFileRow, ctx: SheetRowContext): ValidationResult;
+  createRow(data: Record<string, unknown>, ctx: SheetRowContext): Promise<void>;
+}

--- a/backend/src/imports/helpers/column-detector.spec.ts
+++ b/backend/src/imports/helpers/column-detector.spec.ts
@@ -1,0 +1,189 @@
+import {
+  detectColumns,
+  SHEET_COLUMN_ALIASES,
+  SHEET_REQUIRED_FIELDS,
+} from './column-detector';
+import type { SheetId } from '../engine/import-sheet-handler.interface';
+
+describe('SHEET_REQUIRED_FIELDS', () => {
+  it('defines the required field set for every entity sheet', () => {
+    expect(SHEET_REQUIRED_FIELDS.productos).toEqual([
+      'name',
+      'salePrice',
+      'stock',
+    ]);
+    expect(SHEET_REQUIRED_FIELDS.clientes).toEqual([
+      'name',
+      'documentType',
+      'documentNumber',
+    ]);
+    expect(SHEET_REQUIRED_FIELDS.proveedores).toEqual([
+      'name',
+      'documentNumber',
+    ]);
+    expect(SHEET_REQUIRED_FIELDS.usuarios).toEqual(['email', 'password']);
+  });
+
+  it('covers exactly the four sheet ids', () => {
+    expect(Object.keys(SHEET_REQUIRED_FIELDS).sort()).toEqual([
+      'clientes',
+      'productos',
+      'proveedores',
+      'usuarios',
+    ]);
+  });
+});
+
+describe('SHEET_COLUMN_ALIASES', () => {
+  it('declares alias tables for every entity sheet', () => {
+    expect(Object.keys(SHEET_COLUMN_ALIASES).sort()).toEqual([
+      'clientes',
+      'productos',
+      'proveedores',
+      'usuarios',
+    ]);
+  });
+
+  it('exposes an aliases table per sheet for the required fields', () => {
+    expect(SHEET_COLUMN_ALIASES.clientes.documentType).toBeDefined();
+    expect(SHEET_COLUMN_ALIASES.clientes.documentNumber).toBeDefined();
+    expect(SHEET_COLUMN_ALIASES.proveedores.documentNumber).toBeDefined();
+    expect(SHEET_COLUMN_ALIASES.usuarios.email).toBeDefined();
+    expect(SHEET_COLUMN_ALIASES.usuarios.password).toBeDefined();
+  });
+});
+
+describe('detectColumns', () => {
+  it('detects the Productos sheet from Spanish headers', () => {
+    const result = detectColumns('productos', [
+      'Nombre',
+      'Precio Venta',
+      'Stock',
+      'SKU',
+    ]);
+
+    expect(result.sheetId).toBe('productos');
+    expect(result.mapping).toEqual({
+      name: 'Nombre',
+      sku: 'SKU',
+      salePrice: 'Precio Venta',
+      stock: 'Stock',
+    });
+    expect(result.missingRequiredFields).toEqual([]);
+  });
+
+  it('flags missing required fields on the Productos sheet', () => {
+    const result = detectColumns('productos', ['Nombre', 'Precio Venta']);
+
+    expect(result.mapping).not.toHaveProperty('stock');
+    expect(result.missingRequiredFields).toEqual(['stock']);
+  });
+
+  it('resolves Productos generic price column aliases', () => {
+    const result = detectColumns('productos', [
+      'producto',
+      'pvp',
+      'existencia',
+      'codigo',
+    ]);
+
+    expect(result.mapping.name).toBe('producto');
+    expect(result.mapping.salePrice).toBe('pvp');
+    expect(result.mapping.stock).toBe('existencia');
+    expect(result.mapping.sku).toBe('codigo');
+    expect(result.missingRequiredFields).toEqual([]);
+  });
+
+  it('detects the Clientes sheet and its required fields', () => {
+    const result = detectColumns('clientes', [
+      'Nombre',
+      'Tipo Documento',
+      'Documento',
+    ]);
+
+    expect(result.mapping).toEqual({
+      name: 'Nombre',
+      documentType: 'Tipo Documento',
+      documentNumber: 'Documento',
+    });
+    expect(result.missingRequiredFields).toEqual([]);
+  });
+
+  it('flags the missing documentType on the Clientes sheet', () => {
+    const result = detectColumns('clientes', ['Nombre', 'Documento']);
+
+    expect(result.missingRequiredFields).toEqual(['documentType']);
+  });
+
+  it('detects the Proveedores sheet by NIT alias', () => {
+    const result = detectColumns('proveedores', ['Nombre', 'NIT']);
+
+    expect(result.mapping.name).toBe('Nombre');
+    expect(result.mapping.documentNumber).toBe('NIT');
+    expect(result.missingRequiredFields).toEqual([]);
+  });
+
+  it('flags the missing documentNumber on the Proveedores sheet', () => {
+    const result = detectColumns('proveedores', ['Nombre']);
+
+    expect(result.missingRequiredFields).toEqual(['documentNumber']);
+  });
+
+  it('detects the Usuarios sheet and its required fields', () => {
+    const result = detectColumns('usuarios', ['Correo', 'Contraseña']);
+
+    expect(result.mapping.email).toBe('Correo');
+    expect(result.mapping.password).toBe('Contraseña');
+    expect(result.missingRequiredFields).toEqual([]);
+  });
+
+  it('flags the missing password on the Usuarios sheet', () => {
+    const result = detectColumns('usuarios', ['Correo']);
+
+    expect(result.missingRequiredFields).toEqual(['password']);
+  });
+
+  it('normalizes accented / mixed-case headers before aliasing', () => {
+    const result = detectColumns('usuarios', [
+      'CORREO ELECTRÓNICO',
+      'CONTRASEÑA',
+    ]);
+
+    expect(result.mapping.email).toBe('CORREO ELECTRÓNICO');
+    expect(result.mapping.password).toBe('CONTRASEÑA');
+    expect(result.missingRequiredFields).toEqual([]);
+  });
+
+  it('skips a sheet with no matching required columns', () => {
+    const result = detectColumns('clientes', ['Precio', 'Stock']);
+
+    expect(result.mapping).toEqual({});
+    expect(result.missingRequiredFields).toEqual([
+      'name',
+      'documentType',
+      'documentNumber',
+    ]);
+  });
+
+  it('exposes the detected non-empty headers list', () => {
+    const result = detectColumns('productos', ['Nombre', '', 'Stock']);
+
+    expect(result.detectedColumns).toEqual(['Nombre', 'Stock']);
+  });
+
+  it('round-trips every sheet id through the alias tables', () => {
+    const sheetIds: SheetId[] = [
+      'productos',
+      'clientes',
+      'proveedores',
+      'usuarios',
+    ];
+
+    for (const sheetId of sheetIds) {
+      expect(detectColumns(sheetId, []).sheetId).toBe(sheetId);
+      expect(
+        Array.isArray(detectColumns(sheetId, []).missingRequiredFields),
+      ).toBe(true);
+    }
+  });
+});

--- a/backend/src/imports/helpers/column-detector.ts
+++ b/backend/src/imports/helpers/column-detector.ts
@@ -1,3 +1,5 @@
+import type { SheetId } from '../engine/import-sheet-handler.interface';
+
 export type ImportFieldKey =
   | 'name'
   | 'sku'
@@ -9,6 +11,14 @@ export type ImportFieldKey =
   | 'minStock'
   | 'taxRate'
   | 'description';
+
+/** Result of {@link detectColumns} for a single entity sheet. */
+export interface SheetColumnDetectionResult {
+  sheetId: SheetId;
+  detectedColumns: string[];
+  mapping: Record<string, string>;
+  missingRequiredFields: string[];
+}
 
 export type ColumnMapping = Partial<Record<ImportFieldKey, string>>;
 
@@ -121,5 +131,107 @@ export function detectColumnMapping(headers: string[]): ColumnDetectionResult {
     mapping,
     missingRequiredFields,
     usesGenericPriceColumn,
+  };
+}
+
+/** Fields that must be present on each sheet for it to be importable. */
+export const SHEET_REQUIRED_FIELDS: Record<SheetId, string[]> = {
+  productos: ['name', 'salePrice', 'stock'],
+  clientes: ['name', 'documentType', 'documentNumber'],
+  proveedores: ['name', 'documentNumber'],
+  usuarios: ['email', 'password'],
+};
+
+/**
+ * Per-entity column alias tables, keyed by import field name and normalized
+ * via {@link normalizeHeader}. The Productos table reuses the existing
+ * product-only aliases so both code paths share one source of truth.
+ */
+export const SHEET_COLUMN_ALIASES: Record<SheetId, Record<string, string[]>> = {
+  productos: COLUMN_ALIASES,
+  clientes: {
+    name: ['nombre', 'name', 'cliente', 'customer', 'nombre_cliente'],
+    documentType: [
+      'tipo_documento',
+      'document_type',
+      'tipo_doc',
+      'tipo_de_documento',
+      'documenttype',
+    ],
+    documentNumber: [
+      'documento',
+      'document_number',
+      'numero_documento',
+      'cedula',
+      'documento_identidad',
+      'num_documento',
+      'nit',
+    ],
+    email: ['email', 'correo', 'correo_electronico', 'mail'],
+    phone: ['telefono', 'phone', 'celular', 'movil'],
+    segment: ['segmento', 'segment', 'tipo_cliente'],
+  },
+  proveedores: {
+    name: ['nombre', 'name', 'proveedor', 'supplier', 'razon_social'],
+    documentNumber: [
+      'documento',
+      'document_number',
+      'nit',
+      'nit_number',
+      'numero_documento',
+      'cedula',
+      'ruc',
+      'cuit',
+    ],
+    email: ['email', 'correo', 'correo_electronico', 'mail'],
+    phone: ['telefono', 'phone', 'celular', 'movil'],
+    accountType: [
+      'tipo_cuenta',
+      'account_type',
+      'tipo_de_cuenta',
+      'accounttype',
+    ],
+  },
+  usuarios: {
+    email: ['email', 'correo', 'correo_electronico', 'mail'],
+    password: ['password', 'contrasena', 'clave', 'pass'],
+    name: ['nombre', 'name', 'usuario', 'user', 'nombres'],
+    role: ['rol', 'role', 'perfil'],
+  },
+};
+
+/**
+ * Detects the column mapping for a single entity sheet, returning the minimum
+ * set of import fields that are missing so the sheet can be rejected (or
+ * repaired) before any row is processed.
+ */
+export function detectColumns(
+  sheetId: SheetId,
+  headers: string[],
+): SheetColumnDetectionResult {
+  const detectedColumns = headers.filter((header) => header.trim().length > 0);
+  const normalizedHeaders = detectedColumns.map(normalizeHeader);
+  const aliases = SHEET_COLUMN_ALIASES[sheetId] ?? {};
+  const mapping: Record<string, string> = {};
+
+  for (const [field, fieldAliases] of Object.entries(aliases)) {
+    const matchedIndex = normalizedHeaders.findIndex((header) =>
+      fieldAliases.includes(header),
+    );
+
+    if (matchedIndex >= 0) {
+      mapping[field] = detectedColumns[matchedIndex];
+    }
+  }
+
+  const missingRequiredFields = (SHEET_REQUIRED_FIELDS[sheetId] ?? []).filter(
+    (field) => !mapping[field],
+  );
+
+  return {
+    sheetId,
+    detectedColumns,
+    mapping,
+    missingRequiredFields,
   };
 }

--- a/backend/src/imports/helpers/validators/customer.spec.ts
+++ b/backend/src/imports/helpers/validators/customer.spec.ts
@@ -1,0 +1,149 @@
+import {
+  validateCustomerRow,
+  CUSTOMER_SEGMENTS,
+  DEFAULT_CUSTOMER_SEGMENT,
+} from './customer';
+
+describe('CUSTOMER_SEGMENTS', () => {
+  it('defines the customer segment enum', () => {
+    expect(CUSTOMER_SEGMENTS).toEqual([
+      'VIP',
+      'FREQUENT',
+      'OCCASIONAL',
+      'INACTIVE',
+    ]);
+  });
+
+  it('defaults to OCCASIONAL when no segment is supplied', () => {
+    expect(DEFAULT_CUSTOMER_SEGMENT).toBe('OCCASIONAL');
+  });
+});
+
+describe('validateCustomerRow', () => {
+  const baseRow = {
+    name: 'John Doe',
+    documentType: 'CC',
+    documentNumber: '1234567890',
+  };
+
+  it('accepts a valid customer row and defaults the segment', () => {
+    const result = validateCustomerRow(baseRow, new Set());
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toMatchObject({
+        name: 'John Doe',
+        documentType: 'CC',
+        documentNumber: '1234567890',
+        segment: 'OCCASIONAL',
+      });
+    }
+  });
+
+  it('accepts an explicit valid segment and normalizes its case', () => {
+    const result = validateCustomerRow(
+      { ...baseRow, segment: 'frequent' },
+      new Set(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.segment).toBe('FREQUENT');
+    }
+  });
+
+  it('normalizes the document type case', () => {
+    const result = validateCustomerRow(
+      { ...baseRow, documentType: 'cc' },
+      new Set(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.documentType).toBe('CC');
+    }
+  });
+
+  it('carries optional email and phone through', () => {
+    const result = validateCustomerRow(
+      { ...baseRow, email: 'john@example.com', phone: '3001234567' },
+      new Set(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.email).toBe('john@example.com');
+      expect(result.data.phone).toBe('3001234567');
+    }
+  });
+
+  it('rejects a row without a name', () => {
+    const result = validateCustomerRow(
+      { documentType: 'CC', documentNumber: '1234567890' },
+      new Set(),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.errorCode).toBe('EMPTY_NAME');
+      expect(result.error.field).toBe('name');
+    }
+  });
+
+  it('rejects a row without a document number', () => {
+    const result = validateCustomerRow(
+      { name: 'John Doe', documentType: 'CC' },
+      new Set(),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.errorCode).toBe('EMPTY_DOCUMENT');
+      expect(result.error.field).toBe('documentNumber');
+    }
+  });
+
+  it('rejects a row without a document type', () => {
+    const result = validateCustomerRow(
+      { name: 'John Doe', documentNumber: '1234567890' },
+      new Set(),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.errorCode).toBe('EMPTY_DOCUMENT_TYPE');
+      expect(result.error.field).toBe('documentType');
+    }
+  });
+
+  it('rejects an invalid segment value', () => {
+    const result = validateCustomerRow(
+      { ...baseRow, segment: 'PREMIUM' },
+      new Set(),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.errorCode).toBe('INVALID_SEGMENT');
+      expect(result.error.field).toBe('segment');
+    }
+  });
+
+  it('rejects a document number that already exists in the organization', () => {
+    const existing = new Set(['1234567890']);
+
+    const result = validateCustomerRow(baseRow, existing);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.errorCode).toBe('DUPLICATE_DOCUMENT');
+      expect(result.error.field).toBe('documentNumber');
+    }
+  });
+
+  it('accepts a fresh document number even when a different one exists', () => {
+    const result = validateCustomerRow(baseRow, new Set(['0000000000']));
+
+    expect(result.ok).toBe(true);
+  });
+});

--- a/backend/src/imports/helpers/validators/customer.ts
+++ b/backend/src/imports/helpers/validators/customer.ts
@@ -1,0 +1,133 @@
+import type { RowError } from '../../engine/import-sheet-handler.interface';
+import { normalizeLookupKey, normalizeText } from '../row-validator';
+
+/** Recognized customer segments (mirrors the `CustomerSegment` Prisma enum). */
+export const CUSTOMER_SEGMENTS = [
+  'VIP',
+  'FREQUENT',
+  'OCCASIONAL',
+  'INACTIVE',
+] as const;
+
+export type CustomerSegment = (typeof CUSTOMER_SEGMENTS)[number];
+
+/** Segment applied when a row does not specify one. */
+export const DEFAULT_CUSTOMER_SEGMENT: CustomerSegment = 'OCCASIONAL';
+
+/** Normalized customer import data after validation. */
+export interface CustomerImportData {
+  name: string;
+  documentType: string;
+  documentNumber: string;
+  segment: CustomerSegment;
+  email?: string;
+  phone?: string;
+}
+
+export type CustomerValidationResult =
+  | { ok: true; data: CustomerImportData }
+  | { ok: false; error: RowError };
+
+/**
+ * Validates a single mapped Clientes row before creation.
+ *
+ * `existingDocuments` holds normalized lookup keys of document numbers already
+ * present in the organization (in the database plus this file), which is how
+ * the org-unique documentNumber constraint is enforced during an import.
+ */
+export function validateCustomerRow(
+  mapped: Record<string, unknown>,
+  existingDocuments: Set<string>,
+): CustomerValidationResult {
+  const name = normalizeText(mapped.name);
+  const documentType = normalizeText(mapped.documentType).toUpperCase();
+  const documentNumber = normalizeText(mapped.documentNumber);
+  const email = normalizeText(mapped.email) || undefined;
+  const phone = normalizeText(mapped.phone) || undefined;
+
+  const mappedData: Record<string, unknown> = {
+    name,
+    documentType,
+    documentNumber,
+    email,
+    phone,
+  };
+
+  if (!name) {
+    return {
+      ok: false,
+      error: {
+        errorCode: 'EMPTY_NAME',
+        message: 'Nombre de cliente requerido',
+        field: 'name',
+        mappedData,
+      },
+    };
+  }
+
+  if (!documentNumber) {
+    return {
+      ok: false,
+      error: {
+        errorCode: 'EMPTY_DOCUMENT',
+        message: 'Numero de documento requerido',
+        field: 'documentNumber',
+        mappedData,
+      },
+    };
+  }
+
+  if (!documentType) {
+    return {
+      ok: false,
+      error: {
+        errorCode: 'EMPTY_DOCUMENT_TYPE',
+        message: 'Tipo de documento requerido',
+        field: 'documentType',
+        mappedData,
+      },
+    };
+  }
+
+  const documentKey = normalizeLookupKey(documentNumber);
+  if (existingDocuments.has(documentKey)) {
+    return {
+      ok: false,
+      error: {
+        errorCode: 'DUPLICATE_DOCUMENT',
+        message: 'Ya existe un cliente con ese numero de documento',
+        field: 'documentNumber',
+        mappedData,
+      },
+    };
+  }
+
+  const rawSegment = normalizeText(mapped.segment);
+  const segment = (
+    rawSegment ? rawSegment.toUpperCase() : DEFAULT_CUSTOMER_SEGMENT
+  ) as CustomerSegment;
+
+  if (!CUSTOMER_SEGMENTS.includes(segment)) {
+    return {
+      ok: false,
+      error: {
+        errorCode: 'INVALID_SEGMENT',
+        message: 'Segmento de cliente invalido',
+        field: 'segment',
+        mappedData: { ...mappedData },
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      name,
+      documentType,
+      documentNumber,
+      segment,
+      ...(email ? { email } : {}),
+      ...(phone ? { phone } : {}),
+    },
+  };
+}

--- a/backend/src/imports/helpers/validators/supplier.spec.ts
+++ b/backend/src/imports/helpers/validators/supplier.spec.ts
@@ -1,0 +1,123 @@
+import { validateSupplierRow, SUPPLIER_ACCOUNT_TYPES } from './supplier';
+
+describe('SUPPLIER_ACCOUNT_TYPES', () => {
+  it('defines the supplier account type enum', () => {
+    expect(SUPPLIER_ACCOUNT_TYPES).toEqual(['SAVINGS', 'CHECKING']);
+  });
+});
+
+describe('validateSupplierRow', () => {
+  const baseRow = {
+    name: 'Distribuidora XYZ',
+    documentNumber: '900123456-7',
+  };
+
+  it('accepts a valid supplier row without an account type', () => {
+    const result = validateSupplierRow(baseRow, new Set());
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toMatchObject({
+        name: 'Distribuidora XYZ',
+        documentNumber: '900123456-7',
+      });
+      expect(result.data.accountType).toBeUndefined();
+    }
+  });
+
+  it('accepts a valid supplier with a CHECKING account type', () => {
+    const result = validateSupplierRow(
+      { ...baseRow, accountType: 'CHECKING' },
+      new Set(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.accountType).toBe('CHECKING');
+    }
+  });
+
+  it('normalizes the account type case', () => {
+    const result = validateSupplierRow(
+      { ...baseRow, accountType: 'savings' },
+      new Set(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.accountType).toBe('SAVINGS');
+    }
+  });
+
+  it('carries optional supplier fields through', () => {
+    const result = validateSupplierRow(
+      {
+        ...baseRow,
+        email: 'ventas@xyz.com',
+        phone: '3001234567',
+        bank: 'Bancolombia',
+        accountNumber: '1234567890',
+        contactName: 'Juan Pérez',
+      },
+      new Set(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.email).toBe('ventas@xyz.com');
+      expect(result.data.phone).toBe('3001234567');
+      expect(result.data.bank).toBe('Bancolombia');
+      expect(result.data.accountNumber).toBe('1234567890');
+      expect(result.data.contactName).toBe('Juan Pérez');
+    }
+  });
+
+  it('rejects a row without a name', () => {
+    const result = validateSupplierRow(
+      { documentNumber: '900123456-7' },
+      new Set(),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.errorCode).toBe('EMPTY_NAME');
+      expect(result.error.field).toBe('name');
+    }
+  });
+
+  it('rejects a row without a document number', () => {
+    const result = validateSupplierRow(
+      { name: 'Distribuidora XYZ' },
+      new Set(),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.errorCode).toBe('EMPTY_DOCUMENT');
+      expect(result.error.field).toBe('documentNumber');
+    }
+  });
+
+  it('rejects a document number that already exists in the organization', () => {
+    const result = validateSupplierRow(baseRow, new Set(['900123456-7']));
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.errorCode).toBe('DUPLICATE_DOCUMENT');
+      expect(result.error.field).toBe('documentNumber');
+    }
+  });
+
+  it('rejects an invalid account type', () => {
+    const result = validateSupplierRow(
+      { ...baseRow, accountType: 'CREDIT' },
+      new Set(),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.errorCode).toBe('INVALID_ACCOUNT_TYPE');
+      expect(result.error.field).toBe('accountType');
+    }
+  });
+});

--- a/backend/src/imports/helpers/validators/supplier.ts
+++ b/backend/src/imports/helpers/validators/supplier.ts
@@ -1,0 +1,127 @@
+import type { RowError } from '../../engine/import-sheet-handler.interface';
+import { normalizeLookupKey, normalizeText } from '../row-validator';
+
+/** Recognized supplier account types (mirrors the `SupplierAccountType` enum). */
+export const SUPPLIER_ACCOUNT_TYPES = ['SAVINGS', 'CHECKING'] as const;
+
+export type SupplierAccountType = (typeof SUPPLIER_ACCOUNT_TYPES)[number];
+
+/** Normalized supplier import data after validation. */
+export interface SupplierImportData {
+  name: string;
+  documentNumber: string;
+  accountType?: SupplierAccountType;
+  email?: string;
+  phone?: string;
+  address?: string;
+  contactName?: string;
+  bank?: string;
+  accountNumber?: string;
+}
+
+export type SupplierValidationResult =
+  | { ok: true; data: SupplierImportData }
+  | { ok: false; error: RowError };
+
+/**
+ * Validates a single mapped Proveedores row before creation.
+ *
+ * `existingDocuments` holds normalized lookup keys of document numbers already
+ * present in the organization, which enforces the org-unique documentNumber
+ * constraint during an import.
+ */
+export function validateSupplierRow(
+  mapped: Record<string, unknown>,
+  existingDocuments: Set<string>,
+): SupplierValidationResult {
+  const name = normalizeText(mapped.name);
+  const documentNumber = normalizeText(mapped.documentNumber);
+  const email = normalizeText(mapped.email) || undefined;
+  const phone = normalizeText(mapped.phone) || undefined;
+  const address = normalizeText(mapped.address) || undefined;
+  const contactName = normalizeText(mapped.contactName) || undefined;
+  const bank = normalizeText(mapped.bank) || undefined;
+  const accountNumber = normalizeText(mapped.accountNumber) || undefined;
+
+  const mappedData: Record<string, unknown> = {
+    name,
+    documentNumber,
+    email,
+    phone,
+    address,
+    contactName,
+    bank,
+    accountNumber,
+  };
+
+  if (!name) {
+    return {
+      ok: false,
+      error: {
+        errorCode: 'EMPTY_NAME',
+        message: 'Nombre de proveedor requerido',
+        field: 'name',
+        mappedData,
+      },
+    };
+  }
+
+  if (!documentNumber) {
+    return {
+      ok: false,
+      error: {
+        errorCode: 'EMPTY_DOCUMENT',
+        message: 'Numero de documento requerido',
+        field: 'documentNumber',
+        mappedData,
+      },
+    };
+  }
+
+  const documentKey = normalizeLookupKey(documentNumber);
+  if (existingDocuments.has(documentKey)) {
+    return {
+      ok: false,
+      error: {
+        errorCode: 'DUPLICATE_DOCUMENT',
+        message: 'Ya existe un proveedor con ese numero de documento',
+        field: 'documentNumber',
+        mappedData,
+      },
+    };
+  }
+
+  const rawAccountType = normalizeText(mapped.accountType);
+  let accountType: SupplierAccountType | undefined;
+
+  if (rawAccountType) {
+    const normalized = rawAccountType.toUpperCase() as SupplierAccountType;
+    if (!SUPPLIER_ACCOUNT_TYPES.includes(normalized)) {
+      return {
+        ok: false,
+        error: {
+          errorCode: 'INVALID_ACCOUNT_TYPE',
+          message: 'Tipo de cuenta invalido (use SAVINGS o CHECKING)',
+          field: 'accountType',
+          mappedData: { ...mappedData },
+        },
+      };
+    }
+    accountType = normalized;
+  }
+
+  return {
+    ok: true,
+    data: {
+      name,
+      documentNumber,
+      ...(accountType ? { accountType } : {}),
+      ...(email ? { email } : {}),
+      ...(phone ? { phone } : {}),
+      ...(address ? { address } : {}),
+      ...(contactName ? { contactName } : {}),
+      ...(bank ? { bank } : {}),
+      ...(accountNumber ? { accountNumber } : {}),
+    },
+  };
+}

--- a/backend/src/imports/helpers/validators/user.spec.ts
+++ b/backend/src/imports/helpers/validators/user.spec.ts
@@ -1,0 +1,145 @@
+import { validateUserRow, USER_ROLES, DEFAULT_USER_ROLE } from './user';
+import { validatePasswordPolicy } from '../../../common/validators/password.policy';
+import { PASSWORD_MIN_LENGTH } from '../../../common/validators/password.policy';
+
+describe('USER_ROLES', () => {
+  it('defines the organization role set', () => {
+    expect(USER_ROLES).toEqual([
+      'OWNER',
+      'ADMIN',
+      'MEMBER',
+      'CASHIER',
+      'INVENTORY_USER',
+    ]);
+  });
+
+  it('defaults the role to CASHIER', () => {
+    expect(DEFAULT_USER_ROLE).toBe('CASHIER');
+  });
+});
+
+describe('validateUserRow', () => {
+  const baseRow = {
+    email: 'user@example.com',
+    password: 'correct-horse-battery-staple',
+    name: 'John Doe',
+  };
+
+  it('accepts a valid user row and defaults the role to CASHIER', () => {
+    const result = validateUserRow(baseRow);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toMatchObject({
+        email: 'user@example.com',
+        password: 'correct-horse-battery-staple',
+        name: 'John Doe',
+        role: 'CASHIER',
+      });
+    }
+  });
+
+  it('accepts an explicit valid role and normalizes its case', () => {
+    const result = validateUserRow({ ...baseRow, role: 'admin' });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.role).toBe('ADMIN');
+    }
+  });
+
+  it('rejects an unknown role value', () => {
+    const result = validateUserRow({ ...baseRow, role: 'SUPERADMIN' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.errorCode).toBe('INVALID_ROLE');
+      expect(result.error.field).toBe('role');
+    }
+  });
+
+  it('rejects a password shorter than the shared policy minimum', () => {
+    const result = validateUserRow({ ...baseRow, password: 'short' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.errorCode).toBe('INVALID_PASSWORD');
+      expect(result.error.message).toBe(
+        `Password must be at least ${PASSWORD_MIN_LENGTH} characters`,
+      );
+      expect(result.error.field).toBe('password');
+    }
+  });
+
+  it('rejects a denylisted common password via the shared policy', () => {
+    const result = validateUserRow({ ...baseRow, password: 'password123' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.errorCode).toBe('INVALID_PASSWORD');
+      expect(result.error.message).toBe('This password is too common');
+    }
+  });
+
+  it('delegates password validation to the shared policy function', () => {
+    // The policy must be the single source of truth: a password that the
+    // shared policy rejects must be rejected with its exact message.
+    const sharedPolicyMessage = validatePasswordPolicy('welcome123');
+    const result = validateUserRow({ ...baseRow, password: 'welcome123' });
+
+    expect(sharedPolicyMessage).not.toBeNull();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe(sharedPolicyMessage);
+    }
+  });
+
+  it('rejects a row without a password', () => {
+    const result = validateUserRow({
+      email: 'user@example.com',
+      name: 'John Doe',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.errorCode).toBe('EMPTY_PASSWORD');
+      expect(result.error.field).toBe('password');
+    }
+  });
+
+  it('rejects a row without an email', () => {
+    const result = validateUserRow({
+      password: 'correct-horse-battery-staple',
+      name: 'John Doe',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.errorCode).toBe('EMPTY_EMAIL');
+      expect(result.error.field).toBe('email');
+    }
+  });
+
+  it('rejects a malformed email address', () => {
+    const result = validateUserRow({ ...baseRow, email: 'not-an-email' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.errorCode).toBe('INVALID_EMAIL');
+      expect(result.error.field).toBe('email');
+    }
+  });
+
+  it('rejects a row without a name', () => {
+    const result = validateUserRow({
+      email: 'user@example.com',
+      password: 'correct-horse-battery-staple',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.errorCode).toBe('EMPTY_NAME');
+      expect(result.error.field).toBe('name');
+    }
+  });
+});

--- a/backend/src/imports/helpers/validators/user.ts
+++ b/backend/src/imports/helpers/validators/user.ts
@@ -1,0 +1,140 @@
+import type { RowError } from '../../engine/import-sheet-handler.interface';
+import { normalizeText } from '../row-validator';
+import { validatePasswordPolicy } from '../../../common/validators/password.policy';
+
+/** Recognized organization roles (mirrors the `OrgRole` Prisma enum). */
+export const USER_ROLES = [
+  'OWNER',
+  'ADMIN',
+  'MEMBER',
+  'CASHIER',
+  'INVENTORY_USER',
+] as const;
+
+export type UserRole = (typeof USER_ROLES)[number];
+
+/** Role applied when a row does not specify one. */
+export const DEFAULT_USER_ROLE: UserRole = 'CASHIER';
+
+/** Normalized user import data after validation. */
+export interface UserImportData {
+  email: string;
+  password: string;
+  name: string;
+  role: UserRole;
+}
+
+export type UserValidationResult =
+  | { ok: true; data: UserImportData }
+  | { ok: false; error: RowError };
+
+function isValidEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+/**
+ * Validates a single mapped Usuarios row before creation.
+ *
+ * Password strength is delegated to the shared {@link validatePasswordPolicy}
+ * (minimum length plus a common/breached-password denylist) so the importer
+ * enforces the exact same policy as the auth DTOs. bcrypt(12) hashing and the
+ * nested `OrganizationUser` membership are applied downstream by
+ * `UsersService.create`, which is the single creation path for users.
+ */
+export function validateUserRow(
+  mapped: Record<string, unknown>,
+): UserValidationResult {
+  const email = normalizeText(mapped.email);
+  const password = normalizeText(mapped.password);
+  const name = normalizeText(mapped.name);
+
+  const mappedData: Record<string, unknown> = { email, password, name };
+
+  if (!email) {
+    return {
+      ok: false,
+      error: {
+        errorCode: 'EMPTY_EMAIL',
+        message: 'Correo electronico requerido',
+        field: 'email',
+        mappedData,
+      },
+    };
+  }
+
+  if (!isValidEmail(email)) {
+    return {
+      ok: false,
+      error: {
+        errorCode: 'INVALID_EMAIL',
+        message: 'Correo electronico invalido',
+        field: 'email',
+        mappedData,
+      },
+    };
+  }
+
+  if (!password) {
+    return {
+      ok: false,
+      error: {
+        errorCode: 'EMPTY_PASSWORD',
+        message: 'Contraseña requerida',
+        field: 'password',
+        mappedData,
+      },
+    };
+  }
+
+  const policyMessage = validatePasswordPolicy(password);
+  if (policyMessage) {
+    return {
+      ok: false,
+      error: {
+        errorCode: 'INVALID_PASSWORD',
+        message: policyMessage,
+        field: 'password',
+        mappedData,
+      },
+    };
+  }
+
+  if (!name) {
+    return {
+      ok: false,
+      error: {
+        errorCode: 'EMPTY_NAME',
+        message: 'Nombre de usuario requerido',
+        field: 'name',
+        mappedData,
+      },
+    };
+  }
+
+  const rawRole = normalizeText(mapped.role);
+  const role = (
+    rawRole ? rawRole.toUpperCase() : DEFAULT_USER_ROLE
+  ) as UserRole;
+
+  if (!USER_ROLES.includes(role)) {
+    return {
+      ok: false,
+      error: {
+        errorCode: 'INVALID_ROLE',
+        message: 'Rol de usuario invalido',
+        field: 'role',
+        mappedData: { ...mappedData },
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      email,
+      password,
+      name,
+      role,
+    },
+  };
+}


### PR DESCRIPTION
Closes #2

## Summary
This is **slice 1 / PR1 of 5** in the stacked-to-main chain that turns the product-only importer into a 4-sheet importer (Productos → Clientes → Proveedores → Usuarios). This slice lands the **backend engine contract + per-entity column detection + per-entity validators** so later slices can build handlers, the orchestrator, the controller, and the frontend on top of a tested seam.

- Engine seam: `ImportSheetHandler`, `SheetId`, `SheetRowContext`, `SheetStatus`, `ImportSheetStatus`, `ImportRowError`, `ValidationResult`.
- Column detection: per-entity alias tables and `detectColumns(sheetId, headers)` returning per-sheet `missingRequiredFields` (required sets: Productos name/salePrice/stock, Clientes name/documentType/documentNumber, Proveedores name/documentNumber, Usuarios email/password).
- Validators: customer (segment enum + doc type + org-unique documentNumber), supplier (accountType ∈ SAVINGS/CHECKING + org-unique documentNumber), user (OrgRole set with CASHIER default + password via the **shared** `validatePasswordPolicy`).

## Changes

| File | Change |
|------|--------|
| `backend/src/imports/engine/import-sheet-handler.interface.ts` | New engine contract (handler + row context + sheet status + types) |
| `backend/src/imports/helpers/column-detector.ts` | Added per-entity alias tables, `SHEET_REQUIRED_FIELDS`, `detectColumns(sheetId, headers)` |
| `backend/src/imports/helpers/validators/customer.ts` | New customer import validator |
| `backend/src/imports/helpers/validators/supplier.ts` | New supplier import validator |
| `backend/src/imports/helpers/validators/user.ts` | New user import validator (delegates password policy to `common/validators/password.policy.ts`) |
| `backend/src/imports/**/*.spec.ts` | Red-first tests for every unit above |

## Out of scope (later slices)
Handlers (product/customer/supplier/user), `duplicate-tracker`/`sheet-registry`, `multi-sheet-import.service`, template service, controller/module/DI wiring, and the frontend `/imports` page. `imports.service.ts`, `imports.controller.ts`, and `imports.module.ts` are intentionally untouched here.

## Verification
- `cd backend && npm run test -- imports` → 4 suites, 50/50 passing.
- `npm run build` → clean.
- `eslint` on changed files → clean.
- `npm run test -- imports/helpers/column-detector`, `validators/customer`, `validators/supplier`, `validators/user` all green individually.

## Reviewer note
Strict TDD was used: each unit's spec was authored and failed (RED) before the implementation (GREEN). This slice carries **1208 changed lines** (9 files, 1208 additions), above the 400-line single-PR guideline — but it is the pre-planned slice boundary for PR1 in the `stacked-to-main` chain (change split by the orchestrator: engine + validators here, handlers → orchestrator → controller → frontend in PR2..PR5). If the maintainer prefers a smaller first PR, the validators (customer/supplier/user) can be split into a follow-up without breaking the seam landed by commit 1.

## Checklist
- [x] Linked issue #2
- [x] Conventional commit format (4 work-unit commits, no AI attribution)
- [x] Backend import suite green (50/50)
- [x] Build clean (tsc/nest build)