### PR TITLE
feat(imports): multi-sheet importer orchestrator and template (slice 3/5)

### DIFF
--- a/backend/src/imports/multi-sheet-import.service.spec.ts
+++ b/backend/src/imports/multi-sheet-import.service.spec.ts
@@ -1,0 +1,488 @@
+import { UnprocessableEntityException } from '@nestjs/common';
+import * as ExcelJS from 'exceljs';
+import { MultiSheetImportService } from './multi-sheet-import.service';
+
+type PlanLimitResult = {
+  current: number;
+  limit: number;
+  exceeded: boolean;
+};
+
+interface SheetFixture {
+  name: string;
+  headers: string[];
+  rows: Array<Array<string | number>>;
+}
+
+async function buildWorkbookBuffer(sheets: SheetFixture[]): Promise<Buffer> {
+  const workbook = new ExcelJS.Workbook();
+  for (const sheet of sheets) {
+    const worksheet = workbook.addWorksheet(sheet.name);
+    worksheet.addRow(sheet.headers);
+    for (const row of sheet.rows) {
+      worksheet.addRow(row);
+    }
+  }
+  return Buffer.from(await workbook.xlsx.writeBuffer());
+}
+
+function makeFile(buffer: Buffer, name = 'import.xlsx'): Express.Multer.File {
+  return {
+    buffer,
+    originalname: name,
+    mimetype:
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  } as Express.Multer.File;
+}
+
+describe('MultiSheetImportService', () => {
+  let service: MultiSheetImportService;
+  let prisma: any;
+  let planLimits: {
+    getLimitStatus: jest.Mock;
+    count: jest.Mock;
+    invalidateCache: jest.Mock;
+    checkLimit: jest.Mock;
+  };
+  let productsService: { create: jest.Mock };
+  let customersService: { create: jest.Mock };
+  let suppliersService: { create: jest.Mock };
+  let usersService: { create: jest.Mock };
+
+  beforeEach(() => {
+    prisma = {
+      product: { findMany: jest.fn().mockResolvedValue([]) },
+      customer: { findMany: jest.fn().mockResolvedValue([]) },
+      supplier: { findMany: jest.fn().mockResolvedValue([]) },
+      organizationUser: { findMany: jest.fn().mockResolvedValue([]) },
+      category: {
+        findFirst: jest
+          .fn()
+          .mockResolvedValue({ id: 'cat-1', name: 'General', active: true }),
+        update: jest.fn(),
+        create: jest
+          .fn()
+          .mockResolvedValue({ id: 'cat-9', name: 'Nueva', active: true }),
+      },
+    };
+    planLimits = {
+      getLimitStatus: jest
+        .fn()
+        .mockResolvedValue({ current: 0, limit: -1, exceeded: false }),
+      count: jest.fn().mockResolvedValue(0),
+      invalidateCache: jest.fn(),
+      checkLimit: jest
+        .fn()
+        .mockResolvedValue({ allowed: true, current: 0, limit: -1 }),
+    };
+    productsService = { create: jest.fn().mockResolvedValue(undefined) };
+    customersService = { create: jest.fn().mockResolvedValue(undefined) };
+    suppliersService = { create: jest.fn().mockResolvedValue(undefined) };
+    usersService = { create: jest.fn().mockResolvedValue(undefined) };
+
+    service = new MultiSheetImportService(
+      prisma,
+      planLimits as never,
+      productsService as never,
+      customersService as never,
+      suppliersService as never,
+      usersService as never,
+    );
+  });
+
+  async function flush() {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  describe('sheet resolution order', () => {
+    it('processes sheets in Productos -> Clientes -> Proveedores -> Usuarios order regardless of file order', async () => {
+      const buffer = await buildWorkbookBuffer([
+        {
+          name: 'Clientes',
+          headers: ['Nombre', 'Tipo de Documento', 'Documento'],
+          rows: [['Cliente Uno', 'CC', '111']],
+        },
+        {
+          name: 'Productos',
+          headers: ['Nombre', 'Precio Venta', 'Stock'],
+          rows: [['Producto Uno', 5000, 10]],
+        },
+      ]);
+
+      const started = await service.startFullImport(
+        makeFile(buffer),
+        'user-1',
+        'org-1',
+      );
+
+      await flush();
+
+      expect(productsService.create).toHaveBeenCalledTimes(1);
+      expect(customersService.create).toHaveBeenCalledTimes(1);
+      const productCall =
+        productsService.create.mock.invocationCallOrder[0] ?? 0;
+      const customerCall =
+        customersService.create.mock.invocationCallOrder[0] ?? 0;
+      expect(productCall).toBeLessThan(customerCall);
+
+      const status = service.getImportStatus(started.jobId, 'user-1');
+      expect(status.status).toBe('COMPLETED');
+      expect(status.sheets.map((sheet) => sheet.sheetId)).toEqual([
+        'productos',
+        'clientes',
+      ]);
+      expect(status.importedCount).toBe(2);
+    });
+
+    it('skips unknown and missing sheets leniently while recognized sheets still import', async () => {
+      const buffer = await buildWorkbookBuffer([
+        {
+          name: 'Inventario',
+          headers: ['Nombre', 'Precio Venta', 'Stock'],
+          rows: [['Ignorado', 100, 1]],
+        },
+        {
+          name: 'Productos',
+          headers: ['Nombre', 'Precio Venta', 'Stock'],
+          rows: [['Real', 5000, 10]],
+        },
+      ]);
+
+      const started = await service.startFullImport(
+        makeFile(buffer),
+        'user-1',
+        'org-1',
+      );
+
+      await flush();
+
+      const status = service.getImportStatus(started.jobId, 'user-1');
+      expect(status.status).toBe('COMPLETED');
+      expect(status.sheets.map((sheet) => sheet.sheetId)).toEqual([
+        'productos',
+      ]);
+      expect(status.sheets[0].imported).toBe(1);
+      expect(productsService.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('per-sheet column detection', () => {
+    it('rejects a sheet missing a required column and keeps processing siblings', async () => {
+      const buffer = await buildWorkbookBuffer([
+        {
+          name: 'Clientes',
+          headers: ['Nombre', 'Documento'],
+          rows: [['Cliente Uno', '111']],
+        },
+        {
+          name: 'Productos',
+          headers: ['Nombre', 'Precio Venta', 'Stock'],
+          rows: [['Producto Uno', 5000, 10]],
+        },
+      ]);
+
+      const started = await service.startFullImport(
+        makeFile(buffer),
+        'user-1',
+        'org-1',
+      );
+
+      await flush();
+
+      const status = service.getImportStatus(started.jobId, 'user-1');
+      expect(status.status).toBe('COMPLETED');
+      const clientes = status.sheets.find((s) => s.sheetId === 'clientes');
+      expect(clientes?.status).toBe('REJECTED');
+      expect(clientes?.missingRequiredFields).toContain('documentType');
+      expect(customersService.create).not.toHaveBeenCalled();
+      expect(productsService.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('plan-limit enforcement', () => {
+    it('rejects an Usuarios sheet at the plan limit while other sheets still import', async () => {
+      planLimits.getLimitStatus.mockImplementation((type: string) =>
+        Promise.resolve(
+          type === 'users'
+            ? ({ current: 3, limit: 3, exceeded: true } as PlanLimitResult)
+            : ({ current: 0, limit: -1, exceeded: false } as PlanLimitResult),
+        ),
+      );
+
+      const buffer = await buildWorkbookBuffer([
+        {
+          name: 'Usuarios',
+          headers: ['Correo', 'Contraseña', 'Nombre'],
+          rows: [['new@example.com', 'correct-horse-battery-staple', 'Nuevo']],
+        },
+        {
+          name: 'Productos',
+          headers: ['Nombre', 'Precio Venta', 'Stock'],
+          rows: [['Producto Uno', 5000, 10]],
+        },
+      ]);
+
+      const started = await service.startFullImport(
+        makeFile(buffer),
+        'user-1',
+        'org-1',
+      );
+
+      await flush();
+
+      const status = service.getImportStatus(started.jobId, 'user-1');
+      const usuarios = status.sheets.find((s) => s.sheetId === 'usuarios');
+      expect(usuarios?.status).toBe('REJECTED');
+      expect(usuarios?.planLimitRejected).toBe(true);
+      expect(usersService.create).not.toHaveBeenCalled();
+      expect(productsService.create).toHaveBeenCalledTimes(1);
+      expect(planLimits.invalidateCache).not.toHaveBeenCalledWith(
+        'users',
+        'org-1',
+      );
+    });
+
+    it('invalidates the users plan cache after a processed usuarios sheet', async () => {
+      planLimits.getLimitStatus.mockResolvedValue({
+        current: 1,
+        limit: 3,
+        exceeded: false,
+      } as PlanLimitResult);
+
+      const buffer = await buildWorkbookBuffer([
+        {
+          name: 'Usuarios',
+          headers: ['Correo', 'Contraseña', 'Nombre'],
+          rows: [['new@example.com', 'correct-horse-battery-staple', 'Nuevo']],
+        },
+      ]);
+
+      const started = await service.startFullImport(
+        makeFile(buffer),
+        'user-1',
+        'org-1',
+      );
+
+      await flush();
+
+      const status = service.getImportStatus(started.jobId, 'user-1');
+      const usuarios = status.sheets.find((s) => s.sheetId === 'usuarios');
+      expect(usuarios?.status).toBe('COMPLETED');
+      expect(planLimits.invalidateCache).toHaveBeenCalledWith('users', 'org-1');
+      expect(usersService.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('partial success', () => {
+    it('reports a bad row without aborting the job and imports sibling rows', async () => {
+      const buffer = await buildWorkbookBuffer([
+        {
+          name: 'Productos',
+          headers: ['Nombre', 'Precio Venta', 'Stock'],
+          rows: [
+            ['Bien', 5000, 10],
+            ['Mal', 'precio-invalido', 10],
+          ],
+        },
+      ]);
+
+      const started = await service.startFullImport(
+        makeFile(buffer),
+        'user-1',
+        'org-1',
+      );
+
+      await flush();
+
+      const status = service.getImportStatus(started.jobId, 'user-1');
+      expect(status.status).toBe('COMPLETED');
+      expect(status.importedCount).toBe(1);
+      expect(status.errorCount).toBe(1);
+      const sheet = status.sheets.find((s) => s.sheetId === 'productos');
+      expect(sheet?.imported).toBe(1);
+      expect(sheet?.errors).toBe(1);
+      expect(sheet?.rowErrors).toHaveLength(1);
+      expect(sheet?.rowErrors[0].errorCode).toBe('INVALID_PRICE');
+    });
+  });
+
+  describe('empty file', () => {
+    it('throws 422 for a workbook with no data rows across sheets', async () => {
+      const buffer = await buildWorkbookBuffer([
+        {
+          name: 'Productos',
+          headers: ['Nombre', 'Precio Venta', 'Stock'],
+          rows: [],
+        },
+      ]);
+
+      await expect(
+        service.startFullImport(makeFile(buffer), 'user-1', 'org-1'),
+      ).rejects.toBeInstanceOf(UnprocessableEntityException);
+    });
+  });
+
+  describe('job status per-sheet breakdown', () => {
+    it('returns global counters plus a per-sheet breakdown with counters', async () => {
+      const buffer = await buildWorkbookBuffer([
+        {
+          name: 'Clientes',
+          headers: ['Nombre', 'Tipo de Documento', 'Documento'],
+          rows: [
+            ['Cliente Uno', 'CC', '111'],
+            ['Cliente Dos', 'CC', '222'],
+          ],
+        },
+      ]);
+
+      const started = await service.startFullImport(
+        makeFile(buffer),
+        'user-1',
+        'org-1',
+      );
+
+      await flush();
+
+      const status = service.getImportStatus(started.jobId, 'user-1');
+      expect(status.jobId).toBe(started.jobId);
+      expect(status.status).toBe('COMPLETED');
+      expect(status.totalRows).toBe(2);
+      expect(status.processedRows).toBe(2);
+      expect(status.importedCount).toBe(2);
+      expect(status.sheets).toHaveLength(1);
+      expect(status.sheets[0]).toMatchObject({
+        sheetId: 'clientes',
+        status: 'COMPLETED',
+        totalRows: 2,
+        processedRows: 2,
+        imported: 2,
+        skipped: 0,
+        errors: 0,
+        warnings: 0,
+      });
+    });
+  });
+
+  describe('sheet-aware retry', () => {
+    it('retries a failed clientes row against the customer handler and reconciles counters', async () => {
+      const buffer = await buildWorkbookBuffer([
+        {
+          name: 'Clientes',
+          headers: ['Nombre', 'Tipo de Documento', 'Documento'],
+          rows: [['', 'CC', '111']],
+        },
+      ]);
+
+      const started = await service.startFullImport(
+        makeFile(buffer),
+        'user-1',
+        'org-1',
+      );
+
+      await flush();
+
+      let status = service.getImportStatus(started.jobId, 'user-1');
+      expect(status.errorCount).toBe(1);
+      expect(status.importedCount).toBe(0);
+
+      await service.retryImportRow(started.jobId, 'user-1', {
+        rowIndex: 2,
+        sheetId: 'clientes',
+        correctedData: { name: 'Cliente Corregido' },
+      });
+
+      status = service.getImportStatus(started.jobId, 'user-1');
+      expect(status.errorCount).toBe(0);
+      expect(status.importedCount).toBe(1);
+      expect(customersService.create).toHaveBeenCalledTimes(1);
+      const clientes = status.sheets.find((s) => s.sheetId === 'clientes');
+      expect(clientes?.rowErrors[0].retriedSuccess).toBe(true);
+    });
+
+    it('delegates retry to the correct sheet handler by sheetId', async () => {
+      const buffer = await buildWorkbookBuffer([
+        {
+          name: 'Clientes',
+          headers: ['Nombre', 'Tipo de Documento', 'Documento'],
+          rows: [['', 'CC', '111']],
+        },
+        {
+          name: 'Proveedores',
+          headers: ['Nombre', 'Documento'],
+          rows: [['', '9001-1']],
+        },
+      ]);
+
+      const started = await service.startFullImport(
+        makeFile(buffer),
+        'user-1',
+        'org-1',
+      );
+
+      await flush();
+
+      expect(customersService.create).not.toHaveBeenCalled();
+      expect(suppliersService.create).not.toHaveBeenCalled();
+
+      await service.retryImportRow(started.jobId, 'user-1', {
+        rowIndex: 2,
+        sheetId: 'proveedores',
+        correctedData: { name: 'Proveedor Corregido' },
+      });
+
+      expect(suppliersService.create).toHaveBeenCalledTimes(1);
+      expect(customersService.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handler dispatch', () => {
+    it('routes each entity sheet to its matching create service', async () => {
+      const buffer = await buildWorkbookBuffer([
+        {
+          name: 'Productos',
+          headers: ['Nombre', 'Precio Venta', 'Stock'],
+          rows: [['Producto Uno', 5000, 10]],
+        },
+        {
+          name: 'Clientes',
+          headers: ['Nombre', 'Tipo de Documento', 'Documento'],
+          rows: [['Cliente Uno', 'CC', '111']],
+        },
+        {
+          name: 'Proveedores',
+          headers: ['Nombre', 'Documento'],
+          rows: [['Proveedor Uno', '9001-1']],
+        },
+        {
+          name: 'Usuarios',
+          headers: ['Correo', 'Contraseña', 'Nombre'],
+          rows: [
+            ['user@example.com', 'correct-horse-battery-staple', 'Usuario'],
+          ],
+        },
+      ]);
+
+      const started = await service.startFullImport(
+        makeFile(buffer),
+        'user-1',
+        'org-1',
+      );
+
+      await flush();
+
+      expect(productsService.create).toHaveBeenCalledTimes(1);
+      expect(customersService.create).toHaveBeenCalledTimes(1);
+      expect(suppliersService.create).toHaveBeenCalledTimes(1);
+      expect(usersService.create).toHaveBeenCalledTimes(1);
+      expect(planLimits.invalidateCache).toHaveBeenCalledWith(
+        'customers',
+        'org-1',
+      );
+      expect(planLimits.invalidateCache).toHaveBeenCalledWith('users', 'org-1');
+
+      const status = service.getImportStatus(started.jobId, 'user-1');
+      expect(status.sheets).toHaveLength(4);
+      expect(status.sheets.every((sheet) => sheet.imported === 1)).toBe(true);
+    });
+  });
+});

--- a/backend/src/imports/multi-sheet-import.service.ts
+++ b/backend/src/imports/multi-sheet-import.service.ts
@@ -1,0 +1,826 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  OnModuleDestroy,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import * as ExcelJS from 'exceljs';
+import { PrismaService } from '../prisma/prisma.service';
+import { PlanLimitService } from '../plan-limits/plan-limits.service';
+import { ProductsService } from '../products/products.service';
+import { CustomersService } from '../customers/customers.service';
+import { SuppliersService } from '../suppliers/suppliers.service';
+import { UsersService } from '../users/users.service';
+import { normalizeHeader } from './helpers/column-detector';
+import { normalizeLookupKey } from './helpers/row-validator';
+import { SheetRegistry } from './engine/sheet-registry';
+import { ProductHandler } from './engine/handlers/product.handler';
+import { CustomerHandler } from './engine/handlers/customer.handler';
+import { SupplierHandler } from './engine/handlers/supplier.handler';
+import { UserHandler } from './engine/handlers/user.handler';
+import type {
+  ImportRowError,
+  ImportSheetHandler,
+  ParsedFileRow,
+  RowError,
+  SheetId,
+  SheetRowContext,
+  SheetStatus,
+} from './engine/import-sheet-handler.interface';
+
+type MultiSheetJobStatus = 'PARSING' | 'PROCESSING' | 'COMPLETED' | 'FAILED';
+type ImportEventType = 'SUCCESS' | 'ERROR' | 'WARNING' | 'INFO';
+
+/** Retry input for the sheet-aware retry endpoint (PR4 wires the DTO). */
+export interface SheetAwareRetryDto {
+  rowIndex: number;
+  sheetId: SheetId;
+  correctedData: Record<string, unknown>;
+}
+
+interface ImportWarning {
+  rowIndex: number;
+  warningCode: string;
+  message: string;
+}
+
+interface ImportEvent {
+  type: ImportEventType;
+  message: string;
+  rowIndex: number;
+  timestamp: Date;
+}
+
+interface ParsedWorkbookSheet {
+  name: string;
+  sheetId?: SheetId;
+  headers: string[];
+  rows: ParsedFileRow[];
+}
+
+interface SheetJobState {
+  sheetId: SheetId;
+  status: SheetStatus;
+  totalRows: number;
+  processedRows: number;
+  imported: number;
+  skipped: number;
+  errors: number;
+  warnings: number;
+  missingRequiredFields?: string[];
+  planLimitRejected?: boolean;
+  planLimitMessage?: string;
+  mapping: Record<string, string>;
+  rowErrors: ImportRowError[];
+}
+
+interface MultiSheetJob {
+  id: string;
+  userId: string;
+  organizationId: string;
+  status: MultiSheetJobStatus;
+  fileName: string;
+  totalRows: number;
+  processedRows: number;
+  importedCount: number;
+  skippedCount: number;
+  errorCount: number;
+  warningCount: number;
+  sheets: SheetJobState[];
+  rowErrors: ImportRowError[];
+  warnings: ImportWarning[];
+  recentEvents: ImportEvent[];
+  startedAt: Date;
+  completedAt?: Date;
+  error?: string;
+  handlers: SheetRegistry;
+  parsedSheets: ParsedWorkbookSheet[];
+}
+
+const SHEET_ORDER: SheetId[] = [
+  'productos',
+  'clientes',
+  'proveedores',
+  'usuarios',
+];
+
+const MAX_FILE_ROWS = 5000;
+const JOB_TTL_MS = 30 * 60 * 1000;
+const MAX_RECENT_EVENTS = 10;
+
+@Injectable()
+export class MultiSheetImportService implements OnModuleDestroy {
+  private readonly jobs = new Map<string, MultiSheetJob>();
+  private readonly cleanupInterval: NodeJS.Timeout;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly planLimits: PlanLimitService,
+    private readonly productsService: ProductsService,
+    private readonly customersService: CustomersService,
+    private readonly suppliersService: SuppliersService,
+    private readonly usersService: UsersService,
+  ) {
+    this.cleanupInterval = setInterval(
+      () => this.cleanupExpiredJobs(),
+      5 * 60 * 1000,
+    );
+    this.cleanupInterval.unref?.();
+  }
+
+  onModuleDestroy() {
+    clearInterval(this.cleanupInterval);
+  }
+
+  /**
+   * Parses the uploaded workbook, resolves its sheets in the fixed order
+   * (Productos -> Clientes -> Proveedores -> Usuarios), rejects any file with
+   * no recognisable data and launches one in-memory job that processes each
+   * sheet per-sheet, with per-row fault isolation.
+   */
+  async startFullImport(
+    file: Express.Multer.File,
+    userId: string,
+    organizationId: string | undefined,
+  ) {
+    if (!organizationId) {
+      throw new BadRequestException(
+        'Organization ID is required for this operation',
+      );
+    }
+
+    this.validateIncomingFile(file);
+
+    const parsedSheets = await this.parseWorkbook(file.buffer);
+    const recognized = parsedSheets.filter(
+      (sheet): sheet is ParsedWorkbookSheet & { sheetId: SheetId } =>
+        !!sheet.sheetId,
+    );
+
+    if (recognized.length === 0) {
+      throw new UnprocessableEntityException(
+        'El archivo no contiene hojas reconocidas para importar',
+      );
+    }
+
+    const totalRows = recognized.reduce(
+      (sum, sheet) => sum + sheet.rows.length,
+      0,
+    );
+    if (totalRows === 0) {
+      throw new UnprocessableEntityException(
+        'El archivo no contiene filas para importar',
+      );
+    }
+
+    const overLimit = recognized.find(
+      (sheet) => sheet.rows.length > MAX_FILE_ROWS,
+    );
+    if (overLimit) {
+      throw new BadRequestException(
+        `La hoja ${overLimit.name} supera el maximo permitido de ${MAX_FILE_ROWS} filas`,
+      );
+    }
+
+    const job = this.createJob(file, userId, organizationId, parsedSheets);
+
+    void this.processJob(job.id);
+
+    return {
+      jobId: job.id,
+      totalRows: job.totalRows,
+      sheets: job.sheets.map((sheet) => ({
+        sheetId: sheet.sheetId,
+        status: sheet.status,
+        totalRows: sheet.totalRows,
+      })),
+    };
+  }
+
+  getImportStatus(jobId: string, userId: string) {
+    const job = this.getJobOrThrow(jobId, userId);
+    return this.buildStatusResponse(job);
+  }
+
+  /** Sheet-aware retry: validates and creates a corrected row with the handler for its sheet. */
+  async retryImportRow(jobId: string, userId: string, dto: SheetAwareRetryDto) {
+    const job = this.getJobOrThrow(jobId, userId);
+    const sheet = job.sheets.find((item) => item.sheetId === dto.sheetId);
+    if (!sheet) {
+      throw new NotFoundException('No se encontro la hoja indicada');
+    }
+
+    const unresolved = sheet.rowErrors.find(
+      (error) =>
+        error.rowIndex === dto.rowIndex &&
+        !(error.retried === true && error.retriedSuccess === true),
+    );
+    if (!unresolved) {
+      throw new NotFoundException(
+        'No se encontro un error pendiente para la fila indicada',
+      );
+    }
+
+    const handler = job.handlers.get(dto.sheetId);
+    if (!handler) {
+      throw new NotFoundException(
+        'No se encontro el manejador para la hoja indicada',
+      );
+    }
+
+    const merged = {
+      ...unresolved.mappedData,
+      ...this.sanitizeCorrectedData(dto.correctedData, handler.editableFields),
+    };
+    const rawData: Record<string, string> = {};
+    for (const [field, header] of Object.entries(sheet.mapping)) {
+      const value = merged[field];
+      if (value !== undefined && value !== null) {
+        rawData[header] = String(value);
+      }
+    }
+
+    const row: ParsedFileRow = { rowIndex: dto.rowIndex, rawData };
+    const existingKeys = await this.loadExistingKeys(
+      dto.sheetId,
+      job.organizationId,
+    );
+    const ctx: SheetRowContext = {
+      organizationId: job.organizationId,
+      userId: job.userId,
+      prisma: this.prisma,
+      planLimits: this.planLimits,
+      existingKeys,
+    };
+
+    const result = handler.validateRow(row, ctx);
+    if (!result.ok) {
+      this.applyRetryFailure(unresolved, result.error);
+      this.addEvent(job, 'ERROR', result.error.message, dto.rowIndex);
+      return this.buildStatusResponse(job);
+    }
+
+    try {
+      await handler.createRow(result.data, ctx);
+      job.importedCount += 1;
+      sheet.imported += 1;
+      job.errorCount = Math.max(0, job.errorCount - 1);
+      sheet.errors = Math.max(0, sheet.errors - 1);
+      unresolved.retried = true;
+      unresolved.retriedSuccess = true;
+      unresolved.message = 'Fila corregida e importada correctamente';
+      this.addEvent(
+        job,
+        'SUCCESS',
+        'Fila reintentada e importada',
+        dto.rowIndex,
+      );
+      return this.buildStatusResponse(job);
+    } catch (error) {
+      const mapped = this.mapCreationError(error, dto.rowIndex, result.data);
+      this.applyRetryFailure(unresolved, mapped);
+      this.addEvent(job, 'ERROR', mapped.message, dto.rowIndex);
+      return this.buildStatusResponse(job);
+    }
+  }
+
+  private createJob(
+    file: Express.Multer.File,
+    userId: string,
+    organizationId: string,
+    parsedSheets: ParsedWorkbookSheet[],
+  ): MultiSheetJob {
+    const sheets: SheetJobState[] = SHEET_ORDER.filter((sheetId) =>
+      parsedSheets.some((sheet) => sheet.sheetId === sheetId),
+    ).map((sheetId) => {
+      const parsed = parsedSheets.find((sheet) => sheet.sheetId === sheetId)!;
+      return {
+        sheetId,
+        status: 'PENDING',
+        totalRows: parsed.rows.length,
+        processedRows: 0,
+        imported: 0,
+        skipped: 0,
+        errors: 0,
+        warnings: 0,
+        mapping: {},
+        rowErrors: [],
+      };
+    });
+
+    const job: MultiSheetJob = {
+      id: randomUUID(),
+      userId,
+      organizationId,
+      status: 'PARSING',
+      fileName: file.originalname,
+      totalRows: sheets.reduce((sum, sheet) => sum + sheet.totalRows, 0),
+      processedRows: 0,
+      importedCount: 0,
+      skippedCount: 0,
+      errorCount: 0,
+      warningCount: 0,
+      sheets,
+      rowErrors: [],
+      warnings: [],
+      recentEvents: [],
+      startedAt: new Date(),
+      handlers: this.buildRegistry(),
+      parsedSheets,
+    };
+
+    this.jobs.set(job.id, job);
+    this.addEvent(job, 'INFO', 'Archivo recibido. Iniciando procesamiento', 1);
+    return job;
+  }
+
+  private async processJob(jobId: string) {
+    const job = this.jobs.get(jobId);
+    if (!job) {
+      return;
+    }
+
+    try {
+      job.status = 'PROCESSING';
+
+      for (const sheetId of SHEET_ORDER) {
+        const parsed = job.parsedSheets.find(
+          (item) => item.sheetId === sheetId,
+        );
+        if (!parsed) {
+          continue;
+        }
+        await this.processSheet(job, sheetId, parsed);
+      }
+
+      job.status = 'COMPLETED';
+      job.completedAt = new Date();
+      this.addEvent(job, 'INFO', 'Importacion finalizada', 1);
+    } catch (error) {
+      job.status = 'FAILED';
+      job.completedAt = new Date();
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Error inesperado durante la importacion';
+      job.error = message;
+      this.addEvent(job, 'ERROR', message, 1);
+    }
+  }
+
+  private async processSheet(
+    job: MultiSheetJob,
+    sheetId: SheetId,
+    parsed: ParsedWorkbookSheet,
+  ) {
+    const sheet = job.sheets.find((item) => item.sheetId === sheetId);
+    const handler = job.handlers.get(sheetId);
+    if (!sheet || !handler) {
+      return;
+    }
+
+    const detection = handler.detectColumns(parsed.headers);
+    if (detection.missingRequiredFields.length > 0) {
+      sheet.status = 'REJECTED';
+      sheet.missingRequiredFields = detection.missingRequiredFields;
+      this.addEvent(
+        job,
+        'WARNING',
+        `Hoja ${sheetId} rechazada por columnas faltantes`,
+        1,
+      );
+      return;
+    }
+    sheet.mapping = detection.mapping;
+
+    if (sheetId === 'usuarios' || sheetId === 'clientes') {
+      const limitType = sheetId === 'usuarios' ? 'users' : 'customers';
+      const limitStatus = await this.planLimits.getLimitStatus(
+        limitType,
+        job.organizationId,
+      );
+
+      if (
+        limitStatus.limit !== -1 &&
+        limitStatus.current + parsed.rows.length > limitStatus.limit
+      ) {
+        sheet.status = 'REJECTED';
+        sheet.planLimitRejected = true;
+        sheet.planLimitMessage = `Supera el limite del plan (${limitStatus.current}/${limitStatus.limit})`;
+        this.addEvent(
+          job,
+          'WARNING',
+          `Hoja ${sheetId} rechazada por limite de plan`,
+          1,
+        );
+        return;
+      }
+    }
+
+    sheet.status = 'PROCESSING';
+    const existingKeys = await this.loadExistingKeys(
+      sheetId,
+      job.organizationId,
+    );
+    const ctx: SheetRowContext = {
+      organizationId: job.organizationId,
+      userId: job.userId,
+      prisma: this.prisma,
+      planLimits: this.planLimits,
+      existingKeys,
+    };
+
+    for (const row of parsed.rows) {
+      sheet.processedRows += 1;
+      job.processedRows += 1;
+      await this.processRow(job, sheet, handler, row, ctx);
+    }
+
+    sheet.status = 'COMPLETED';
+    this.addEvent(job, 'INFO', `Hoja ${sheetId} procesada`, 1);
+
+    if (sheetId === 'usuarios' || sheetId === 'clientes') {
+      const limitType = sheetId === 'usuarios' ? 'users' : 'customers';
+      this.planLimits.invalidateCache(limitType, job.organizationId);
+    }
+  }
+
+  private async processRow(
+    job: MultiSheetJob,
+    sheet: SheetJobState,
+    handler: ImportSheetHandler,
+    row: ParsedFileRow,
+    ctx: SheetRowContext,
+  ) {
+    const result = handler.validateRow(row, ctx);
+    if (!result.ok) {
+      this.addRowError(job, sheet, handler, row, result.error);
+      return;
+    }
+
+    try {
+      await handler.createRow(result.data, ctx);
+      job.importedCount += 1;
+      sheet.imported += 1;
+      this.addEvent(
+        job,
+        'SUCCESS',
+        `Fila ${row.rowIndex} importada`,
+        row.rowIndex,
+      );
+    } catch (error) {
+      const mapped = this.mapCreationError(error, row.rowIndex, result.data);
+      this.addRowError(job, sheet, handler, row, mapped);
+    }
+  }
+
+  private addRowError(
+    job: MultiSheetJob,
+    sheet: SheetJobState,
+    handler: ImportSheetHandler,
+    row: ParsedFileRow,
+    error: RowError,
+  ) {
+    sheet.errors += 1;
+    job.errorCount += 1;
+    const importRowError: ImportRowError = {
+      rowIndex: row.rowIndex,
+      sheetId: sheet.sheetId,
+      errorCode: error.errorCode,
+      message: error.message,
+      field: error.field,
+      mappedData: error.mappedData,
+      editableFields: handler.editableFields,
+      retried: false,
+    };
+    sheet.rowErrors.push(importRowError);
+    job.rowErrors.push(importRowError);
+    this.addEvent(job, 'ERROR', error.message, row.rowIndex);
+  }
+
+  private applyRetryFailure(unresolved: ImportRowError, error: RowError) {
+    unresolved.retried = true;
+    unresolved.retriedSuccess = false;
+    unresolved.errorCode = error.errorCode;
+    unresolved.message = error.message;
+    unresolved.field = error.field;
+    unresolved.mappedData = error.mappedData;
+  }
+
+  private mapCreationError(
+    error: unknown,
+    rowIndex: number,
+    mappedData: Record<string, unknown>,
+  ): RowError {
+    if (error instanceof ConflictException) {
+      const message = String(error.message ?? '').toLowerCase();
+      if (message.includes('sku')) {
+        return {
+          errorCode: 'DUPLICATE_SKU',
+          message: 'SKU ya existe en la base de datos',
+          field: 'sku',
+          mappedData,
+        };
+      }
+      if (message.includes('barcode')) {
+        return {
+          errorCode: 'DUPLICATE_BARCODE',
+          message: 'Codigo de barras ya existe en la base de datos',
+          field: 'barcode',
+          mappedData,
+        };
+      }
+      if (message.includes('document')) {
+        return {
+          errorCode: 'DUPLICATE_DOCUMENT',
+          message: 'Ya existe un registro con ese numero de documento',
+          field: 'documentNumber',
+          mappedData,
+        };
+      }
+      if (message.includes('email')) {
+        return {
+          errorCode: 'DUPLICATE_EMAIL',
+          message: 'Ya existe un usuario con ese correo',
+          field: 'email',
+          mappedData,
+        };
+      }
+    }
+
+    return {
+      errorCode: 'IMPORT_FAILURE',
+      message:
+        error instanceof Error
+          ? error.message
+          : `Error inesperado al importar la fila ${rowIndex}`,
+      mappedData,
+    };
+  }
+
+  private sanitizeCorrectedData(
+    data: Record<string, unknown>,
+    editableFields: string[],
+  ): Record<string, unknown> {
+    const allowed = new Set(editableFields);
+    const output: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(data)) {
+      if (allowed.has(key)) {
+        output[key] = value;
+      }
+    }
+    return output;
+  }
+
+  private buildRegistry(): SheetRegistry {
+    return new SheetRegistry([
+      new ProductHandler(this.productsService),
+      new CustomerHandler(this.customersService),
+      new SupplierHandler(this.suppliersService),
+      new UserHandler(this.usersService),
+    ]);
+  }
+
+  private buildStatusResponse(job: MultiSheetJob) {
+    return {
+      jobId: job.id,
+      status: job.status,
+      fileName: job.fileName,
+      totalRows: job.totalRows,
+      processedRows: job.processedRows,
+      importedCount: job.importedCount,
+      skippedCount: job.skippedCount,
+      errorCount: job.errorCount,
+      warningCount: job.warningCount,
+      sheets: job.sheets.map((sheet) => ({
+        sheetId: sheet.sheetId,
+        status: sheet.status,
+        totalRows: sheet.totalRows,
+        processedRows: sheet.processedRows,
+        imported: sheet.imported,
+        skipped: sheet.skipped,
+        errors: sheet.errors,
+        warnings: sheet.warnings,
+        missingRequiredFields: sheet.missingRequiredFields,
+        planLimitRejected: sheet.planLimitRejected,
+        planLimitMessage: sheet.planLimitMessage,
+        rowErrors: sheet.rowErrors,
+      })),
+      errors: job.rowErrors,
+      warnings: job.warnings,
+      recentEvents: job.recentEvents,
+      startedAt: job.startedAt,
+      completedAt: job.completedAt,
+      error: job.error,
+      progress:
+        job.totalRows > 0
+          ? Math.min(100, Math.round((job.processedRows / job.totalRows) * 100))
+          : 0,
+    };
+  }
+
+  private getJobOrThrow(jobId: string, userId: string) {
+    const job = this.jobs.get(jobId);
+    if (!job) {
+      throw new NotFoundException('No se encontro la importacion solicitada');
+    }
+    if (job.userId !== userId) {
+      throw new ForbiddenException('No tienes acceso a esta importacion');
+    }
+    return job;
+  }
+
+  private cleanupExpiredJobs() {
+    const now = Date.now();
+    for (const [jobId, job] of this.jobs.entries()) {
+      const referenceTime =
+        job.completedAt?.getTime() ?? job.startedAt.getTime();
+      if (now - referenceTime > JOB_TTL_MS) {
+        this.jobs.delete(jobId);
+      }
+    }
+  }
+
+  private async loadExistingKeys(
+    sheetId: SheetId,
+    organizationId: string,
+  ): Promise<Set<string>> {
+    let keys: string[] = [];
+
+    switch (sheetId) {
+      case 'productos': {
+        const products = await this.prisma.product.findMany({
+          where: { organizationId },
+          select: { sku: true },
+        });
+        keys = products
+          .map((product) => normalizeLookupKey(product.sku))
+          .filter(Boolean);
+        break;
+      }
+      case 'clientes': {
+        const customers = await this.prisma.customer.findMany({
+          where: { organizationId },
+          select: { documentNumber: true },
+        });
+        keys = customers
+          .map((customer) => normalizeLookupKey(customer.documentNumber))
+          .filter(Boolean);
+        break;
+      }
+      case 'proveedores': {
+        const suppliers = await this.prisma.supplier.findMany({
+          where: { organizationId },
+          select: { documentNumber: true },
+        });
+        keys = suppliers
+          .map((supplier) => normalizeLookupKey(supplier.documentNumber))
+          .filter(Boolean);
+        break;
+      }
+      case 'usuarios': {
+        const memberships = await this.prisma.organizationUser.findMany({
+          where: { organizationId },
+          select: { user: { select: { email: true } } },
+        });
+        keys = memberships
+          .map((membership) => normalizeLookupKey(membership.user.email))
+          .filter(Boolean);
+        break;
+      }
+    }
+
+    return new Set(keys);
+  }
+
+  private validateIncomingFile(file: Express.Multer.File) {
+    if (!file || !file.buffer) {
+      throw new BadRequestException('Archivo no recibido o invalido');
+    }
+
+    const lowerName = file.originalname.toLowerCase();
+    if (!lowerName.endsWith('.xlsx')) {
+      throw new BadRequestException(
+        'Formato no soportado. Usa un archivo .xlsx',
+      );
+    }
+  }
+
+  private async parseWorkbook(buffer: Buffer): Promise<ParsedWorkbookSheet[]> {
+    const workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.load(buffer as any);
+
+    if (workbook.worksheets.length === 0) {
+      throw new UnprocessableEntityException(
+        'El archivo Excel no contiene hojas',
+      );
+    }
+
+    const sheets: ParsedWorkbookSheet[] = [];
+
+    for (const worksheet of workbook.worksheets) {
+      const headerRow = worksheet.getRow(1);
+      const maxColumns = Math.max(headerRow.cellCount, worksheet.columnCount);
+
+      if (maxColumns === 0) {
+        throw new UnprocessableEntityException(
+          'No se detectaron columnas en el archivo',
+        );
+      }
+
+      const headers: string[] = [];
+      for (let i = 1; i <= maxColumns; i += 1) {
+        headers.push(this.cellValueToString(headerRow.getCell(i).value));
+      }
+
+      const rows: ParsedFileRow[] = [];
+      for (let rowIndex = 2; rowIndex <= worksheet.rowCount; rowIndex += 1) {
+        const row = worksheet.getRow(rowIndex);
+        const rawData: Record<string, string> = {};
+        let hasValues = false;
+
+        headers.forEach((header, headerIndex) => {
+          if (!header) {
+            return;
+          }
+          const value = this.cellValueToString(
+            row.getCell(headerIndex + 1).value,
+          );
+          rawData[header] = value;
+          if (value.length > 0) {
+            hasValues = true;
+          }
+        });
+
+        if (hasValues) {
+          rows.push({ rowIndex, rawData });
+        }
+      }
+
+      sheets.push({
+        name: worksheet.name,
+        sheetId: this.resolveSheetId(worksheet.name),
+        headers,
+        rows,
+      });
+    }
+
+    return sheets;
+  }
+
+  private resolveSheetId(name: string): SheetId | undefined {
+    const normalized = normalizeHeader(name);
+    return SHEET_ORDER.find((sheetId) => sheetId === normalized);
+  }
+
+  private addEvent(
+    job: MultiSheetJob,
+    type: ImportEventType,
+    message: string,
+    rowIndex: number,
+  ) {
+    job.recentEvents.push({
+      type,
+      message,
+      rowIndex,
+      timestamp: new Date(),
+    });
+    if (job.recentEvents.length > MAX_RECENT_EVENTS) {
+      job.recentEvents.shift();
+    }
+  }
+
+  private cellValueToString(value: ExcelJS.CellValue): string {
+    if (value === null || value === undefined) {
+      return '';
+    }
+    if (value instanceof Date) {
+      return value.toISOString();
+    }
+    if (typeof value === 'string') {
+      return value.trim();
+    }
+    if (typeof value === 'number' || typeof value === 'boolean') {
+      return String(value);
+    }
+    if (typeof value === 'object') {
+      if ('text' in value && typeof value.text === 'string') {
+        return value.text.trim();
+      }
+      if ('richText' in value && Array.isArray(value.richText)) {
+        return value.richText
+          .map((entry) => entry?.text ?? '')
+          .join('')
+          .trim();
+      }
+      if ('result' in value) {
+        return this.cellValueToString(value.result as ExcelJS.CellValue);
+      }
+    }
+    return String(value).trim();
+  }
+}

--- a/backend/src/imports/template.service.spec.ts
+++ b/backend/src/imports/template.service.spec.ts
@@ -1,0 +1,144 @@
+import * as ExcelJS from 'exceljs';
+import {
+  TemplateService,
+  buildTemplateDefinitions,
+  SHEET_DISPLAY_NAMES,
+} from './template.service';
+
+function readRow(cells: { value: ExcelJS.CellValue }[]): string[] {
+  return cells.map((cell) => String(cell.value ?? ''));
+}
+
+function readAllRowsText(worksheet: ExcelJS.Worksheet): string {
+  const parts: string[] = [];
+  for (let rowNumber = 1; rowNumber <= worksheet.rowCount; rowNumber += 1) {
+    const row = worksheet.getRow(rowNumber);
+    for (let col = 1; col <= row.cellCount; col += 1) {
+      parts.push(String(row.getCell(col).value ?? ''));
+    }
+  }
+  return parts.join(' ');
+}
+
+function readHeaderRow(worksheet: ExcelJS.Worksheet, count: number): string[] {
+  const row = worksheet.getRow(1);
+  const cells = [];
+  for (let i = 1; i <= count; i += 1) {
+    cells.push({ value: row.getCell(i).value });
+  }
+  return readRow(cells);
+}
+
+describe('TemplateService', () => {
+  let service: TemplateService;
+
+  beforeEach(() => {
+    service = new TemplateService();
+  });
+
+  describe('buildTemplateDefinitions', () => {
+    it('defines the four entity sheets in the required order', () => {
+      const defs = buildTemplateDefinitions();
+      expect(defs.map((def) => def.sheetName)).toEqual([
+        'Productos',
+        'Clientes',
+        'Proveedores',
+        'Usuarios',
+      ]);
+      expect(defs.map((def) => def.sheetId)).toEqual([
+        'productos',
+        'clientes',
+        'proveedores',
+        'usuarios',
+      ]);
+    });
+
+    it('marks the required columns per entity', () => {
+      const defs = buildTemplateDefinitions();
+      const productos = defs.find((def) => def.sheetId === 'productos')!;
+      expect(productos.requiredKeys).toEqual(['name', 'salePrice', 'stock']);
+
+      const clientes = defs.find((def) => def.sheetId === 'clientes')!;
+      expect(clientes.requiredKeys).toEqual([
+        'name',
+        'documentType',
+        'documentNumber',
+      ]);
+
+      const proveedores = defs.find((def) => def.sheetId === 'proveedores')!;
+      expect(proveedores.requiredKeys).toEqual(['name', 'documentNumber']);
+
+      const usuarios = defs.find((def) => def.sheetId === 'usuarios')!;
+      expect(usuarios.requiredKeys).toEqual(['email', 'password']);
+    });
+
+    it('exposes a display header for every column', () => {
+      const defs = buildTemplateDefinitions();
+      for (const def of defs) {
+        const columns = def.columns;
+        expect(columns.length).toBeGreaterThan(0);
+        for (const column of columns) {
+          expect(column.header.length).toBeGreaterThan(0);
+          expect(column.key.length).toBeGreaterThan(0);
+        }
+      }
+      expect(SHEET_DISPLAY_NAMES.productos).toBe('Productos');
+    });
+  });
+
+  describe('buildWorkbook', () => {
+    it('builds a workbook with the four entity sheets plus Instrucciones', () => {
+      const workbook = service.buildWorkbook();
+      expect(workbook.worksheets.map((ws) => ws.name)).toEqual([
+        'Productos',
+        'Clientes',
+        'Proveedores',
+        'Usuarios',
+        'Instrucciones',
+      ]);
+    });
+
+    it('marks required columns with an asterisk in the Productos header row', () => {
+      const workbook = service.buildWorkbook();
+      const productos = workbook.getWorksheet('Productos')!;
+      const def = buildTemplateDefinitions().find(
+        (item) => item.sheetId === 'productos',
+      )!;
+      const headers = readHeaderRow(productos, def.columns.length);
+
+      expect(headers[0]).toBe('Nombre *');
+      const salePriceIndex = def.columns.findIndex(
+        (col) => col.key === 'salePrice',
+      );
+      expect(headers[salePriceIndex]).toBe('Precio Venta *');
+      const stockIndex = def.columns.findIndex((col) => col.key === 'stock');
+      expect(headers[stockIndex]).toBe('Stock *');
+      const skuIndex = def.columns.findIndex((col) => col.key === 'sku');
+      expect(headers[skuIndex]).toBe('SKU');
+    });
+
+    it('adds example rows beneath the header row for each entity sheet', () => {
+      const workbook = service.buildWorkbook();
+      const clientes = workbook.getWorksheet('Clientes')!;
+      const def = buildTemplateDefinitions().find(
+        (item) => item.sheetId === 'clientes',
+      )!;
+      const exampleRow = clientes.getRow(2).values;
+      const exampleCells = [];
+      for (let i = 1; i <= def.columns.length; i += 1) {
+        exampleCells.push({ value: exampleRow?.[i] });
+      }
+      const example = readRow(exampleCells);
+      expect(example[0].length).toBeGreaterThan(0);
+    });
+
+    it('lists required columns, example rows and retry guidance in Instrucciones', () => {
+      const workbook = service.buildWorkbook();
+      const instrucciones = workbook.getWorksheet('Instrucciones')!;
+      const text = readAllRowsText(instrucciones);
+      expect(text.toLowerCase()).toContain('columna requerida');
+      expect(text.toLowerCase()).toContain('reintentar');
+      expect(text.toLowerCase()).toContain('productos - columnas requeridas');
+    });
+  });
+});

--- a/backend/src/imports/template.service.ts
+++ b/backend/src/imports/template.service.ts
@@ -1,0 +1,193 @@
+import { Injectable } from '@nestjs/common';
+import * as ExcelJS from 'exceljs';
+import type { Response } from 'express';
+import type { SheetId } from './engine/import-sheet-handler.interface';
+import {
+  SHEET_COLUMN_ALIASES,
+  SHEET_REQUIRED_FIELDS,
+} from './helpers/column-detector';
+
+/** Human readable name of each importable sheet used on the template. */
+export const SHEET_DISPLAY_NAMES: Record<SheetId, string> = {
+  productos: 'Productos',
+  clientes: 'Clientes',
+  proveedores: 'Proveedores',
+  usuarios: 'Usuarios',
+};
+
+export const TEMPLATE_SHEET_ORDER: SheetId[] = [
+  'productos',
+  'clientes',
+  'proveedores',
+  'usuarios',
+];
+
+/** Spanish display header for each importable field key. */
+const DISPLAY_HEADERS: Record<string, string> = {
+  name: 'Nombre',
+  sku: 'SKU',
+  barcode: 'Codigo de Barras',
+  category: 'Categoria',
+  salePrice: 'Precio Venta',
+  costPrice: 'Precio Costo',
+  stock: 'Stock',
+  minStock: 'Stock Minimo',
+  taxRate: 'Impuesto',
+  description: 'Descripcion',
+  documentType: 'Tipo de Documento',
+  documentNumber: 'Documento',
+  email: 'Email',
+  phone: 'Telefono',
+  segment: 'Segmento',
+  password: 'Contraseña',
+  role: 'Rol',
+  address: 'Direccion',
+  contactName: 'Nombre de Contacto',
+  bank: 'Banco',
+  accountNumber: 'Numero de Cuenta',
+  accountType: 'Tipo de Cuenta',
+};
+
+/** Example value shown in the template's sample row. */
+const EXAMPLE_VALUES: Record<string, string | number> = {
+  name: 'Ejemplo',
+  sku: 'IMP-001',
+  barcode: '7700000000001',
+  category: 'General',
+  salePrice: 5000,
+  costPrice: 3500,
+  stock: 10,
+  minStock: 2,
+  taxRate: 19,
+  description: 'Descripcion opcional',
+  documentType: 'CC',
+  documentNumber: '1234567890',
+  email: 'ejemplo@correo.com',
+  phone: '3001234567',
+  segment: 'OCCASIONAL',
+  password: 'ContrasenaSegura123',
+  role: 'CASHIER',
+  address: 'Calle 123 #45-67',
+  contactName: 'Juan Perez',
+  bank: 'Bancolombia',
+  accountNumber: '1234567890',
+  accountType: 'SAVINGS',
+};
+
+export interface TemplateColumn {
+  key: string;
+  header: string;
+  required: boolean;
+  example: string | number;
+}
+
+export interface SheetTemplateDefinition {
+  sheetId: SheetId;
+  sheetName: string;
+  columns: TemplateColumn[];
+  requiredKeys: string[];
+}
+
+/**
+ * Builds the canonical column definitions for the four importable sheets,
+ * deriving each column list from the per-entity alias tables (which reflect
+ * the fields the create-service DTOs accept) and the required-column set.
+ */
+export function buildTemplateDefinitions(): SheetTemplateDefinition[] {
+  return TEMPLATE_SHEET_ORDER.map((sheetId) => {
+    const aliases = SHEET_COLUMN_ALIASES[sheetId] ?? {};
+    const required = SHEET_REQUIRED_FIELDS[sheetId] ?? [];
+    const columns: TemplateColumn[] = Object.keys(aliases).map((key) => ({
+      key,
+      header: DISPLAY_HEADERS[key] ?? key,
+      required: required.includes(key),
+      example: EXAMPLE_VALUES[key] ?? '',
+    }));
+    return {
+      sheetId,
+      sheetName: SHEET_DISPLAY_NAMES[sheetId],
+      columns,
+      requiredKeys: [...required],
+    };
+  });
+}
+
+/**
+ * Generates the multi-sheet import template workbook on the fly. It contains
+ * the four entity sheets (Productos, Clientes, Proveedores, Usuarios) with a
+ * marked header row and a sample row, plus an Instrucciones sheet describing
+ * required columns, markers and retry guidance.
+ */
+@Injectable()
+export class TemplateService {
+  /** Builds the full template workbook in memory. */
+  buildWorkbook(): ExcelJS.Workbook {
+    const workbook = new ExcelJS.Workbook();
+    const definitions = buildTemplateDefinitions();
+
+    for (const definition of definitions) {
+      const worksheet = workbook.addWorksheet(definition.sheetName);
+      const headerRow = definition.columns.map((column) =>
+        column.required ? `${column.header} *` : column.header,
+      );
+      worksheet.addRow(headerRow);
+      worksheet.addRow(definition.columns.map((column) => column.example));
+      worksheet.columns.forEach((column) => {
+        column.width = 18;
+      });
+    }
+
+    this.buildInstructionsSheet(workbook, definitions);
+    return workbook;
+  }
+
+  /** Streams the generated template to the response with an xlsx content type. */
+  async downloadTemplate(response: Response): Promise<void> {
+    const workbook = this.buildWorkbook();
+
+    response.setHeader(
+      'Content-Type',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    );
+    response.setHeader(
+      'Content-Disposition',
+      `attachment; filename=plantilla_importacion_multi_${Date.now()}.xlsx`,
+    );
+
+    const buffer = await workbook.xlsx.writeBuffer();
+    response.send(Buffer.from(buffer));
+  }
+
+  private buildInstructionsSheet(
+    workbook: ExcelJS.Workbook,
+    definitions: SheetTemplateDefinition[],
+  ): void {
+    const instructions = workbook.addWorksheet('Instrucciones');
+    const lines: string[] = [];
+
+    lines.push(
+      '(*) indica columna requerida para importar esa hoja.',
+      'Descarga la plantilla, completa cada hoja y subela en /imports.',
+      '',
+    );
+
+    for (const definition of definitions) {
+      const required = definition.columns
+        .filter((column) => column.required)
+        .map((column) => column.header)
+        .join(', ');
+      lines.push(`${definition.sheetName} - Columnas requeridas: ${required}.`);
+    }
+
+    lines.push(
+      '',
+      'Cada fila se crea mediante el servicio de creacion de la entidad.',
+      'Puedes corregir errores y reintentar fila por fila desde la interfaz.',
+    );
+
+    lines.forEach((text) => {
+      instructions.addRow([text]);
+    });
+    instructions.getColumn(1).width = 120;
+  }
+}


### PR DESCRIPTION
Closes #2

## Summary
This is **slice 3 / PR3 of 5** in the stacked-to-main chain that turns the product-only importer into a 4-sheet importer (Productos → Clientes → Proveedores → Usuarios). PR1 (#90, engine contract + column detection + validators) and PR2 (#91, per-entity handlers + duplicate tracker + sheet registry) are both merged. This slice lands the **orchestrator + on-the-fly ExcelJS template** on top of that tested engine, without touching the controller/dto/module wiring (that is PR4).

- `MultiSheetImportService`: parses the workbook, resolves sheets in the fixed order (Productos → Clientes → Proveedores → Usuarios), dispatches rows to the matching `ImportSheetHandler` through a per-job `SheetRegistry`, enforces plan limits per sheet (usuarios/clientes) with post-sheet cache invalidation, tracks global + per-sheet counters with a PARSING → PROCESSING → COMPLETED|FAILED lifecycle and partial-success isolation, rejects empty files with 422, and exposes sheet-aware retry.
- `TemplateService`: builds the 4 entity sheets + Instrucciones workbook on the fly from the create-service DTO column sets, with required-column markers (`*`).

`imports.service.ts`, `imports.controller.ts`, `imports.module.ts`, and `dto/import.dto.ts` are intentionally untouched. The product-only `/imports/products` path stays green.

## Dependency diagram
```
master (head)
  └─ PR1 (#90, merged) — engine contract + column detection + validators
      └─ PR2 (#91, merged) — per-entity handlers + duplicate-tracker + sheet-registry
          └─ PR3 (📍 this PR) — orchestrator + ExcelJS template
              └─ PR4 — controller routes + module DI + dto
                  └─ PR5 — frontend /imports page
```

## Changes
| File | Change |
|------|--------|
| `backend/src/imports/multi-sheet-import.service.ts` | New multi-sheet orchestrator: sheet-order resolution, per-sheet column detection + plan-limit pre-check, per-row fault isolation, job lifecycle + per-sheet counters, sheet-aware retry |
| `backend/src/imports/template.service.ts` | New on-the-fly ExcelJS template (4 entity sheets + Instrucciones) derived from create-service DTO columns with required markers |
| `backend/src/imports/multi-sheet-import.service.spec.ts` | Red-first tests (11) for the orchestrator |
| `backend/src/imports/template.service.spec.ts` | Red-first tests (7) for the template service |

## Out of scope (later slices)
Controller routes + module DI + dto (`imports.controller.ts`, `imports.module.ts`, `dto/import.dto.ts`, and the `imports.service.ts` product-pipeline rewire) → PR4; frontend `/imports` page + `useImport`/types/Sidebar → PR5.

## Verification
- `cd backend && npm run test -- imports` → **12 suites, 117/117 passing** (was 10 suites / 99; +18 new tests here). Product/import path stays green.
- `npm run build` (nest build) → clean.
- `eslint` on changed files → 0 errors (remaining warnings mirror the existing `imports.service.ts` codebase patterns).

## Reviewer note
Strict TDD was used: each spec was authored and failed (RED) before the implementation (GREEN). This slice carries **1651 changed lines (4 files, 1651 additions)** — above the 400-line single-PR guideline, but it is the pre-planned slice boundary for PR3 in the `stacked-to-main` chain (change split by the orchestrator: engine → handlers → orchestrator+template → controller → frontend). The orchestrator is a single focused file because it genuinely aggregates the engine; the template service is its small companion.

## Checklist
- [x] Linked issue #2
- [x] Conventional commit format (2 work-unit commits, tests with code, no AI attribution)
- [x] Backend import suite green (117/117)
- [x] Build clean (tsc/nest build)
