### PR TITLE
feat(imports): multi-sheet importer controller, DI and product rewire (slice 4/5)

### DIFF
--- a/backend/src/imports/dto/import.dto.spec.ts
+++ b/backend/src/imports/dto/import.dto.spec.ts
@@ -1,0 +1,63 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import {
+  RetryImportRowDto,
+  ImportSheetStatusDto,
+  ImportJobStatusResponseDto,
+} from './import.dto';
+
+describe('ImportDtos', () => {
+  describe('RetryImportRowDto', () => {
+    it('accepts a valid sheetId', async () => {
+      const dto = plainToInstance(RetryImportRowDto, {
+        rowIndex: 5,
+        sheetId: 'clientes',
+        correctedData: { name: 'Cliente Uno' },
+      });
+      const errors = await validate(dto);
+      expect(errors).toEqual([]);
+    });
+
+    it('rejects an unknown sheetId', async () => {
+      const dto = plainToInstance(RetryImportRowDto, {
+        rowIndex: 5,
+        sheetId: 'nope',
+        correctedData: {},
+      });
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('allows omitting sheetId for product-only retries', async () => {
+      const dto = plainToInstance(RetryImportRowDto, {
+        rowIndex: 5,
+        correctedData: { name: 'Producto Uno' },
+      });
+      const errors = await validate(dto);
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe('sheet-aware job status breakdown', () => {
+    it('validates a per-sheet status with counters and rowErrors', async () => {
+      const sheet = plainToInstance(ImportSheetStatusDto, {
+        sheetId: 'productos',
+        status: 'COMPLETED',
+        totalRows: 1,
+        processedRows: 1,
+        imported: 1,
+        skipped: 0,
+        errors: 0,
+        warnings: 0,
+        rowErrors: [],
+      });
+      const errors = await validate(sheet);
+      expect(errors).toEqual([]);
+    });
+
+    it('exposes the sheets[] array on the job status response type', async () => {
+      const instance = plainToInstance(ImportJobStatusResponseDto, {});
+      expect('sheets' in instance).toBe(true);
+    });
+  });
+});

--- a/backend/src/imports/dto/import.dto.ts
+++ b/backend/src/imports/dto/import.dto.ts
@@ -1,11 +1,63 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsInt, IsObject, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsIn,
+  IsInt,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+/** The four importable entity sheets processed by the multi-sheet importer. */
+export const IMPORT_SHEET_IDS = [
+  'productos',
+  'clientes',
+  'proveedores',
+  'usuarios',
+] as const;
+
+export type ImportSheetId = (typeof IMPORT_SHEET_IDS)[number];
+
+/** Per-sheet lifecycle sub-status used inside a job's per-sheet breakdown. */
+export const IMPORT_SHEET_STATUSES = [
+  'PENDING',
+  'PROCESSING',
+  'COMPLETED',
+  'REJECTED',
+  'FAILED',
+] as const;
+
+export type ImportSheetStatus = (typeof IMPORT_SHEET_STATUSES)[number];
+
+/** Overall import job lifecycle status. */
+export const IMPORT_JOB_STATUSES = [
+  'PARSING',
+  'PROCESSING',
+  'COMPLETED',
+  'FAILED',
+] as const;
+
+export type ImportJobStatus = (typeof IMPORT_JOB_STATUSES)[number];
 
 export class RetryImportRowDto {
   @ApiProperty({ example: 5 })
   @IsInt()
   @Min(2)
   rowIndex: number;
+
+  @ApiPropertyOptional({
+    enum: IMPORT_SHEET_IDS,
+    description:
+      'Sheet the failed row belongs to. Product-only retries default to "productos".',
+  })
+  @IsOptional()
+  @IsIn(IMPORT_SHEET_IDS)
+  sheetId?: ImportSheetId;
 
   @ApiPropertyOptional({
     type: 'object',
@@ -20,4 +72,153 @@ export class RetryImportRowDto {
   })
   @IsObject()
   correctedData: Record<string, unknown>;
+}
+
+/** A reported row error carrying its originating sheet and retry state. */
+export class ImportRowErrorDto {
+  @ApiProperty({ example: 5 })
+  @IsInt()
+  rowIndex: number;
+
+  @ApiProperty({ enum: IMPORT_SHEET_IDS })
+  @IsIn(IMPORT_SHEET_IDS)
+  sheetId: ImportSheetId;
+
+  @ApiProperty({ example: 'INVALID_PRICE' })
+  @IsString()
+  errorCode: string;
+
+  @ApiProperty({ example: 'Precio de venta invalido' })
+  @IsString()
+  message: string;
+
+  @ApiPropertyOptional({ example: 'salePrice' })
+  @IsOptional()
+  @IsString()
+  field?: string;
+
+  @ApiPropertyOptional({ type: 'object', additionalProperties: true })
+  @IsOptional()
+  @IsObject()
+  mappedData?: Record<string, unknown>;
+
+  @ApiProperty({ type: [String] })
+  @IsArray()
+  @IsString({ each: true })
+  editableFields: string[];
+
+  @ApiProperty({ example: false })
+  @IsOptional()
+  @IsBoolean()
+  retried: boolean;
+
+  @ApiPropertyOptional({ example: false })
+  @IsOptional()
+  @IsBoolean()
+  retriedSuccess?: boolean;
+}
+
+/** Per-sheet counters and sub-status returned in a job's per-sheet breakdown. */
+export class ImportSheetStatusDto {
+  @ApiProperty({ enum: IMPORT_SHEET_IDS })
+  @IsIn(IMPORT_SHEET_IDS)
+  sheetId: ImportSheetId;
+
+  @ApiProperty({ enum: IMPORT_SHEET_STATUSES })
+  @IsIn(IMPORT_SHEET_STATUSES)
+  status: ImportSheetStatus;
+
+  @ApiProperty({ example: 10 })
+  @IsInt()
+  totalRows: number;
+
+  @ApiProperty({ example: 10 })
+  @IsInt()
+  processedRows: number;
+
+  @ApiProperty({ example: 10 })
+  @IsInt()
+  imported: number;
+
+  @ApiProperty({ example: 0 })
+  @IsInt()
+  skipped: number;
+
+  @ApiProperty({ example: 0 })
+  @IsInt()
+  errors: number;
+
+  @ApiProperty({ example: 0 })
+  @IsInt()
+  warnings: number;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  missingRequiredFields?: string[];
+
+  @ApiPropertyOptional({ example: false })
+  @IsOptional()
+  @IsBoolean()
+  planLimitRejected?: boolean;
+
+  @ApiPropertyOptional({ example: 'Supera el limite del plan' })
+  @IsOptional()
+  @IsString()
+  planLimitMessage?: string;
+
+  @ApiProperty({ type: [ImportRowErrorDto] })
+  @ValidateNested({ each: true })
+  @Type(() => ImportRowErrorDto)
+  rowErrors: ImportRowErrorDto[];
+}
+
+/** Shape of the multi-entity import job status / per-sheet breakdown. */
+export class ImportJobStatusResponseDto {
+  @ApiProperty({ example: 'a1b2c3d4' })
+  @IsString()
+  jobId: string;
+
+  @ApiProperty({ enum: IMPORT_JOB_STATUSES })
+  @IsIn(IMPORT_JOB_STATUSES)
+  status: ImportJobStatus;
+
+  @ApiProperty({ example: 'import.xlsx' })
+  @IsString()
+  fileName: string;
+
+  @ApiProperty({ example: 10 })
+  @IsNumber()
+  totalRows: number;
+
+  @ApiProperty({ example: 10 })
+  @IsNumber()
+  processedRows: number;
+
+  @ApiProperty({ example: 10 })
+  @IsNumber()
+  importedCount: number;
+
+  @ApiProperty({ example: 0 })
+  @IsNumber()
+  skippedCount: number;
+
+  @ApiProperty({ example: 0 })
+  @IsNumber()
+  errorCount: number;
+
+  @ApiProperty({ example: 0 })
+  @IsNumber()
+  warningCount: number;
+
+  @ApiProperty({ type: [ImportSheetStatusDto] })
+  @ValidateNested({ each: true })
+  @Type(() => ImportSheetStatusDto)
+  sheets: ImportSheetStatusDto[] = [];
+
+  @ApiProperty({ type: [ImportRowErrorDto] })
+  @ValidateNested({ each: true })
+  @Type(() => ImportRowErrorDto)
+  errors: ImportRowErrorDto[] = [];
 }

--- a/backend/src/imports/imports.controller.spec.ts
+++ b/backend/src/imports/imports.controller.spec.ts
@@ -1,0 +1,156 @@
+import { NotFoundException } from '@nestjs/common';
+import { OrgRole } from '@prisma/client';
+import { ROLES_KEY } from '../common/decorators/roles.decorator';
+import { ImportsController } from './imports.controller';
+import type { RequestUser } from '../common/interfaces/request-user.interface';
+
+describe('ImportsController', () => {
+  const importsServiceMock = {
+    getImportStatus: jest.fn(),
+    retryImportRow: jest.fn(),
+  };
+  const multiSheetImportServiceMock = {
+    startFullImport: jest.fn(),
+    getImportStatus: jest.fn(),
+    retryImportRow: jest.fn(),
+  };
+  const templateServiceMock = {
+    downloadTemplate: jest.fn(),
+  };
+
+  const cashierUser: RequestUser = {
+    userId: 'cashier-1',
+    email: 'cashier@example.com',
+    organizationId: 'org-1',
+    role: OrgRole.CASHIER,
+    tokenVersion: 1,
+    isSuperAdmin: false,
+  };
+
+  let controller: ImportsController;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    controller = new ImportsController(
+      importsServiceMock as never,
+      multiSheetImportServiceMock as never,
+      templateServiceMock as never,
+    );
+  });
+
+  describe('full template endpoint', () => {
+    it('streams the multi-sheet template via TemplateService', async () => {
+      const res = { setHeader: jest.fn(), send: jest.fn() };
+      await controller.downloadFullTemplate(res as never);
+      expect(templateServiceMock.downloadTemplate).toHaveBeenCalledWith(res);
+    });
+
+    it('is restricted to ADMIN and CASHIER', () => {
+      const requiredRoles = Reflect.getMetadata(
+        ROLES_KEY,
+        ImportsController.prototype.downloadFullTemplate,
+      );
+      expect(requiredRoles).toContain(OrgRole.ADMIN);
+      expect(requiredRoles).toContain(OrgRole.CASHIER);
+    });
+  });
+
+  describe('full import endpoint', () => {
+    it('delegates to the multi-sheet orchestrator with the JWT org', async () => {
+      const file = { originalname: 'a.xlsx' } as Express.Multer.File;
+      await controller.startFullImport(file, cashierUser);
+      expect(multiSheetImportServiceMock.startFullImport).toHaveBeenCalledWith(
+        file,
+        'cashier-1',
+        'org-1',
+      );
+    });
+
+    it('is restricted to ADMIN and CASHIER', () => {
+      const requiredRoles = Reflect.getMetadata(
+        ROLES_KEY,
+        ImportsController.prototype.startFullImport,
+      );
+      expect(requiredRoles).toContain(OrgRole.ADMIN);
+      expect(requiredRoles).toContain(OrgRole.CASHIER);
+    });
+  });
+
+  describe('sheet-aware status dispatch', () => {
+    it('falls back to the multi-sheet service when the product service does not own the job', () => {
+      importsServiceMock.getImportStatus.mockImplementation(() => {
+        throw new NotFoundException('No se encontró la importacion solicitada');
+      });
+      multiSheetImportServiceMock.getImportStatus.mockReturnValue({
+        jobId: 'full-job',
+        sheets: [],
+      });
+
+      const result = controller.getImportStatus('full-job', {
+        user: { userId: 'cashier-1' },
+      });
+
+      expect(importsServiceMock.getImportStatus).toHaveBeenCalledWith(
+        'full-job',
+        'cashier-1',
+      );
+      expect(multiSheetImportServiceMock.getImportStatus).toHaveBeenCalledWith(
+        'full-job',
+        'cashier-1',
+      );
+      expect(result).toEqual({ jobId: 'full-job', sheets: [] });
+    });
+
+    it('returns the product job status when the product service owns it', () => {
+      importsServiceMock.getImportStatus.mockReturnValue({
+        jobId: 'product-job',
+        sheets: [{ sheetId: 'productos' }],
+      });
+
+      const result = controller.getImportStatus('product-job', {
+        user: { userId: 'cashier-1' },
+      });
+
+      expect(
+        multiSheetImportServiceMock.getImportStatus,
+      ).not.toHaveBeenCalled();
+      expect(result.jobId).toBe('product-job');
+    });
+  });
+
+  describe('sheet-aware retry dispatch', () => {
+    it('routes a non-productos sheetId to the multi-sheet service', async () => {
+      await controller.retryImportRow(
+        'full-job',
+        { rowIndex: 5, sheetId: 'clientes', correctedData: { name: 'X' } },
+        { user: { userId: 'cashier-1' } },
+      );
+
+      expect(multiSheetImportServiceMock.retryImportRow).toHaveBeenCalledWith(
+        'full-job',
+        'cashier-1',
+        { rowIndex: 5, sheetId: 'clientes', correctedData: { name: 'X' } },
+      );
+      expect(importsServiceMock.retryImportRow).not.toHaveBeenCalled();
+    });
+
+    it('routes an omitted sheetId (product-only) to the product service', async () => {
+      importsServiceMock.retryImportRow.mockResolvedValue({
+        jobId: 'product-job',
+      });
+
+      await controller.retryImportRow(
+        'product-job',
+        { rowIndex: 5, correctedData: { name: 'X' } },
+        { user: { userId: 'cashier-1' } },
+      );
+
+      expect(importsServiceMock.retryImportRow).toHaveBeenCalledWith(
+        'product-job',
+        'cashier-1',
+        { rowIndex: 5, correctedData: { name: 'X' } },
+      );
+      expect(multiSheetImportServiceMock.retryImportRow).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/imports/imports.controller.ts
+++ b/backend/src/imports/imports.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   HttpStatus,
+  NotFoundException,
   Param,
   ParseFilePipeBuilder,
   Post,
@@ -16,6 +17,7 @@ import {
   ApiBearerAuth,
   ApiBody,
   ApiConsumes,
+  ApiOkResponse,
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
@@ -29,7 +31,12 @@ import { Roles } from '../common/decorators/roles.decorator';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 import type { RequestUser } from '../common/interfaces/request-user.interface';
 import { ImportsService } from './imports.service';
-import { RetryImportRowDto } from './dto/import.dto';
+import { MultiSheetImportService } from './multi-sheet-import.service';
+import { TemplateService } from './template.service';
+import {
+  RetryImportRowDto,
+  ImportJobStatusResponseDto,
+} from './dto/import.dto';
 
 @ApiTags('Imports')
 @Controller('imports')
@@ -37,7 +44,11 @@ import { RetryImportRowDto } from './dto/import.dto';
 @UseInterceptors(AdminOrganizationInterceptor)
 @ApiBearerAuth()
 export class ImportsController {
-  constructor(private readonly importsService: ImportsService) {}
+  constructor(
+    private readonly importsService: ImportsService,
+    private readonly multiSheetImportService: MultiSheetImportService,
+    private readonly templateService: TemplateService,
+  ) {}
 
   @Get('products/template')
   @Roles(OrgRole.ADMIN, OrgRole.CASHIER)
@@ -82,24 +93,98 @@ export class ImportsController {
     );
   }
 
+  @Get('full-template')
+  @Roles(OrgRole.ADMIN, OrgRole.CASHIER)
+  @ApiOperation({ summary: 'Download multi-sheet import template' })
+  async downloadFullTemplate(@Res() res: any): Promise<void> {
+    return this.templateService.downloadTemplate(res);
+  }
+
+  @Post('full')
+  @Roles(OrgRole.ADMIN, OrgRole.CASHIER)
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['file'],
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+        },
+      },
+    },
+  })
+  @ApiOperation({ summary: 'Upload multi-sheet Excel file (.xlsx)' })
+  async startFullImport(
+    @UploadedFile(
+      new ParseFilePipeBuilder()
+        .addMaxSizeValidator({ maxSize: 5 * 1024 * 1024 })
+        .build({
+          fileIsRequired: true,
+          errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+        }),
+    )
+    file: Express.Multer.File,
+    @CurrentUser() user: RequestUser,
+  ): Promise<any> {
+    return this.multiSheetImportService.startFullImport(
+      file,
+      user.userId,
+      user.organizationId,
+    );
+  }
+
   @Get(':jobId/status')
   @Roles(OrgRole.ADMIN, OrgRole.CASHIER)
+  @ApiOkResponse({ type: ImportJobStatusResponseDto })
   @ApiOperation({ summary: 'Get import job status for polling' })
   getImportStatus(
     @Param('jobId') jobId: string,
     @Request() req: { user: { userId: string } },
   ): any {
-    return this.importsService.getImportStatus(jobId, req.user.userId);
+    const userId = req.user.userId;
+    try {
+      return this.importsService.getImportStatus(jobId, userId);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        return this.multiSheetImportService.getImportStatus(jobId, userId);
+      }
+      throw error;
+    }
   }
 
   @Post(':jobId/retry-row')
   @Roles(OrgRole.ADMIN, OrgRole.CASHIER)
+  @ApiOkResponse({ type: ImportJobStatusResponseDto })
   @ApiOperation({ summary: 'Retry a failed row with corrected data' })
-  retryImportRow(
+  async retryImportRow(
     @Param('jobId') jobId: string,
     @Body() dto: RetryImportRowDto,
     @Request() req: { user: { userId: string } },
   ): Promise<any> {
-    return this.importsService.retryImportRow(jobId, req.user.userId, dto);
+    const userId = req.user.userId;
+
+    if (dto.sheetId && dto.sheetId !== 'productos') {
+      return this.multiSheetImportService.retryImportRow(jobId, userId, {
+        rowIndex: dto.rowIndex,
+        sheetId: dto.sheetId,
+        correctedData: dto.correctedData,
+      });
+    }
+
+    try {
+      return this.importsService.retryImportRow(jobId, userId, dto);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        return this.multiSheetImportService.retryImportRow(jobId, userId, {
+          rowIndex: dto.rowIndex,
+          sheetId: dto.sheetId ?? 'productos',
+          correctedData: dto.correctedData,
+        });
+      }
+      throw error;
+    }
   }
 }

--- a/backend/src/imports/imports.module.ts
+++ b/backend/src/imports/imports.module.ts
@@ -1,13 +1,31 @@
 import { Module } from '@nestjs/common';
 import { ImportsController } from './imports.controller';
 import { ImportsService } from './imports.service';
+import { MultiSheetImportService } from './multi-sheet-import.service';
+import { TemplateService } from './template.service';
 import { ProductsModule } from '../products/products.module';
+import { CustomersModule } from '../customers/customers.module';
+import { SuppliersModule } from '../suppliers/suppliers.module';
+import { UsersModule } from '../users/users.module';
+import { PlanLimitsModule } from '../plan-limits/plan-limits.module';
 import { OrganizationRequiredGuard } from '../common/guards/organization-required.guard';
 import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
 
 @Module({
-  imports: [ProductsModule],
+  imports: [
+    ProductsModule,
+    CustomersModule,
+    SuppliersModule,
+    UsersModule,
+    PlanLimitsModule,
+  ],
   controllers: [ImportsController],
-  providers: [ImportsService, OrganizationRequiredGuard, AdminOrganizationInterceptor],
+  providers: [
+    ImportsService,
+    MultiSheetImportService,
+    TemplateService,
+    OrganizationRequiredGuard,
+    AdminOrganizationInterceptor,
+  ],
 })
 export class ImportsModule {}

--- a/backend/src/imports/imports.service.spec.ts
+++ b/backend/src/imports/imports.service.spec.ts
@@ -1,0 +1,151 @@
+import { ImportsService } from './imports.service';
+import * as ExcelJS from 'exceljs';
+
+async function buildXlsxBuffer(
+  rows: Array<Array<string | number>>,
+): Promise<Buffer> {
+  const workbook = new ExcelJS.Workbook();
+  const worksheet = workbook.addWorksheet('Productos');
+  const headers = [
+    'Nombre',
+    'SKU',
+    'Precio Venta',
+    'Precio Costo',
+    'Stock',
+    'Stock Minimo',
+    'Impuesto (%)',
+    'Codigo de Barras',
+    'Categoria',
+  ];
+  worksheet.addRow(headers);
+  for (const row of rows) {
+    worksheet.addRow(row);
+  }
+  return Buffer.from(await workbook.xlsx.writeBuffer());
+}
+
+function makeFile(
+  buffer: Buffer,
+  name = 'inventario.xlsx',
+): Express.Multer.File {
+  return {
+    buffer,
+    originalname: name,
+    mimetype:
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  } as Express.Multer.File;
+}
+
+describe('ImportsService', () => {
+  let service: ImportsService;
+  let prisma: any;
+  let productsService: { create: jest.Mock };
+
+  beforeEach(() => {
+    prisma = {
+      product: {
+        findMany: jest.fn().mockResolvedValue([]),
+        findUnique: jest.fn().mockResolvedValue(null),
+      },
+      category: {
+        findMany: jest.fn().mockResolvedValue([]),
+        findFirst: jest
+          .fn()
+          .mockResolvedValue({ id: 'cat-1', name: 'General', active: true }),
+        update: jest.fn(),
+        create: jest
+          .fn()
+          .mockResolvedValue({ id: 'cat-9', name: 'Nueva', active: true }),
+      },
+    };
+    productsService = { create: jest.fn().mockResolvedValue(undefined) };
+    service = new ImportsService(prisma, productsService as never);
+  });
+
+  async function flush() {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  it('imports a product and returns a sheet-aware job status', async () => {
+    const buffer = await buildXlsxBuffer([
+      ['Pan', '', 5000, '', 10, '', 19, ''],
+    ]);
+    const started = await service.startProductsImport(
+      makeFile(buffer),
+      'user-1',
+      'org-1',
+    );
+    await flush();
+
+    expect(productsService.create).toHaveBeenCalledTimes(1);
+
+    const status = service.getImportStatus(started.jobId, 'user-1');
+    expect(status.status).toBe('COMPLETED');
+    expect(status.importedCount).toBe(1);
+    expect(status.sheets).toHaveLength(1);
+    expect(status.sheets[0].sheetId).toBe('productos');
+    expect(status.sheets[0].imported).toBe(1);
+    expect(status.detectedColumns).toEqual(
+      expect.arrayContaining(['Nombre', 'Precio Venta', 'Stock']),
+    );
+  });
+
+  it('skips rows without a product name instead of failing them', async () => {
+    const buffer = await buildXlsxBuffer([['', '', 5000, '', 10, '', 19, '']]);
+    const started = await service.startProductsImport(
+      makeFile(buffer),
+      'user-1',
+      'org-1',
+    );
+    await flush();
+
+    expect(productsService.create).not.toHaveBeenCalled();
+
+    const status = service.getImportStatus(started.jobId, 'user-1');
+    expect(status.skippedCount).toBe(1);
+    expect(status.errorCount).toBe(0);
+  });
+
+  it('reports an in-file duplicate SKU with the productos sheet and sheetId on the error', async () => {
+    const buffer = await buildXlsxBuffer([
+      ['Pan', 'PAN-1', 5000, '', 10, '', 0, ''],
+      ['Otro', 'PAN-1', 6000, '', 5, '', 0, ''],
+    ]);
+    const started = await service.startProductsImport(
+      makeFile(buffer),
+      'user-1',
+      'org-1',
+    );
+    await flush();
+
+    const status = service.getImportStatus(started.jobId, 'user-1');
+    expect(status.errorCount).toBe(1);
+    expect(status.errors[0].errorCode).toBe('DUPLICATE_SKU_FILE');
+    expect(status.errors[0].sheetId).toBe('productos');
+    expect(status.sheets[0].sheetId).toBe('productos');
+  });
+
+  it('defaults a retry to the productos sheet and reconciles counters', async () => {
+    const buffer = await buildXlsxBuffer([['Pan', '', '', '', 10, '', 0, '']]);
+    const started = await service.startProductsImport(
+      makeFile(buffer),
+      'user-1',
+      'org-1',
+    );
+    await flush();
+
+    let status = service.getImportStatus(started.jobId, 'user-1');
+    expect(status.errors[0].errorCode).toBe('INVALID_PRICE');
+
+    status = await service.retryImportRow(started.jobId, 'user-1', {
+      rowIndex: status.errors[0].rowIndex,
+      correctedData: { salePrice: 5000 },
+    });
+
+    expect(productsService.create).toHaveBeenCalledTimes(1);
+    expect(status.importedCount).toBe(1);
+    expect(status.errorCount).toBe(0);
+    expect(status.errors[0].retriedSuccess).toBe(true);
+    expect(status.errors[0].sheetId).toBe('productos');
+  });
+});

--- a/backend/src/imports/imports.service.ts
+++ b/backend/src/imports/imports.service.ts
@@ -12,6 +12,11 @@ import * as ExcelJS from 'exceljs';
 import { PrismaService } from '../prisma/prisma.service';
 import { ProductsService } from '../products/products.service';
 import type { RetryImportRowDto } from './dto/import.dto';
+import type {
+  SheetId,
+  ImportSheetStatus,
+} from './engine/import-sheet-handler.interface';
+import { parseProductRow } from './engine/handlers/product.handler';
 import {
   detectColumnMapping,
   type ColumnMapping,
@@ -21,8 +26,6 @@ import {
   normalizeCategoryName,
   normalizeLookupKey,
   normalizeText,
-  parseDecimal,
-  parseInteger,
   toTitleCase,
   type ParsedImportRowData,
 } from './helpers/row-validator';
@@ -45,6 +48,7 @@ interface ImportEvent {
 
 interface ImportRowError {
   rowIndex: number;
+  sheetId: SheetId;
   rawData: Record<string, string>;
   mappedData: Record<string, unknown>;
   errorCode: string;
@@ -137,7 +141,9 @@ export class ImportsService implements OnModuleDestroy {
     organizationId: string | undefined,
   ) {
     if (!organizationId) {
-      throw new BadRequestException('Organization ID is required for this operation');
+      throw new BadRequestException(
+        'Organization ID is required for this operation',
+      );
     }
     this.validateIncomingFile(file);
 
@@ -571,159 +577,33 @@ export class ImportsService implements OnModuleDestroy {
         kind: 'ok';
         data: ParsedImportRowData;
       } {
-    const getValue = (field: keyof ColumnMapping) => {
-      const header = job.columnMapping[field];
-      if (!header) {
-        return '';
+    const mapped: Record<string, unknown> = {};
+    for (const [field, header] of Object.entries(job.columnMapping)) {
+      if (header) {
+        mapped[field] = row.rawData[header];
       }
-      return normalizeText(row.rawData[header]);
-    };
+    }
 
-    const mappedData: Record<string, unknown> = {
-      name: getValue('name'),
-      sku: getValue('sku'),
-      barcode: getValue('barcode'),
-      category: getValue('category') || 'General',
-      salePrice: getValue('salePrice'),
-      costPrice: getValue('costPrice'),
-      stock: getValue('stock'),
-      minStock: getValue('minStock'),
-      taxRate: getValue('taxRate'),
-      description: getValue('description'),
-    };
-
-    const name = normalizeText(mappedData.name);
-    if (!name) {
+    // Preserve the product-only skip-on-empty-name behavior: rows without a
+    // product name are skipped, not reported as errors. Everything else is
+    // delegated to the extracted product handler parser so both code paths
+    // share one source of product import semantics.
+    if (!normalizeText(mapped.name)) {
       return { kind: 'skip' };
     }
 
-    let sku = normalizeText(mappedData.sku);
-    if (!sku) {
-      sku = buildGeneratedSku(row.rowIndex - 1);
-    }
-
-    const salePrice = parseDecimal(mappedData.salePrice);
-    if (salePrice === null || salePrice <= 0) {
+    const parsed = parseProductRow(mapped, row.rowIndex);
+    if (parsed.kind === 'error') {
       return {
         kind: 'error',
-        errorCode: 'INVALID_PRICE',
-        message: 'Precio de venta invalido',
-        field: 'salePrice',
-        mappedData: {
-          ...mappedData,
-          sku,
-          name,
-        },
+        errorCode: parsed.errorCode,
+        message: parsed.message,
+        field: parsed.field,
+        mappedData: parsed.mappedData,
       };
     }
 
-    const stock = parseInteger(mappedData.stock);
-    if (stock === null || stock < 0) {
-      return {
-        kind: 'error',
-        errorCode: 'INVALID_STOCK',
-        message: 'Stock invalido. Debe ser un numero entero mayor o igual a 0',
-        field: 'stock',
-        mappedData: {
-          ...mappedData,
-          sku,
-          name,
-          salePrice,
-        },
-      };
-    }
-
-    const rawCostPrice = normalizeText(mappedData.costPrice);
-    let costInferred = false;
-    let costPrice = parseDecimal(rawCostPrice);
-
-    if (!rawCostPrice) {
-      costInferred = true;
-      costPrice = salePrice;
-    }
-
-    if (costPrice === null || costPrice < 0) {
-      return {
-        kind: 'error',
-        errorCode: 'INVALID_COST_PRICE',
-        message: 'Precio de costo invalido',
-        field: 'costPrice',
-        mappedData: {
-          ...mappedData,
-          sku,
-          name,
-          salePrice,
-          stock,
-        },
-      };
-    }
-
-    const minStockRaw = normalizeText(mappedData.minStock);
-    let minStock = parseInteger(minStockRaw);
-    if (!minStockRaw) {
-      minStock = 0;
-    }
-
-    if (minStock === null || minStock < 0) {
-      return {
-        kind: 'error',
-        errorCode: 'INVALID_MIN_STOCK',
-        message:
-          'Stock minimo invalido. Debe ser un numero entero mayor o igual a 0',
-        field: 'minStock',
-        mappedData: {
-          ...mappedData,
-          sku,
-          name,
-          salePrice,
-          stock,
-          costPrice,
-        },
-      };
-    }
-
-    const taxRateRaw = normalizeText(mappedData.taxRate);
-    const taxRateProvided = taxRateRaw.length > 0;
-    let taxRate = parseDecimal(taxRateRaw);
-    if (!taxRateProvided) {
-      taxRate = 0;
-    }
-
-    if (taxRate === null || taxRate < 0) {
-      return {
-        kind: 'error',
-        errorCode: 'INVALID_TAX_RATE',
-        message: 'Impuesto invalido',
-        field: 'taxRate',
-        mappedData: {
-          ...mappedData,
-          sku,
-          name,
-          salePrice,
-          stock,
-          costPrice,
-          minStock,
-        },
-      };
-    }
-
-    return {
-      kind: 'ok',
-      data: {
-        name,
-        sku,
-        barcode: normalizeText(mappedData.barcode) || undefined,
-        category: normalizeText(mappedData.category) || 'General',
-        salePrice,
-        costPrice,
-        stock,
-        minStock,
-        taxRate,
-        taxRateProvided,
-        description: normalizeText(mappedData.description) || undefined,
-        costInferred,
-      },
-    };
+    return { kind: 'ok', data: parsed.data };
   }
 
   private parseMappedDataForRetry(
@@ -767,101 +647,20 @@ export class ImportsService implements OnModuleDestroy {
       };
     }
 
-    const salePrice = parseDecimal(mappedData.salePrice);
-    if (salePrice === null || salePrice <= 0) {
+    // Delegate the rest of the row validation to the extracted product handler
+    // parser so the retry path reuses the exact same product semantics.
+    const parsed = parseProductRow(mappedData, rowIndex);
+    if (parsed.kind === 'error') {
       return {
         kind: 'error',
-        errorCode: 'INVALID_PRICE',
-        message: 'Precio de venta invalido',
-        field: 'salePrice',
-        mappedData,
+        errorCode: parsed.errorCode,
+        message: parsed.message,
+        field: parsed.field,
+        mappedData: parsed.mappedData,
       };
     }
 
-    const stock = parseInteger(mappedData.stock);
-    if (stock === null || stock < 0) {
-      return {
-        kind: 'error',
-        errorCode: 'INVALID_STOCK',
-        message: 'Stock invalido. Debe ser un numero entero mayor o igual a 0',
-        field: 'stock',
-        mappedData,
-      };
-    }
-
-    const rawCostPrice = normalizeText(mappedData.costPrice);
-    let costInferred = false;
-    let costPrice = parseDecimal(rawCostPrice);
-
-    if (!rawCostPrice) {
-      costInferred = true;
-      costPrice = salePrice;
-    }
-
-    if (costPrice === null || costPrice < 0) {
-      return {
-        kind: 'error',
-        errorCode: 'INVALID_COST_PRICE',
-        message: 'Precio de costo invalido',
-        field: 'costPrice',
-        mappedData,
-      };
-    }
-
-    const minStockRaw = normalizeText(mappedData.minStock);
-    let minStock = parseInteger(minStockRaw);
-    if (!minStockRaw) {
-      minStock = 0;
-    }
-
-    if (minStock === null || minStock < 0) {
-      return {
-        kind: 'error',
-        errorCode: 'INVALID_MIN_STOCK',
-        message:
-          'Stock minimo invalido. Debe ser un numero entero mayor o igual a 0',
-        field: 'minStock',
-        mappedData,
-      };
-    }
-
-    const taxRateRaw = normalizeText(mappedData.taxRate);
-    const taxRateProvided =
-      source.taxRate !== undefined &&
-      source.taxRate !== null &&
-      taxRateRaw.length > 0;
-    let taxRate = parseDecimal(taxRateRaw);
-    if (!taxRateProvided) {
-      taxRate = 0;
-    }
-
-    if (taxRate === null || taxRate < 0) {
-      return {
-        kind: 'error',
-        errorCode: 'INVALID_TAX_RATE',
-        message: 'Impuesto invalido',
-        field: 'taxRate',
-        mappedData,
-      };
-    }
-
-    return {
-      kind: 'ok',
-      data: {
-        name,
-        sku: normalizeText(mappedData.sku),
-        barcode: normalizeText(mappedData.barcode) || undefined,
-        category: normalizeText(mappedData.category) || 'General',
-        salePrice,
-        costPrice,
-        stock,
-        minStock,
-        taxRate,
-        taxRateProvided,
-        description: normalizeText(mappedData.description) || undefined,
-        costInferred,
-      },
-    };
+    return { kind: 'ok', data: parsed.data };
   }
 
   private async validateDuplicateInDatabase(
@@ -1087,6 +886,7 @@ export class ImportsService implements OnModuleDestroy {
 
     job.errors.push({
       rowIndex,
+      sheetId: 'productos',
       rawData,
       mappedData: data.mappedData ?? {},
       errorCode,
@@ -1140,6 +940,22 @@ export class ImportsService implements OnModuleDestroy {
   }
 
   private buildStatusResponse(job: ImportJobInternal) {
+    const productSheet: ImportSheetStatus = {
+      sheetId: 'productos',
+      status:
+        job.status === 'PARSING'
+          ? 'PENDING'
+          : job.status === 'PROCESSING'
+            ? 'PROCESSING'
+            : job.status,
+      totalRows: job.totalRows,
+      processedRows: job.processedRows,
+      imported: job.importedCount,
+      skipped: job.skippedCount,
+      errors: job.errorCount,
+      warnings: job.warningCount,
+    };
+
     return {
       jobId: job.id,
       status: job.status,
@@ -1152,6 +968,7 @@ export class ImportsService implements OnModuleDestroy {
       warningCount: job.warningCount,
       columnMapping: job.columnMapping,
       detectedColumns: job.detectedColumns,
+      sheets: [productSheet],
       errors: job.errors,
       warnings: job.warnings,
       recentEvents: job.recentEvents,


### PR DESCRIPTION
Closes #2

## Summary
This is **slice 4 / PR4 of 5** in the stacked-to-main chain that turns the product-only importer into a 4-sheet importer (Productos → Clientes → Proveedores → Usuarios). PR1 (#90), PR2 (#91) and PR3 (#92) are all merged. This slice lands the **controller routes, module DI wiring, sheet-aware DTO shapes and the product-pipeline rewire** on top of the tested orchestrator + template.

- **DTO**: `RetryImportRowDto` is now sheet-aware (optional `sheetId`), and the import shapes expose a per-sheet job breakdown (`sheets[]` with per-sheet counters, errors and substatuses).
- **Controller**: adds `GET /imports/full-template` and `POST /imports/full`, and makes `GET /imports/:jobId/status` + `POST /imports/:jobId/retry-row` sheet-aware. All routes sit behind the same guards as the existing import routes (`JwtAuthGuard`, `RolesGuard` ADMIN/CASHIER, `OrganizationRequiredGuard`, `AdminOrganizationInterceptor`, `@ApiBearerAuth`).
- **Module**: wires `CustomersModule`, `SuppliersModule`, `UsersModule`, `PlanLimitsModule` (plus the already-referenced `ProductsModule`) and registers `MultiSheetImportService` + `TemplateService`, so the orchestrator can build fresh per-job handlers.
- **Service rewire**: the product-only pipeline now delegates row parsing/validation to the extracted product handler (`parseProductRow`), preserving the skip-on-empty-name, in-file/DB duplicate codes, category auto-create and `COST_INFERRED`/`CATEGORY_CREATED` warnings. `imports.service.ts` also exposes a sheet-aware job status (single `productos` sheet breakdown + `sheetId` on every error). The `/imports/products` path stays behaviorally green.

## Dependency diagram
```
master (head)
  └─ PR1 (#90, merged) — engine contract + column detection + validators
      └─ PR2 (#91, merged) — per-entity handlers + duplicate-tracker + sheet-registry
          └─ PR3 (#92, merged) — orchestrator + ExcelJS template
              └─ PR4 (📍 this PR) — controller routes + module DI + dto + product rewire
                  └─ PR5 — frontend /imports page
```

## Changes
| File | Change |
|------|--------|
| `backend/src/imports/dto/import.dto.ts` | Sheet-aware `RetryImportRowDto` (`sheetId`) + `sheets[]` job/error breakdown DTOs |
| `backend/src/imports/dto/import.dto.spec.ts` | Red-first tests (5) for the DTO shapes |
| `backend/src/imports/imports.controller.ts` | `GET /imports/full-template`, `POST /imports/full`, sheet-aware status/retry dispatch behind the existing guards |
| `backend/src/imports/imports.controller.spec.ts` | Red-first tests (8) for routes + sheet-aware dispatch |
| `backend/src/imports/imports.module.ts` | Wire customers/suppliers/users/plan-limits modules + orchestrator/template providers |
| `backend/src/imports/imports.service.ts` | Delegate product row parsing to the product handler; sheet-aware job status (`sheets[]`, `sheetId` on errors) |
| `backend/src/imports/imports.service.spec.ts` | Red-first tests (4) for the reword product path + sheet-aware status |

## Out of scope (later slices)
Frontend `/imports` page + `useImport`/types/Sidebar → PR5.

## Verification
- `cd backend && npm run test -- imports` → **15 suites, 134/134 passing** (was 12 suites / 117; +17 new tests here). The `/imports/products` product path stays green.
- `npm run build` (nest build) → clean (EXIT=0).
- `eslint` on changed files → 0 errors (warnings mirror the existing `imports.service.ts` codebase patterns).

## Reviewer note
Strict TDD was used: each spec was authored and failed (RED) before the implementation (GREEN). This slice carries **979 changed lines (7 files, 735 insertions + 244 deletions)** — above the 400-line single-PR guideline and slightly above the 600-line per-slice forecast, but within the owner-approved **2000-line per-slice budget** and it is the pre-planned slice boundary in the `stacked-to-main` chain (engine → handlers → orchestrator+template → controller → frontend).

Deferred follow-up (flagged in PR3, still open): the supplier alias table in `column-detector.ts` does not yet alias address/contactName/bank/accountNumber, so those `CreateSupplierDto` fields are not detectable by `detectColumns`/`mapRawRow` and are silently dropped. Fixing that alias table is outside this slice.

## Checklist
- [x] Linked issue #2
- [x] Conventional commit format (3 work-unit commits, tests with code, no AI attribution)
- [x] Backend import suite green (134/134)
- [x] Build clean (tsc/nest build)
