### PR TITLE
feat(imports): multi-sheet importer per-entity handlers (slice 2/5)

### DIFF
--- a/backend/src/imports/engine/duplicate-tracker.spec.ts
+++ b/backend/src/imports/engine/duplicate-tracker.spec.ts
@@ -1,0 +1,88 @@
+import { DuplicateTracker } from './duplicate-tracker';
+
+describe('DuplicateTracker', () => {
+  describe('lookup / isDuplicate', () => {
+    it('reports a fresh key as not a duplicate', () => {
+      const tracker = new DuplicateTracker();
+      const lookup = tracker.lookup('PROD-001');
+
+      expect(lookup.duplicate).toBe(false);
+      expect(lookup.reason).toBeUndefined();
+      expect(tracker.isDuplicate('PROD-001')).toBe(false);
+    });
+
+    it('reports a pre-seeded existing key as an existing duplicate', () => {
+      const tracker = new DuplicateTracker(['PROD-001']);
+      const lookup = tracker.lookup('PROD-001');
+
+      expect(lookup.duplicate).toBe(true);
+      expect(lookup.reason).toBe('existing');
+    });
+
+    it('reports a key registered in this file as a file duplicate', () => {
+      const tracker = new DuplicateTracker();
+      tracker.register('PROD-001');
+
+      const lookup = tracker.lookup('PROD-001');
+
+      expect(lookup.duplicate).toBe(true);
+      expect(lookup.reason).toBe('file');
+    });
+
+    it('reports a key that is both existing and seen as existing', () => {
+      const tracker = new DuplicateTracker(['PROD-001']);
+      tracker.register('PROD-001');
+
+      const lookup = tracker.lookup('PROD-001');
+
+      expect(lookup.duplicate).toBe(true);
+      expect(lookup.reason).toBe('existing');
+    });
+  });
+
+  describe('register', () => {
+    it('returns true the first time a key is registered', () => {
+      const tracker = new DuplicateTracker();
+      expect(tracker.register('SKU-A')).toBe(true);
+    });
+
+    it('returns false when the key was already registered', () => {
+      const tracker = new DuplicateTracker();
+      tracker.register('SKU-A');
+      expect(tracker.register('SKU-A')).toBe(false);
+    });
+
+    it('ignores empty keys without marking them seen', () => {
+      const tracker = new DuplicateTracker();
+      expect(tracker.register('')).toBe(false);
+      expect(tracker.hasSeen('')).toBe(false);
+    });
+  });
+
+  describe('hasExisting / hasSeen / seed', () => {
+    it('distinguishes existing keys from seen-in-file keys', () => {
+      const tracker = new DuplicateTracker(['DB-KEY']);
+      tracker.register('FILE-KEY');
+
+      expect(tracker.hasExisting('DB-KEY')).toBe(true);
+      expect(tracker.hasSeen('DB-KEY')).toBe(false);
+
+      expect(tracker.hasExisting('FILE-KEY')).toBe(false);
+      expect(tracker.hasSeen('FILE-KEY')).toBe(true);
+    });
+
+    it('seeds additional existing keys after construction', () => {
+      const tracker = new DuplicateTracker();
+      tracker.seed('LATE-EXISTING');
+
+      expect(tracker.hasExisting('LATE-EXISTING')).toBe(true);
+      expect(tracker.isDuplicate('LATE-EXISTING')).toBe(true);
+    });
+
+    it('never treats an empty key as a duplicate', () => {
+      const tracker = new DuplicateTracker(['']);
+      expect(tracker.isDuplicate('')).toBe(false);
+      expect(tracker.lookup('').duplicate).toBe(false);
+    });
+  });
+});

--- a/backend/src/imports/engine/duplicate-tracker.ts
+++ b/backend/src/imports/engine/duplicate-tracker.ts
@@ -1,0 +1,90 @@
+/**
+ * Tracks the lookup keys that identify a single importable record (e.g. a
+ * product SKU, a customer/supplier document number, or a user email) so the
+ * engine can reject duplicates both against records already present in the
+ * database and against rows seen earlier in the same file.
+ *
+ * A handler owns one or more trackers for the duration of a single import job
+ * (the orchestrator constructs handlers per job, so no state leaks between
+ * imports). {@link seed} registers keys that already exist in the database;
+ * {@link register} marks a key as seen in the current file.
+ */
+export type DuplicateReason = 'existing' | 'file';
+
+export interface DuplicateLookup {
+  /** The key that was checked. */
+  key: string;
+  /** Whether the key collides with an existing or already-seen key. */
+  duplicate: boolean;
+  /** Why the key is considered a duplicate, when it is. */
+  reason?: DuplicateReason;
+}
+
+export class DuplicateTracker {
+  private readonly existingKeys: Set<string>;
+  private readonly seenKeys = new Set<string>();
+
+  constructor(existingKeys: Iterable<string> = []) {
+    this.existingKeys = new Set(existingKeys);
+  }
+
+  /** Registers a database-existing key that must never be re-imported. */
+  seed(key: string): void {
+    if (key) {
+      this.existingKeys.add(key);
+    }
+  }
+
+  /** True when the key is known to already exist in the database. */
+  hasExisting(key: string): boolean {
+    return !!key && this.existingKeys.has(key);
+  }
+
+  /** True when the key was already seen in the current file. */
+  hasSeen(key: string): boolean {
+    return !!key && this.seenKeys.has(key);
+  }
+
+  /**
+   * Returns the duplicate verdict for a key: an `existing` duplicate when the
+   * key is already in the database, a `file` duplicate when it was seen earlier
+   * in this file, or a non-duplicate otherwise.
+   */
+  lookup(key: string): DuplicateLookup {
+    if (!key) {
+      return { key, duplicate: false };
+    }
+
+    if (this.existingKeys.has(key)) {
+      return { key, duplicate: true, reason: 'existing' };
+    }
+
+    if (this.seenKeys.has(key)) {
+      return { key, duplicate: true, reason: 'file' };
+    }
+
+    return { key, duplicate: false };
+  }
+
+  /** True when the key is an existing or already-seen duplicate. */
+  isDuplicate(key: string): boolean {
+    return this.lookup(key).duplicate;
+  }
+
+  /**
+   * Marks a key as seen in the current file. Returns `true` when the key was
+   * newly registered and `false` when it was already seen (or empty).
+   */
+  register(key: string): boolean {
+    if (!key) {
+      return false;
+    }
+
+    if (this.seenKeys.has(key)) {
+      return false;
+    }
+
+    this.seenKeys.add(key);
+    return true;
+  }
+}

--- a/backend/src/imports/engine/handlers/customer.handler.spec.ts
+++ b/backend/src/imports/engine/handlers/customer.handler.spec.ts
@@ -1,0 +1,140 @@
+import { CustomerHandler } from './customer.handler';
+import type { ParsedFileRow, SheetRowContext } from '../import-sheet-handler.interface';
+
+describe('CustomerHandler', () => {
+  let customersService: { create: jest.Mock };
+  let handler: CustomerHandler;
+
+  beforeEach(() => {
+    customersService = { create: jest.fn().mockResolvedValue(undefined) };
+    handler = new CustomerHandler(customersService as never);
+  });
+
+  function makeCtx(overrides: Partial<SheetRowContext> = {}): SheetRowContext {
+    return {
+      organizationId: 'org-1',
+      userId: 'user-1',
+      prisma: {},
+      planLimits: {},
+      existingKeys: new Set<string>(),
+      ...overrides,
+    } as unknown as SheetRowContext;
+  }
+
+  function makeRow(rawData: Record<string, string>, rowIndex = 2): ParsedFileRow {
+    return { rowIndex, rawData };
+  }
+
+  describe('validateRow', () => {
+    it('validates a mapped row and registers its document number', () => {
+      const ctx = makeCtx();
+
+      const result = handler.validateRow(
+        makeRow({
+          'Nombre': 'John Doe',
+          'Tipo de Documento': 'CC',
+          'Documento': '1234567890',
+          'Segmento': 'frequent',
+        }),
+        ctx,
+      );
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data).toMatchObject({
+          name: 'John Doe',
+          documentType: 'CC',
+          documentNumber: '1234567890',
+          segment: 'FREQUENT',
+        });
+      }
+      expect(ctx.existingKeys.has('1234567890')).toBe(true);
+    });
+
+    it('rejects a document number already present in the organization', () => {
+      const ctx = makeCtx({ existingKeys: new Set(['1234567890']) });
+
+      const result = handler.validateRow(
+        makeRow({
+          'Nombre': 'John Doe',
+          'Tipo de Documento': 'CC',
+          'Documento': '1234567890',
+        }),
+        ctx,
+      );
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.errorCode).toBe('DUPLICATE_DOCUMENT');
+        expect(result.error.field).toBe('documentNumber');
+      }
+    });
+
+    it('rejects a duplicate document number within the same file', () => {
+      const ctx = makeCtx();
+      handler.validateRow(
+        makeRow({ 'Nombre': 'A', 'Tipo de Documento': 'CC', 'Documento': '999' }, 2),
+        ctx,
+      );
+
+      const duplicate = handler.validateRow(
+        makeRow({ 'Nombre': 'B', 'Tipo de Documento': 'CC', 'Documento': '999' }, 3),
+        ctx,
+      );
+
+      expect(duplicate.ok).toBe(false);
+      if (!duplicate.ok) {
+        expect(duplicate.error.errorCode).toBe('DUPLICATE_DOCUMENT');
+      }
+    });
+
+    it('propagates a validation failure (missing name)', () => {
+      const ctx = makeCtx();
+
+      const result = handler.validateRow(
+        makeRow({ 'Tipo de Documento': 'CC', 'Documento': '1234567890' }),
+        ctx,
+      );
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.errorCode).toBe('EMPTY_NAME');
+      }
+    });
+  });
+
+  describe('createRow', () => {
+    it('creates the customer via the service with the organization id', async () => {
+      const ctx = makeCtx();
+
+      await handler.createRow(
+        { name: 'John Doe', documentType: 'CC', documentNumber: '1234567890', segment: 'OCCASIONAL' },
+        ctx,
+      );
+
+      expect(customersService.create).toHaveBeenCalledTimes(1);
+      const [dto, organizationId] = customersService.create.mock.calls[0];
+      expect(dto).toMatchObject({
+        name: 'John Doe',
+        documentType: 'CC',
+        documentNumber: '1234567890',
+      });
+      expect(organizationId).toBe('org-1');
+    });
+  });
+
+  describe('contract metadata', () => {
+    it('declares the clientes sheet id, required and editable fields', () => {
+      expect(handler.sheetId).toBe('clientes');
+      expect(handler.requiredFields).toEqual(['name', 'documentType', 'documentNumber']);
+      expect(handler.editableFields).toEqual([
+        'name',
+        'documentType',
+        'documentNumber',
+        'email',
+        'phone',
+        'segment',
+      ]);
+    });
+  });
+});

--- a/backend/src/imports/engine/handlers/customer.handler.ts
+++ b/backend/src/imports/engine/handlers/customer.handler.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@nestjs/common';
+import type {
+  ImportSheetHandler,
+  ParsedFileRow,
+  SheetRowContext,
+  ValidationResult,
+} from '../import-sheet-handler.interface';
+import {
+  detectColumns,
+  mapRawRow,
+  type SheetColumnDetectionResult,
+} from '../../helpers/column-detector';
+import { validateCustomerRow } from '../../helpers/validators/customer';
+import { normalizeLookupKey } from '../../helpers/row-validator';
+import { CustomersService } from '../../../customers/customers.service';
+
+const CUSTOMER_EDITABLE_FIELDS = [
+  'name',
+  'documentType',
+  'documentNumber',
+  'email',
+  'phone',
+  'segment',
+];
+
+/**
+ * Per-entity handler for the Clientes sheet. It maps the raw sheet columns,
+ * validates each row with the shared customer validator (segment enum, document
+ * type, org-unique document number) and delegates creation to
+ * {@link CustomersService.create}.
+ *
+ * {@link SheetRowContext.existingKeys} holds the document numbers already known
+ * to the organization plus the ones seen earlier in the file, so the org-unique
+ * documentNumber constraint is enforced both against the database and within a
+ * single upload.
+ */
+@Injectable()
+export class CustomerHandler implements ImportSheetHandler {
+  readonly sheetId = 'clientes';
+  readonly requiredFields = ['name', 'documentType', 'documentNumber'];
+  readonly editableFields = CUSTOMER_EDITABLE_FIELDS;
+
+  constructor(private readonly customersService: CustomersService) {}
+
+  detectColumns(headers: string[]): SheetColumnDetectionResult {
+    return detectColumns(this.sheetId, headers);
+  }
+
+  validateRow(row: ParsedFileRow, ctx: SheetRowContext): ValidationResult {
+    const mapped = mapRawRow(this.sheetId, row.rawData);
+    const result = validateCustomerRow(mapped, ctx.existingKeys);
+
+    if (!result.ok) {
+      return { ok: false, error: result.error };
+    }
+
+    ctx.existingKeys.add(normalizeLookupKey(result.data.documentNumber));
+    return { ok: true, data: { ...result.data } };
+  }
+
+  async createRow(
+    data: Record<string, unknown>,
+    ctx: SheetRowContext,
+  ): Promise<void> {
+    await this.customersService.create(data as never, ctx.organizationId);
+  }
+}

--- a/backend/src/imports/engine/handlers/product.handler.spec.ts
+++ b/backend/src/imports/engine/handlers/product.handler.spec.ts
@@ -1,0 +1,298 @@
+import { ProductHandler, parseProductRow, PRODUCT_EDITABLE_FIELDS } from './product.handler';
+import type {
+  ParsedFileRow,
+  SheetRowContext,
+} from '../import-sheet-handler.interface';
+import { buildGeneratedSku } from '../../helpers/row-validator';
+
+describe('parseProductRow', () => {
+  it('accepts a minimal valid row and defaults sku/category/cost fields', () => {
+    const result = parseProductRow(
+      { name: 'Pan', salePrice: '5000', stock: '10' },
+      2,
+    );
+
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.data).toMatchObject({
+        name: 'Pan',
+        sku: buildGeneratedSku(1),
+        category: 'General',
+        salePrice: 5000,
+        stock: 10,
+        minStock: 0,
+        taxRate: 0,
+        taxRateProvided: false,
+        costInferred: true,
+      });
+    }
+  });
+
+  it('generates a sku from the row index when the row lacks one', () => {
+    const result = parseProductRow(
+      { name: 'Producto', salePrice: '100', stock: '1' },
+      7,
+    );
+
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.data.sku).toBe(buildGeneratedSku(6));
+    }
+  });
+
+  it('infers cost price from sale price when cost is missing', () => {
+    const result = parseProductRow(
+      { name: 'Producto', salePrice: '2500', stock: '5' },
+      2,
+    );
+
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.data.costPrice).toBe(2500);
+      expect(result.data.costInferred).toBe(true);
+    }
+  });
+
+  it('rejects a row without a name', () => {
+    const result = parseProductRow({ salePrice: '5000', stock: '10' }, 2);
+
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.errorCode).toBe('EMPTY_NAME');
+      expect(result.field).toBe('name');
+    }
+  });
+
+  it('rejects an invalid sale price', () => {
+    const result = parseProductRow(
+      { name: 'Producto', salePrice: 'abc', stock: '10' },
+      2,
+    );
+
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.errorCode).toBe('INVALID_PRICE');
+      expect(result.field).toBe('salePrice');
+    }
+  });
+
+  it('rejects an invalid stock', () => {
+    const result = parseProductRow(
+      { name: 'Producto', salePrice: '5000', stock: '-1' },
+      2,
+    );
+
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.errorCode).toBe('INVALID_STOCK');
+      expect(result.field).toBe('stock');
+    }
+  });
+
+  it('rejects an invalid cost price', () => {
+    const result = parseProductRow(
+      { name: 'Producto', salePrice: '5000', stock: '10', costPrice: 'x' },
+      2,
+    );
+
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.errorCode).toBe('INVALID_COST_PRICE');
+      expect(result.field).toBe('costPrice');
+    }
+  });
+
+  it('parses comma decimal separators for price fields', () => {
+    const result = parseProductRow(
+      { name: 'Producto', salePrice: '5.000,50', stock: '10' },
+      2,
+    );
+
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.data.salePrice).toBe(5000.5);
+    }
+  });
+});
+
+describe('ProductHandler', () => {
+  let productsService: { create: jest.Mock };
+  let handler: ProductHandler;
+
+  beforeEach(() => {
+    productsService = { create: jest.fn().mockResolvedValue(undefined) };
+    handler = new ProductHandler(productsService as never);
+  });
+
+  function makeCtx(overrides: Partial<SheetRowContext> = {}): SheetRowContext {
+    return {
+      organizationId: 'org-1',
+      userId: 'user-1',
+      prisma: {
+        category: {
+          findFirst: jest.fn().mockResolvedValue(null),
+          create: jest.fn().mockResolvedValue({ id: 'cat-1', name: 'Bebidas', active: true }),
+          update: jest.fn().mockResolvedValue({ id: 'cat-1', name: 'Bebidas', active: true }),
+        },
+      },
+      planLimits: {},
+      existingKeys: new Set<string>(),
+      ...overrides,
+    } as unknown as SheetRowContext;
+  }
+
+  function makeRow(rawData: Record<string, string>, rowIndex = 2): ParsedFileRow {
+    return { rowIndex, rawData };
+  }
+
+  describe('validateRow', () => {
+    it('maps detected columns, parses and reports sku duplicates', () => {
+      const ctx = makeCtx();
+      handler.validateRow(makeRow({ 'Nombre': 'Pan', 'Precio': '5000', 'Stock': '10' }), ctx);
+
+      const duplicate = handler.validateRow(makeRow({ 'Nombre': 'Otro', 'SKU': 'IMP-001', 'Precio': '10', 'Stock': '1' }), ctx);
+
+      expect(duplicate.ok).toBe(false);
+      if (!duplicate.ok) {
+        expect(duplicate.error.errorCode).toBe('DUPLICATE_SKU');
+        expect(duplicate.error.field).toBe('sku');
+      }
+    });
+
+    it('detects a barcode duplicate within the same file', () => {
+      const ctx = makeCtx();
+      handler.validateRow(
+        makeRow({ 'Nombre': 'Pan', 'Codigo de Barras': '7702011', 'Precio': '5000', 'Stock': '10' }, 2),
+        ctx,
+      );
+
+      const duplicate = handler.validateRow(
+        makeRow({ 'Nombre': 'Otro', 'Codigo de Barras': '7702011', 'Precio': '10', 'Stock': '1' }, 3),
+        ctx,
+      );
+
+      expect(duplicate.ok).toBe(false);
+      if (!duplicate.ok) {
+        expect(duplicate.error.errorCode).toBe('DUPLICATE_BARCODE');
+        expect(duplicate.error.field).toBe('barcode');
+      }
+    });
+
+    it('detects a sku already present in the organization (seeded existing keys)', () => {
+      const ctx = makeCtx({ existingKeys: new Set(['pan']) });
+
+      const result = handler.validateRow(
+        makeRow({ 'Nombre': 'Pan', 'SKU': 'Pan', 'Precio': '5000', 'Stock': '10' }),
+        ctx,
+      );
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.errorCode).toBe('DUPLICATE_SKU');
+      }
+    });
+
+    it('returns parsed product data on a valid row', () => {
+      const ctx = makeCtx();
+
+      const result = handler.validateRow(
+        makeRow({ 'Nombre': 'Pan', 'Precio': '5000', 'Stock': '10' }),
+        ctx,
+      );
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data).toMatchObject({
+          name: 'Pan',
+          salePrice: 5000,
+          stock: 10,
+        });
+      }
+    });
+  });
+
+  describe('createRow', () => {
+    it('resolves an existing category and creates the product via the service', async () => {
+      const prisma = {
+        category: {
+          findFirst: jest.fn().mockResolvedValue({ id: 'cat-existing', name: 'Bebidas', active: true }),
+          create: jest.fn(),
+          update: jest.fn(),
+        },
+      };
+      const ctx = makeCtx({ prisma } as never);
+      const data = {
+        name: 'Pan',
+        sku: 'IMP-001',
+        barcode: undefined,
+        category: 'Bebidas',
+        salePrice: 5000,
+        costPrice: 3500,
+        stock: 10,
+        minStock: 0,
+        taxRate: 0,
+        taxRateProvided: false,
+        description: undefined,
+        costInferred: false,
+      };
+
+      await handler.createRow(data, ctx);
+
+      expect(prisma.category.create).not.toHaveBeenCalled();
+      expect(productsService.create).toHaveBeenCalledTimes(1);
+      const args = productsService.create.mock.calls[0];
+      expect(args[0]).toMatchObject({
+        name: 'Pan',
+        salePrice: 5000,
+        categoryId: 'cat-existing',
+      });
+      expect(args[1]).toBe('user-1');
+      expect(args[2]).toBe('org-1');
+    });
+
+    it('auto-creates a missing category and reuses the created category', async () => {
+      const prisma = {
+        category: {
+          findFirst: jest.fn().mockResolvedValue(null),
+          create: jest.fn().mockResolvedValue({ id: 'cat-new', name: 'Limpieza', active: true }),
+          update: jest.fn(),
+        },
+      };
+      const ctx = makeCtx({ prisma } as never);
+      const data = {
+        name: 'Detergente',
+        sku: 'IMP-002',
+        barcode: undefined,
+        category: 'Limpieza',
+        salePrice: 8000,
+        costPrice: 6000,
+        stock: 30,
+        minStock: 5,
+        taxRate: 19,
+        taxRateProvided: true,
+        description: undefined,
+        costInferred: false,
+      };
+
+      await handler.createRow(data, ctx);
+
+      expect(prisma.category.create).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { name: 'Limpieza', organizationId: 'org-1' } }),
+      );
+      expect(productsService.create).toHaveBeenCalledTimes(1);
+      const firstArg = productsService.create.mock.calls[0][0];
+      expect(firstArg).toMatchObject({ categoryId: 'cat-new', taxable: true, taxRate: 19 });
+    });
+  });
+
+  describe('contract metadata', () => {
+    it('declares the productos sheet id', () => {
+      expect(handler.sheetId).toBe('productos');
+    });
+
+    it('declares required fields and editable fields', () => {
+      expect(handler.requiredFields).toEqual(['name', 'salePrice', 'stock']);
+      expect(handler.editableFields).toEqual(PRODUCT_EDITABLE_FIELDS);
+    });
+  });
+});

--- a/backend/src/imports/engine/handlers/product.handler.ts
+++ b/backend/src/imports/engine/handlers/product.handler.ts
@@ -1,0 +1,420 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma, type Category } from '@prisma/client';
+import type {
+  ImportSheetHandler,
+  ParsedFileRow,
+  SheetRowContext,
+  ValidationResult,
+} from '../import-sheet-handler.interface';
+import { DuplicateTracker } from '../duplicate-tracker';
+import {
+  detectColumns,
+  mapRawRow,
+  type SheetColumnDetectionResult,
+} from '../../helpers/column-detector';
+import {
+  buildGeneratedSku,
+  normalizeCategoryName,
+  normalizeLookupKey,
+  normalizeText,
+  parseDecimal,
+  parseInteger,
+  toTitleCase,
+} from '../../helpers/row-validator';
+import { ProductsService } from '../../../products/products.service';
+
+/** Fields the UI exposes for inline editing of a product row. */
+export const PRODUCT_EDITABLE_FIELDS = [
+  'name',
+  'sku',
+  'barcode',
+  'category',
+  'salePrice',
+  'costPrice',
+  'stock',
+  'minStock',
+  'taxRate',
+  'description',
+];
+
+/** Normalized product import data after {@link parseProductRow}. */
+export interface ParsedProductData {
+  name: string;
+  sku: string;
+  barcode?: string;
+  category: string;
+  salePrice: number;
+  costPrice: number;
+  stock: number;
+  minStock: number;
+  taxRate: number;
+  taxRateProvided: boolean;
+  description?: string;
+  costInferred: boolean;
+}
+
+export type ParseProductRowResult =
+  | {
+      kind: 'error';
+      errorCode: string;
+      message: string;
+      field?: string;
+      mappedData: Record<string, unknown>;
+    }
+  | { kind: 'ok'; data: ParsedProductData };
+
+/**
+ * Pure, field-keyed row parser for the Productos sheet. Given the mapped cells
+ * (field name -> raw string) it applies the current product import semantics:
+ * a generated SKU when absent, an inferred cost price, defaulted min-stock and
+ * tax rate, and the same numeric parsing helpers as the product-only importer.
+ */
+export function parseProductRow(
+  mapped: Record<string, unknown>,
+  rowIndex: number,
+): ParseProductRowResult {
+  const name = normalizeText(mapped.name);
+
+  if (!name) {
+    return {
+      kind: 'error',
+      errorCode: 'EMPTY_NAME',
+      message: 'Nombre de producto requerido',
+      field: 'name',
+      mappedData: { ...mapped },
+    };
+  }
+
+  let sku = normalizeText(mapped.sku);
+  if (!sku) {
+    sku = buildGeneratedSku(rowIndex - 1);
+  }
+
+  const salePrice = parseDecimal(mapped.salePrice);
+  if (salePrice === null || salePrice <= 0) {
+    return {
+      kind: 'error',
+      errorCode: 'INVALID_PRICE',
+      message: 'Precio de venta invalido',
+      field: 'salePrice',
+      mappedData: { ...mapped, sku, name },
+    };
+  }
+
+  const stock = parseInteger(mapped.stock);
+  if (stock === null || stock < 0) {
+    return {
+      kind: 'error',
+      errorCode: 'INVALID_STOCK',
+      message: 'Stock invalido. Debe ser un numero entero mayor o igual a 0',
+      field: 'stock',
+      mappedData: { ...mapped, sku, name, salePrice },
+    };
+  }
+
+  const rawCostPrice = normalizeText(mapped.costPrice);
+  let costInferred = false;
+  let costPrice = parseDecimal(rawCostPrice);
+
+  if (!rawCostPrice) {
+    costInferred = true;
+    costPrice = salePrice;
+  }
+
+  if (costPrice === null || costPrice < 0) {
+    return {
+      kind: 'error',
+      errorCode: 'INVALID_COST_PRICE',
+      message: 'Precio de costo invalido',
+      field: 'costPrice',
+      mappedData: { ...mapped, sku, name, salePrice, stock },
+    };
+  }
+
+  const minStockRaw = normalizeText(mapped.minStock);
+  let minStock = parseInteger(minStockRaw);
+  if (!minStockRaw) {
+    minStock = 0;
+  }
+
+  if (minStock === null || minStock < 0) {
+    return {
+      kind: 'error',
+      errorCode: 'INVALID_MIN_STOCK',
+      message:
+        'Stock minimo invalido. Debe ser un numero entero mayor o igual a 0',
+      field: 'minStock',
+      mappedData: { ...mapped, sku, name, salePrice, stock, costPrice },
+    };
+  }
+
+  const taxRateRaw = normalizeText(mapped.taxRate);
+  const taxRateProvided = taxRateRaw.length > 0;
+  let taxRate = parseDecimal(taxRateRaw);
+  if (!taxRateProvided) {
+    taxRate = 0;
+  }
+
+  if (taxRate === null || taxRate < 0) {
+    return {
+      kind: 'error',
+      errorCode: 'INVALID_TAX_RATE',
+      message: 'Impuesto invalido',
+      field: 'taxRate',
+      mappedData: {
+        ...mapped,
+        sku,
+        name,
+        salePrice,
+        stock,
+        costPrice,
+        minStock,
+      },
+    };
+  }
+
+  return {
+    kind: 'ok',
+    data: {
+      name,
+      sku,
+      barcode: normalizeText(mapped.barcode) || undefined,
+      category: normalizeText(mapped.category) || 'General',
+      salePrice,
+      costPrice,
+      stock,
+      minStock,
+      taxRate,
+      taxRateProvided,
+      description: normalizeText(mapped.description) || undefined,
+      costInferred,
+    },
+  };
+}
+
+/**
+ * Self-contained, unit-testable handler for the Productos sheet. It preserves
+ * the current product import semantics — sku/barcode org-unique duplicate
+ * detection and category auto-create — without wiring the full product-only
+ * pipeline onto it (that rewire is the final slice).
+ *
+ * The handler is meant to be instantiated once per import job so the in-file
+ * duplicate trackers and the category cache stay job-scoped.
+ */
+@Injectable()
+export class ProductHandler implements ImportSheetHandler {
+  readonly sheetId = 'productos';
+  readonly requiredFields = ['name', 'salePrice', 'stock'];
+  readonly editableFields = PRODUCT_EDITABLE_FIELDS;
+
+  private readonly skuTracker = new DuplicateTracker();
+  private readonly barcodeTracker = new DuplicateTracker();
+  private readonly categoriesByNormalizedName = new Map<string, Category>();
+  private seededExisting = false;
+
+  constructor(private readonly productsService: ProductsService) {}
+
+  detectColumns(headers: string[]): SheetColumnDetectionResult {
+    return detectColumns(this.sheetId, headers);
+  }
+
+  validateRow(row: ParsedFileRow, ctx: SheetRowContext): ValidationResult {
+    const mapped = mapRawRow(this.sheetId, row.rawData);
+    const parsed = parseProductRow(mapped, row.rowIndex);
+
+    if (parsed.kind === 'error') {
+      return {
+        ok: false,
+        error: {
+          errorCode: parsed.errorCode,
+          message: parsed.message,
+          field: parsed.field,
+          mappedData: parsed.mappedData,
+        },
+      };
+    }
+
+    // Seed the sku tracker with the organization's existing skus on first use.
+    // Barcodes are tracked for same-file duplicates only; barcode collisions
+    // against the database are caught by `ProductsService.create`.
+    if (!this.seededExisting) {
+      for (const key of ctx.existingKeys) {
+        this.skuTracker.seed(key);
+      }
+      this.seededExisting = true;
+    }
+
+    const data = parsed.data;
+    const skuKey = normalizeLookupKey(data.sku);
+    const barcodeKey = data.barcode ? normalizeLookupKey(data.barcode) : '';
+
+    if (this.skuTracker.isDuplicate(skuKey)) {
+      return this.duplicateError('DUPLICATE_SKU', 'SKU duplicado', 'sku', data);
+    }
+
+    if (barcodeKey && this.barcodeTracker.isDuplicate(barcodeKey)) {
+      return this.duplicateError(
+        'DUPLICATE_BARCODE',
+        'Codigo de barras duplicado',
+        'barcode',
+        data,
+      );
+    }
+
+    this.skuTracker.register(skuKey);
+    if (barcodeKey) {
+      this.barcodeTracker.register(barcodeKey);
+    }
+    ctx.existingKeys.add(skuKey);
+
+    return { ok: true, data: { ...data } };
+  }
+
+  async createRow(
+    data: Record<string, unknown>,
+    ctx: SheetRowContext,
+  ): Promise<void> {
+    const parsed = data as unknown as ParsedProductData;
+    const category = await this.resolveCategory(parsed.category, ctx);
+
+    const taxable = parsed.taxRateProvided && parsed.taxRate > 0;
+    const taxRate = taxable ? parsed.taxRate : 0;
+
+    await this.productsService.create(
+      {
+        name: parsed.name,
+        sku: parsed.sku,
+        barcode: parsed.barcode,
+        description: parsed.description,
+        costPrice: parsed.costPrice,
+        salePrice: parsed.salePrice,
+        taxable,
+        taxRate,
+        stock: parsed.stock,
+        minStock: parsed.minStock,
+        categoryId: category.id,
+      },
+      ctx.userId,
+      ctx.organizationId,
+    );
+  }
+
+  private duplicateError(
+    errorCode: string,
+    message: string,
+    field: string,
+    data: ParsedProductData,
+  ): {
+    ok: false;
+    error: {
+      errorCode: string;
+      message: string;
+      field: string;
+      mappedData: Record<string, unknown>;
+    };
+  } {
+    return {
+      ok: false,
+      error: {
+        errorCode,
+        message,
+        field,
+        mappedData: { ...data },
+      },
+    };
+  }
+
+  private async resolveCategory(
+    categoryName: string,
+    ctx: SheetRowContext,
+  ): Promise<Category> {
+    const normalized = normalizeCategoryName(categoryName || 'General');
+    const cached = this.categoriesByNormalizedName.get(normalized);
+
+    if (cached) {
+      if (!cached.active) {
+        const updated = await ctx.prisma.category.update({
+          where: { id: cached.id },
+          data: { active: true },
+        });
+        this.categoriesByNormalizedName.set(
+          normalizeCategoryName(updated.name),
+          updated,
+        );
+        return updated;
+      }
+      return cached;
+    }
+
+    const existing = await ctx.prisma.category.findFirst({
+      where: {
+        organizationId: ctx.organizationId,
+        name: {
+          equals: normalizeText(categoryName),
+          mode: 'insensitive',
+        },
+      },
+    });
+
+    if (existing) {
+      if (!existing.active) {
+        const updated = await ctx.prisma.category.update({
+          where: { id: existing.id },
+          data: { active: true },
+        });
+        this.categoriesByNormalizedName.set(
+          normalizeCategoryName(updated.name),
+          updated,
+        );
+        return updated;
+      }
+
+      this.categoriesByNormalizedName.set(
+        normalizeCategoryName(existing.name),
+        existing,
+      );
+      return existing;
+    }
+
+    const displayName = toTitleCase(categoryName || 'General') || 'General';
+
+    try {
+      const createdCategory = await ctx.prisma.category.create({
+        data: {
+          name: displayName,
+          organizationId: ctx.organizationId,
+        },
+      });
+      this.categoriesByNormalizedName.set(
+        normalizeCategoryName(createdCategory.name),
+        createdCategory,
+      );
+      return createdCategory;
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        const fallback = await ctx.prisma.category.findFirst({
+          where: {
+            organizationId: ctx.organizationId,
+            name: {
+              equals: displayName,
+              mode: 'insensitive',
+            },
+          },
+        });
+
+        if (fallback) {
+          this.categoriesByNormalizedName.set(
+            normalizeCategoryName(fallback.name),
+            fallback,
+          );
+          return fallback;
+        }
+      }
+
+      throw error;
+    }
+  }
+}

--- a/backend/src/imports/engine/handlers/supplier.handler.spec.ts
+++ b/backend/src/imports/engine/handlers/supplier.handler.spec.ts
@@ -1,0 +1,140 @@
+import { SupplierHandler } from './supplier.handler';
+import type { ParsedFileRow, SheetRowContext } from '../import-sheet-handler.interface';
+
+describe('SupplierHandler', () => {
+  let suppliersService: { create: jest.Mock };
+  let handler: SupplierHandler;
+
+  beforeEach(() => {
+    suppliersService = { create: jest.fn().mockResolvedValue(undefined) };
+    handler = new SupplierHandler(suppliersService as never);
+  });
+
+  function makeCtx(overrides: Partial<SheetRowContext> = {}): SheetRowContext {
+    return {
+      organizationId: 'org-1',
+      userId: 'user-1',
+      prisma: {},
+      planLimits: {},
+      existingKeys: new Set<string>(),
+      ...overrides,
+    } as unknown as SheetRowContext;
+  }
+
+  function makeRow(rawData: Record<string, string>, rowIndex = 2): ParsedFileRow {
+    return { rowIndex, rawData };
+  }
+
+  describe('validateRow', () => {
+    it('validates a mapped supplier row and normalizes account type', () => {
+      const ctx = makeCtx();
+
+      const result = handler.validateRow(
+        makeRow({
+          'Nombre': 'Distribuidora XYZ',
+          'Documento': '900123456',
+          'Tipo de Cuenta': 'savings',
+        }),
+        ctx,
+      );
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data).toMatchObject({
+          name: 'Distribuidora XYZ',
+          documentNumber: '900123456',
+          accountType: 'SAVINGS',
+        });
+      }
+      expect(ctx.existingKeys.has('900123456')).toBe(true);
+    });
+
+    it('rejects a document number already present in the organization', () => {
+      const ctx = makeCtx({ existingKeys: new Set(['900123456']) });
+
+      const result = handler.validateRow(
+        makeRow({ 'Nombre': 'Distribuidora XYZ', 'Documento': '900123456' }),
+        ctx,
+      );
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.errorCode).toBe('DUPLICATE_DOCUMENT');
+        expect(result.error.field).toBe('documentNumber');
+      }
+    });
+
+    it('rejects a duplicate document number within the same file', () => {
+      const ctx = makeCtx();
+      handler.validateRow(
+        makeRow({ 'Nombre': 'A', 'Documento': '111' }, 2),
+        ctx,
+      );
+
+      const duplicate = handler.validateRow(
+        makeRow({ 'Nombre': 'B', 'Documento': '111' }, 3),
+        ctx,
+      );
+
+      expect(duplicate.ok).toBe(false);
+      if (!duplicate.ok) {
+        expect(duplicate.error.errorCode).toBe('DUPLICATE_DOCUMENT');
+      }
+    });
+
+    it('rejects an invalid account type', () => {
+      const ctx = makeCtx();
+
+      const result = handler.validateRow(
+        makeRow({ 'Nombre': 'Distribuidora XYZ', 'Documento': '900123456', 'Tipo de Cuenta': 'CREDIT' }),
+        ctx,
+      );
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.errorCode).toBe('INVALID_ACCOUNT_TYPE');
+        expect(result.error.field).toBe('accountType');
+      }
+    });
+
+    it('propagates a validation failure (missing document)', () => {
+      const ctx = makeCtx();
+
+      const result = handler.validateRow(makeRow({ 'Nombre': 'Distribuidora XYZ' }), ctx);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.errorCode).toBe('EMPTY_DOCUMENT');
+      }
+    });
+  });
+
+  describe('createRow', () => {
+    it('creates the supplier via the service with the organization id', async () => {
+      const ctx = makeCtx();
+
+      await handler.createRow(
+        { name: 'Distribuidora XYZ', documentNumber: '900123456', accountType: 'SAVINGS' },
+        ctx,
+      );
+
+      expect(suppliersService.create).toHaveBeenCalledTimes(1);
+      const [dto, organizationId] = suppliersService.create.mock.calls[0];
+      expect(dto).toMatchObject({
+        name: 'Distribuidora XYZ',
+        documentNumber: '900123456',
+      });
+      expect(organizationId).toBe('org-1');
+    });
+  });
+
+  describe('contract metadata', () => {
+    it('declares the proveedores sheet id, required and editable fields', () => {
+      expect(handler.sheetId).toBe('proveedores');
+      expect(handler.requiredFields).toEqual(['name', 'documentNumber']);
+      expect(handler.editableFields).toContain('name');
+      expect(handler.editableFields).toContain('documentNumber');
+      expect(handler.editableFields).toContain('accountType');
+    });
+  });
+});

--- a/backend/src/imports/engine/handlers/supplier.handler.ts
+++ b/backend/src/imports/engine/handlers/supplier.handler.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@nestjs/common';
+import type {
+  ImportSheetHandler,
+  ParsedFileRow,
+  SheetRowContext,
+  ValidationResult,
+} from '../import-sheet-handler.interface';
+import {
+  detectColumns,
+  mapRawRow,
+  type SheetColumnDetectionResult,
+} from '../../helpers/column-detector';
+import { validateSupplierRow } from '../../helpers/validators/supplier';
+import { normalizeLookupKey } from '../../helpers/row-validator';
+import { SuppliersService } from '../../../suppliers/suppliers.service';
+
+const SUPPLIER_EDITABLE_FIELDS = [
+  'name',
+  'documentNumber',
+  'email',
+  'phone',
+  'address',
+  'contactName',
+  'bank',
+  'accountNumber',
+  'accountType',
+];
+
+/**
+ * Per-entity handler for the Proveedores sheet. It maps the raw sheet columns,
+ * validates each row with the shared supplier validator (account type
+ * SAVINGS/CHECKING, org-unique document number) and delegates creation to
+ * {@link SuppliersService.create}.
+ *
+ * {@link SheetRowContext.existingKeys} holds the document numbers already known
+ * to the organization plus the ones seen earlier in the file, so the org-unique
+ * documentNumber constraint is enforced both against the database and within a
+ * single upload.
+ */
+@Injectable()
+export class SupplierHandler implements ImportSheetHandler {
+  readonly sheetId = 'proveedores';
+  readonly requiredFields = ['name', 'documentNumber'];
+  readonly editableFields = SUPPLIER_EDITABLE_FIELDS;
+
+  constructor(private readonly suppliersService: SuppliersService) {}
+
+  detectColumns(headers: string[]): SheetColumnDetectionResult {
+    return detectColumns(this.sheetId, headers);
+  }
+
+  validateRow(row: ParsedFileRow, ctx: SheetRowContext): ValidationResult {
+    const mapped = mapRawRow(this.sheetId, row.rawData);
+    const result = validateSupplierRow(mapped, ctx.existingKeys);
+
+    if (!result.ok) {
+      return { ok: false, error: result.error };
+    }
+
+    ctx.existingKeys.add(normalizeLookupKey(result.data.documentNumber));
+    return { ok: true, data: { ...result.data } };
+  }
+
+  async createRow(
+    data: Record<string, unknown>,
+    ctx: SheetRowContext,
+  ): Promise<void> {
+    await this.suppliersService.create(data as never, ctx.organizationId);
+  }
+}

--- a/backend/src/imports/engine/handlers/user.handler.spec.ts
+++ b/backend/src/imports/engine/handlers/user.handler.spec.ts
@@ -1,0 +1,134 @@
+import { UserHandler } from './user.handler';
+import type { ParsedFileRow, SheetRowContext } from '../import-sheet-handler.interface';
+
+describe('UserHandler', () => {
+  let usersService: { create: jest.Mock };
+  let handler: UserHandler;
+
+  beforeEach(() => {
+    usersService = { create: jest.fn().mockResolvedValue(undefined) };
+    handler = new UserHandler(usersService as never);
+  });
+
+  function makeCtx(overrides: Partial<SheetRowContext> = {}): SheetRowContext {
+    return {
+      organizationId: 'org-1',
+      userId: 'user-1',
+      prisma: {},
+      planLimits: {},
+      existingKeys: new Set<string>(),
+      ...overrides,
+    } as unknown as SheetRowContext;
+  }
+
+  function makeRow(rawData: Record<string, string>, rowIndex = 2): ParsedFileRow {
+    return { rowIndex, rawData };
+  }
+
+  describe('validateRow', () => {
+    it('validates a mapped user row and defaults the role to CASHIER', () => {
+      const ctx = makeCtx();
+
+      const result = handler.validateRow(
+        makeRow({
+          'Correo': 'user@example.com',
+          'Password': 'correct-horse-battery-staple',
+          'Nombre': 'John Doe',
+        }),
+        ctx,
+      );
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data).toMatchObject({
+          email: 'user@example.com',
+          password: 'correct-horse-battery-staple',
+          name: 'John Doe',
+          role: 'CASHIER',
+        });
+      }
+      expect(ctx.existingKeys.has('user@example.com')).toBe(true);
+    });
+
+    it('rejects an email already registered (pre-seeded existing key)', () => {
+      const ctx = makeCtx({ existingKeys: new Set(['user@example.com']) });
+
+      const result = handler.validateRow(
+        makeRow({
+          'Correo': 'user@example.com',
+          'Password': 'correct-horse-battery-staple',
+          'Nombre': 'John Doe',
+        }),
+        ctx,
+      );
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.errorCode).toBe('DUPLICATE_EMAIL');
+        expect(result.error.field).toBe('email');
+      }
+    });
+
+    it('rejects a duplicate email within the same file', () => {
+      const ctx = makeCtx();
+      handler.validateRow(
+        makeRow({ 'Correo': 'dup@example.com', 'Password': 'correct-horse-battery-staple', 'Nombre': 'A' }, 2),
+        ctx,
+      );
+
+      const duplicate = handler.validateRow(
+        makeRow({ 'Correo': 'dup@example.com', 'Password': 'correct-horse-battery-staple', 'Nombre': 'B' }, 3),
+        ctx,
+      );
+
+      expect(duplicate.ok).toBe(false);
+      if (!duplicate.ok) {
+        expect(duplicate.error.errorCode).toBe('DUPLICATE_EMAIL');
+      }
+    });
+
+    it('propagates a weak-password rejection via the shared policy', () => {
+      const ctx = makeCtx();
+
+      const result = handler.validateRow(
+        makeRow({ 'Correo': 'user@example.com', 'Password': 'short', 'Nombre': 'John Doe' }),
+        ctx,
+      );
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.errorCode).toBe('INVALID_PASSWORD');
+        expect(result.error.field).toBe('password');
+      }
+    });
+  });
+
+  describe('createRow', () => {
+    it('creates the user via the service with the organization id', async () => {
+      const ctx = makeCtx();
+
+      await handler.createRow(
+        { email: 'user@example.com', password: 'correct-horse-battery-staple', name: 'John Doe', role: 'CASHIER' },
+        ctx,
+      );
+
+      expect(usersService.create).toHaveBeenCalledTimes(1);
+      const [dto, organizationId] = usersService.create.mock.calls[0];
+      expect(dto).toMatchObject({
+        email: 'user@example.com',
+        password: 'correct-horse-battery-staple',
+        name: 'John Doe',
+        role: 'CASHIER',
+      });
+      expect(organizationId).toBe('org-1');
+    });
+  });
+
+  describe('contract metadata', () => {
+    it('declares the usuarios sheet id, required and editable fields', () => {
+      expect(handler.sheetId).toBe('usuarios');
+      expect(handler.requiredFields).toEqual(['email', 'password']);
+      expect(handler.editableFields).toEqual(['email', 'password', 'name', 'role']);
+    });
+  });
+});

--- a/backend/src/imports/engine/handlers/user.handler.ts
+++ b/backend/src/imports/engine/handlers/user.handler.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@nestjs/common';
+import type {
+  ImportSheetHandler,
+  ParsedFileRow,
+  SheetRowContext,
+  ValidationResult,
+} from '../import-sheet-handler.interface';
+import {
+  detectColumns,
+  mapRawRow,
+  type SheetColumnDetectionResult,
+} from '../../helpers/column-detector';
+import { validateUserRow } from '../../helpers/validators/user';
+import { normalizeLookupKey } from '../../helpers/row-validator';
+import { UsersService } from '../../../users/users.service';
+
+const USER_EDITABLE_FIELDS = ['email', 'password', 'name', 'role'];
+
+/**
+ * Per-entity handler for the Usuarios sheet. It maps the raw sheet columns,
+ * validates each row with the shared user validator (role set, password policy
+ * delegated to {@link validatePasswordPolicy}, role default CASHIER) and
+ * delegates creation to {@link UsersService.create}, which creates the global
+ * `User` plus the nested `OrganizationUser` membership.
+ *
+ * Email uniqueness is global, so {@link SheetRowContext.existingKeys} holds the
+ * emails already registered plus the ones seen earlier in this file; the
+ * validator does not check duplicates, so the handler does it here and reports
+ * the row with DUPLICATE_EMAIL before creation.
+ */
+@Injectable()
+export class UserHandler implements ImportSheetHandler {
+  readonly sheetId = 'usuarios';
+  readonly requiredFields = ['email', 'password'];
+  readonly editableFields = USER_EDITABLE_FIELDS;
+
+  constructor(private readonly usersService: UsersService) {}
+
+  detectColumns(headers: string[]): SheetColumnDetectionResult {
+    return detectColumns(this.sheetId, headers);
+  }
+
+  validateRow(row: ParsedFileRow, ctx: SheetRowContext): ValidationResult {
+    const mapped = mapRawRow(this.sheetId, row.rawData);
+    const result = validateUserRow(mapped);
+
+    if (!result.ok) {
+      return { ok: false, error: result.error };
+    }
+
+    const emailKey = normalizeLookupKey(result.data.email);
+    if (ctx.existingKeys.has(emailKey)) {
+      return {
+        ok: false,
+        error: {
+          errorCode: 'DUPLICATE_EMAIL',
+          message: 'Ya existe un usuario con ese correo',
+          field: 'email',
+          mappedData: { ...result.data },
+        },
+      };
+    }
+
+    ctx.existingKeys.add(emailKey);
+    return { ok: true, data: { ...result.data } };
+  }
+
+  async createRow(
+    data: Record<string, unknown>,
+    ctx: SheetRowContext,
+  ): Promise<void> {
+    await this.usersService.create(data as never, ctx.organizationId);
+  }
+}

--- a/backend/src/imports/engine/sheet-registry.spec.ts
+++ b/backend/src/imports/engine/sheet-registry.spec.ts
@@ -1,0 +1,55 @@
+import { SheetRegistry, IMPORT_SHEET_HANDLERS } from './sheet-registry';
+import type {
+  ImportSheetHandler,
+  ParsedFileRow,
+  SheetRowContext,
+  ValidationResult,
+} from './import-sheet-handler.interface';
+
+function fakeHandler(sheetId: ImportSheetHandler['sheetId']): ImportSheetHandler {
+  return {
+    sheetId,
+    requiredFields: ['name'],
+    editableFields: ['name'],
+    detectColumns: (headers) => ({
+      sheetId,
+      detectedColumns: headers,
+      mapping: {},
+      missingRequiredFields: [],
+    }),
+    validateRow: (_row: ParsedFileRow, _ctx: SheetRowContext): ValidationResult => ({
+      ok: true,
+      data: { name: 'x' },
+    }),
+    createRow: async (_data, _ctx) => undefined,
+  };
+}
+
+describe('SheetRegistry', () => {
+  it('exposes the DI injection token', () => {
+    expect(IMPORT_SHEET_HANDLERS).toBe('IMPORT_SHEET_HANDLERS');
+  });
+
+  it('resolves a registered handler by sheet id', () => {
+    const productos = fakeHandler('productos');
+    const clientes = fakeHandler('clientes');
+    const registry = new SheetRegistry([productos, clientes]);
+
+    expect(registry.get('productos')).toBe(productos);
+    expect(registry.get('clientes')).toBe(clientes);
+  });
+
+  it('returns undefined for an unregistered sheet id', () => {
+    const registry = new SheetRegistry([fakeHandler('productos')]);
+
+    expect(registry.get('usuarios')).toBeUndefined();
+  });
+
+  it('returns every registered handler via all()', () => {
+    const products = [fakeHandler('productos'), fakeHandler('proveedores')];
+    const registry = new SheetRegistry(products);
+
+    expect(registry.all()).toHaveLength(2);
+    expect(registry.all()).toEqual(expect.arrayContaining(products));
+  });
+});

--- a/backend/src/imports/engine/sheet-registry.ts
+++ b/backend/src/imports/engine/sheet-registry.ts
@@ -1,0 +1,39 @@
+import type {
+  ImportSheetHandler,
+  SheetId,
+} from './import-sheet-handler.interface';
+
+/**
+ * DI token under which the engine registers the array of entity handlers. The
+ * module provider aggregates the per-entity handlers in the next slice; the
+ * registry is a plain, instantiable class so it stays unit-testable without a
+ * Nest testing module.
+ */
+export const IMPORT_SHEET_HANDLERS = 'IMPORT_SHEET_HANDLERS';
+
+/**
+ * Resolves a per-entity {@link ImportSheetHandler} by its {@link SheetId}.
+ *
+ * The handlers are provided as a DI array — one handler per importable sheet —
+ * and this registry indexes them so the orchestrator can look up the correct
+ * handler for a detected sheet without a switch statement.
+ */
+export class SheetRegistry {
+  private readonly bySheetId: Map<SheetId, ImportSheetHandler>;
+
+  constructor(handlers: readonly ImportSheetHandler[]) {
+    this.bySheetId = new Map(
+      handlers.map((handler) => [handler.sheetId, handler]),
+    );
+  }
+
+  /** Returns the handler registered for `sheetId`, or `undefined` when unregistered. */
+  get(sheetId: SheetId): ImportSheetHandler | undefined {
+    return this.bySheetId.get(sheetId);
+  }
+
+  /** Returns every registered entity handler, in registration order. */
+  all(): readonly ImportSheetHandler[] {
+    return [...this.bySheetId.values()];
+  }
+}

--- a/backend/src/imports/helpers/column-detector.ts
+++ b/backend/src/imports/helpers/column-detector.ts
@@ -235,3 +235,25 @@ export function detectColumns(
     missingRequiredFields,
   };
 }
+
+/**
+ * Re-maps a raw worksheet row's header-keyed cells into the field-keyed object
+ * the per-entity handlers expect, using the alias detection for `sheetId`.
+ *
+ * Cell values are left as their raw strings; field-level parsing and
+ * normalization are owned by each entity's validator/parser so the helpers here
+ * stay purely about column mapping.
+ */
+export function mapRawRow(
+  sheetId: SheetId,
+  rawData: Record<string, string>,
+): Record<string, unknown> {
+  const { mapping } = detectColumns(sheetId, Object.keys(rawData));
+  const mapped: Record<string, unknown> = {};
+
+  for (const [field, header] of Object.entries(mapping)) {
+    mapped[field] = rawData[header];
+  }
+
+  return mapped;
+}


### PR DESCRIPTION
Closes #2

## Summary
This is **slice 2 / PR2 of 5** in the stacked-to-main chain that turns the product-only importer into a 4-sheet importer (Productos → Clientes → Proveedores → Usuarios). PR1 (#90, engine contract + column detection + validators) is already merged. This slice lands the **per-entity handlers** on top of that tested seam, as self-contained, unit-testable `ImportSheetHandler` implementations plus the engine's duplicate tracker and sheet registry.

- Engine helpers: `DuplicateTracker` (org-unique + within-file duplicate detection) and `SheetRegistry` (resolves an `ImportSheetHandler` by `SheetId` from the DI handler array).
- `ProductHandler`: extracts the current product row semantics (generated SKU, inferred cost, defaulted min-stock/tax, sku/barcode org-unique duplicate detection, category auto-create) without rewiring `imports.service.ts` (that rewire is slice 4 / task 4.4).
- `CustomerHandler`: `customer` validator + `CustomersService.create(dto, organizationId)`.
- `SupplierHandler`: `supplier` validator + `SuppliersService.create`.
- `UserHandler`: `user` validator + `UsersService.create` (nested global `User` + `OrganizationUser`, role default CASHIER), email duplicate detection.

`imports.service.ts`, `imports.controller.ts`, and `imports.module.ts` are intentionally untouched. The product-only `/imports/products` path stays green.

## Dependency diagram
```
master (head)
  └─ PR1 (#90, merged) — engine contract + column detection + validators
      └─ PR2 (📍 this PR) — per-entity handlers + duplicate-tracker + sheet-registry
          └─ PR3 — orchestrator + ExcelJS template
              └─ PR4 — controller routes + module DI + dto
                  └─ PR5 — frontend /imports page
```

## Changes
| File | Change |
|------|--------|
| `backend/src/imports/engine/duplicate-tracker.ts` | New `DuplicateTracker` (existing + seen-in-file duplicate detection) |
| `backend/src/imports/engine/sheet-registry.ts` | New `SheetRegistry` + `IMPORT_SHEET_HANDLERS` DI token |
| `backend/src/imports/engine/handlers/product.handler.ts` | New `ProductHandler` + pure `parseProductRow` (existing product semantics) |
| `backend/src/imports/engine/handlers/customer.handler.ts` | New `CustomerHandler` |
| `backend/src/imports/engine/handlers/supplier.handler.ts` | New `SupplierHandler` |
| `backend/src/imports/engine/handlers/user.handler.ts` | New `UserHandler` |
| `backend/src/imports/helpers/column-detector.ts` | Added `mapRawRow(sheetId, rawData)` shared re-mapping helper |
| `backend/src/imports/engine/**/*.spec.ts` | Red-first tests for every unit above |

## Out of scope (later slices)
Orchestrator (`multi-sheet-import.service`), template service, controller routes + module DI + dto (incl. the `imports.service.ts` rewire), and the frontend `/imports` page.

## Verification
- `cd backend && npm run test -- imports` → **10 suites, 99/99 passing** (49 new tests in this slice; product/import path stays green).
- `npm run build` (nest build) → clean.
- `eslint` on changed files → clean.

## Reviewer note
Strict TDD was used: each unit's spec was authored and failed (RED) before the implementation (GREEN). This slice carries **1637 changed lines (13 files, 1637 additions)** — above the 400-line single-PR guideline, but it is the pre-planned slice boundary for PR2 in the `stacked-to-main` chain (change split by the orchestrator: handlers here; orchestrator → controller → frontend in PR3..PR5). If the maintainer prefers a smaller review, the non-product handlers (customer/supplier/user, each ~1 commit) can be split into follow-ups without breaking the seams landed by the first commit.

## Checklist
- [x] Linked issue #2
- [x] Conventional commit format (5 work-unit commits, tests with code, no AI attribution)
- [x] Backend import suite green (99/99)
- [x] Build clean (tsc/nest build)
