### PR TITLE
feat(imports): frontend /imports multi-sheet page (slice 5/5)

### DIFF
--- a/frontend/src/app/imports/page.test.tsx
+++ b/frontend/src/app/imports/page.test.tsx
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type {
+  ImportFullJobStatus,
+  ImportSheetStatus,
+  ImportSheetRowError,
+} from "@/types";
+
+const useImportMock = vi.fn();
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("@/components/layout/DashboardLayout", () => ({
+  DashboardLayout: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/contexts/ToastContext", () => ({
+  useToast: () => ({ success: toastSuccess, error: toastError }),
+}));
+
+vi.mock("@/hooks/useImport", () => ({
+  useImport: () => useImportMock(),
+}));
+
+import ImportsPage from "./page";
+
+function makeRow(overrides: Partial<ImportSheetRowError> = {}): ImportSheetRowError {
+  return {
+    rowIndex: 5,
+    sheetId: "clientes",
+    errorCode: "INVALID_DOCUMENT",
+    message: "Documento invalido",
+    mappedData: { name: "Ana Perez", documentNumber: "1010101" },
+    editableFields: ["name", "documentNumber"],
+    retried: false,
+    retriedSuccess: false,
+    ...overrides,
+  };
+}
+
+function makeSheet(overrides: Partial<ImportSheetStatus> = {}): ImportSheetStatus {
+  return {
+    sheetId: "productos",
+    status: "COMPLETED",
+    totalRows: 10,
+    processedRows: 10,
+    imported: 10,
+    skipped: 0,
+    errors: 0,
+    warnings: 0,
+    rowErrors: [],
+    ...overrides,
+  };
+}
+
+function makeFullStatus(
+  overrides: Partial<ImportFullJobStatus> = {},
+): ImportFullJobStatus {
+  return {
+    jobId: "job-1",
+    status: "COMPLETED",
+    fileName: "import.xlsx",
+    totalRows: 20,
+    processedRows: 19,
+    importedCount: 18,
+    skippedCount: 0,
+    errorCount: 1,
+    warningCount: 0,
+    sheets: [makeSheet(), makeSheet({ sheetId: "clientes", errors: 1, rowErrors: [makeRow()] })],
+    errors: [makeRow()],
+    ...overrides,
+  };
+}
+
+function makeImportResult(status: ImportFullJobStatus | undefined) {
+  return {
+    startImport: { mutateAsync: vi.fn().mockResolvedValue({ jobId: "job-1" }), isPending: false },
+    statusQuery: { data: status, isLoading: false },
+    startData: status ? { jobId: status.jobId, totalRows: status.totalRows, detectedColumns: [], columnMapping: {} } : null,
+    retryRow: { mutateAsync: vi.fn().mockResolvedValue(status), isPending: false },
+    downloadTemplate: { mutateAsync: vi.fn().mockResolvedValue(undefined), isPending: false },
+    reset: vi.fn(),
+  };
+}
+
+describe("ImportsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the upload zone and the template button before starting", () => {
+    useImportMock.mockReturnValue(makeImportResult(undefined));
+
+    render(<ImportsPage />);
+
+    expect(screen.getByText("Importar Inventario")).toBeInTheDocument();
+    expect(screen.getByText(/Arrastra un archivo o haz click para subir/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Plantilla/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Iniciar importacion/i })).toBeInTheDocument();
+  });
+
+  it("starts a full import when a file is selected and submitted", async () => {
+    const result = makeImportResult(undefined);
+    useImportMock.mockReturnValue(result);
+    const mutateAsync = result.startImport.mutateAsync;
+
+    render(<ImportsPage />);
+
+    const file = new File(["xlsx"], "import.xlsx", { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" });
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.click(screen.getByRole("button", { name: /Iniciar importacion/i }));
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledOnce());
+    expect(mutateAsync).toHaveBeenCalledWith(file);
+  });
+
+  it("renders the per-sheet progress and errors after an import completes", () => {
+    useImportMock.mockReturnValue(makeImportResult(makeFullStatus()));
+
+    render(<ImportsPage />);
+
+    expect(screen.getAllByText("Productos").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Clientes").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("COMPLETED").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Errores por hoja/)).toBeInTheDocument();
+    expect(screen.getByText("Documento invalido")).toBeInTheDocument();
+  });
+
+  it("retries a failed row sending its sheetId", async () => {
+    const result = makeImportResult(makeFullStatus());
+    useImportMock.mockReturnValue(result);
+    const retryMutate = result.retryRow.mutateAsync;
+
+    render(<ImportsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Editar/i }));
+    fireEvent.change(screen.getByLabelText("Nombre"), { target: { value: "Ana Maria Perez" } });
+    fireEvent.click(screen.getByRole("button", { name: /Reintentar fila/i }));
+
+    await waitFor(() => expect(retryMutate).toHaveBeenCalledOnce());
+    expect(retryMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rowIndex: 5,
+        sheetId: "clientes",
+        correctedData: expect.objectContaining({ name: "Ana Maria Perez" }),
+      }),
+    );
+  });
+
+  it("downloads the multi-sheet template", async () => {
+    const result = makeImportResult(undefined);
+    useImportMock.mockReturnValue(result);
+
+    render(<ImportsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Plantilla/i }));
+    await waitFor(() => expect(result.downloadTemplate.mutateAsync).toHaveBeenCalledOnce());
+  });
+});

--- a/frontend/src/app/imports/page.tsx
+++ b/frontend/src/app/imports/page.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useState } from "react";
+import { DashboardLayout } from "@/components/layout/DashboardLayout";
+import { ImportUpload } from "@/components/imports/ImportUpload";
+import { TemplateDownloadButton } from "@/components/imports/TemplateDownloadButton";
+import { ImportSheetProgress } from "@/components/imports/ImportSheetProgress";
+import { ImportSheetErrors } from "@/components/imports/ImportSheetErrors";
+import { useImport } from "@/hooks/useImport";
+import { useToast } from "@/contexts/ToastContext";
+import { getApiErrorMessage } from "@/lib/api";
+import { Button } from "@/components/ui/Button";
+import { Badge } from "@/components/ui/Badge";
+import { CheckCircle2, FileSpreadsheet, RefreshCcw, Upload } from "lucide-react";
+import type { ImportSheetRowError } from "@/types";
+
+export default function ImportsPage() {
+  const toast = useToast();
+  const {
+    startImport,
+    statusQuery,
+    startData,
+    retryRow,
+    downloadTemplate,
+    reset,
+  } = useImport({ mode: "full" });
+
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+
+  const status = statusQuery.data;
+  const hasStarted = !!startData;
+  const isProcessing = status?.status === "PARSING" || status?.status === "PROCESSING";
+  const isFinished = status?.status === "COMPLETED" || status?.status === "FAILED";
+
+  const onFileSelected = (file: File) => {
+    if (!file.name.toLowerCase().endsWith(".xlsx")) {
+      toast.error("Formato no soportado. Usa un archivo .xlsx");
+      return;
+    }
+
+    setSelectedFile(file);
+  };
+
+  const handleStartImport = async () => {
+    if (!selectedFile) {
+      toast.error("Selecciona un archivo para iniciar la importacion");
+      return;
+    }
+
+    try {
+      await startImport.mutateAsync(selectedFile);
+      toast.success("Importacion iniciada correctamente");
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "No se pudo iniciar la importacion"));
+    }
+  };
+
+  const handleDownloadTemplate = async () => {
+    try {
+      await downloadTemplate.mutateAsync();
+      toast.success("Plantilla descargada correctamente");
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "No se pudo descargar la plantilla"));
+    }
+  };
+
+  const handleRetryRow = async (
+    error: ImportSheetRowError,
+    correctedData: Record<string, unknown>,
+  ) => {
+    try {
+      await retryRow.mutateAsync({
+        rowIndex: error.rowIndex,
+        sheetId: error.sheetId,
+        correctedData,
+      });
+      toast.success("Fila reintentada correctamente");
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "No se pudo reintentar la fila"));
+    }
+  };
+
+  const handleReset = () => {
+    reset();
+    setSelectedFile(null);
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-4 lg:space-y-5">
+        {/* Page Header */}
+        <div>
+          <div className="flex items-center gap-3 mb-1">
+            <div className="w-1 h-7 rounded-full bg-primary shrink-0" />
+            <h1 className="text-2xl lg:text-3xl font-bold text-foreground">
+              Importar Inventario
+            </h1>
+          </div>
+          <p className="text-sm text-muted-foreground ml-4">
+            Importa productos, clientes, proveedores y usuarios desde un archivo
+            multi-hoja (.xlsx)
+          </p>
+        </div>
+
+        <div className="rounded-3xl border border-accent/30 bg-accent/10 overflow-hidden transition-all duration-300">
+          <div className="px-5 py-4 border-b border-accent/20 flex items-center gap-2">
+            <div className="p-1.5 bg-accent/20 rounded-lg">
+              <Upload className="w-4 h-4 text-accent" />
+            </div>
+            <h3 className="text-sm font-semibold text-foreground">
+              Importación Multi-Hoja
+            </h3>
+          </div>
+
+          <div className="p-5 space-y-4">
+            {!hasStarted && (
+              <>
+                <ImportUpload
+                  selectedFile={selectedFile}
+                  onFileSelected={onFileSelected}
+                  onClear={() => setSelectedFile(null)}
+                />
+
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    onClick={handleStartImport}
+                    disabled={!selectedFile}
+                    loading={startImport.isPending}
+                  >
+                    Iniciar importacion
+                  </Button>
+                  <TemplateDownloadButton
+                    onDownload={handleDownloadTemplate}
+                    loading={downloadTemplate.isPending}
+                  />
+                </div>
+              </>
+            )}
+
+            {hasStarted && (
+              <>
+                <div className="rounded-2xl border border-accent/20 bg-background/40 p-3 space-y-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="text-xs uppercase tracking-wide font-semibold text-muted-foreground">
+                        Archivo
+                      </p>
+                      <p className="text-sm font-medium text-foreground truncate">
+                        {status?.fileName ?? selectedFile?.name ?? "Importacion en curso"}
+                      </p>
+                    </div>
+
+                    <Badge variant={isProcessing ? "warning" : isFinished ? "success" : "primary"}>
+                      {status?.status ?? "PARSING"}
+                    </Badge>
+                  </div>
+
+                  <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                    <Badge variant="secondary" className="justify-center">
+                      Procesados: {status?.processedRows ?? 0}
+                    </Badge>
+                    <Badge variant="success" className="justify-center">
+                      Importados: {status?.importedCount ?? 0}
+                    </Badge>
+                    <Badge variant="warning" className="justify-center">
+                      Omitidos: {status?.skippedCount ?? 0}
+                    </Badge>
+                    <Badge variant="danger" className="justify-center">
+                      Errores: {status?.errorCount ?? 0}
+                    </Badge>
+                  </div>
+                </div>
+
+                <ImportSheetProgress
+                  sheets={status?.sheets ?? []}
+                  isLoading={statusQuery.isLoading && hasStarted}
+                />
+
+                <ImportSheetErrors
+                  errors={status?.errors ?? []}
+                  retryPending={retryRow.isPending}
+                  onRetry={handleRetryRow}
+                />
+
+                {isFinished && (
+                  <div className="flex items-center justify-end gap-2">
+                    <div className="flex-1" />
+                    {status?.status === "COMPLETED" && (
+                      <div className="flex items-center gap-1.5 text-xs text-emerald-600 dark:text-emerald-400">
+                        <CheckCircle2 className="w-4 h-4" />
+                        Importacion finalizada
+                      </div>
+                    )}
+                    <TemplateDownloadButton
+                      onDownload={handleDownloadTemplate}
+                      loading={downloadTemplate.isPending}
+                    />
+                    <Button variant="primary" onClick={handleReset}>
+                      <RefreshCcw className="w-4 h-4" /> Nueva importacion
+                    </Button>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-start gap-2 rounded-xl border border-border/60 bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+          <FileSpreadsheet className="w-4 h-4 shrink-0 mt-0.5" />
+          <span>
+            El archivo debe contener las hojas Productos, Clientes, Proveedores y
+            Usuarios. Descarga la plantilla para conocer las columnas requeridas.
+          </span>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/frontend/src/components/imports/ImportSheetErrors.test.tsx
+++ b/frontend/src/components/imports/ImportSheetErrors.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ImportSheetErrors } from "./ImportSheetErrors";
+import type { ImportSheetRowError } from "@/types";
+
+function makeError(overrides: Partial<ImportSheetRowError> = {}): ImportSheetRowError {
+  return {
+    rowIndex: 5,
+    sheetId: "clientes",
+    errorCode: "DUPLICATE_DOCUMENT",
+    message: "Documento duplicado",
+    mappedData: { name: "Ana Perez", documentNumber: "1010101" },
+    editableFields: ["name", "documentNumber"],
+    retried: false,
+    retriedSuccess: false,
+    ...overrides,
+  };
+}
+
+describe("ImportSheetErrors", () => {
+  it("does not render anything when there are no errors", () => {
+    render(<ImportSheetErrors errors={[]} onRetry={vi.fn()} />);
+    expect(screen.queryByText(/Fila/)).not.toBeInTheDocument();
+  });
+
+  it("groups errors by their originating sheet", () => {
+    render(
+      <ImportSheetErrors
+        errors={[
+          makeError({ sheetId: "clientes" }),
+          makeError({ rowIndex: 9, sheetId: "productos", errorCode: "INVALID_PRICE" }),
+        ]}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Clientes")).toBeInTheDocument();
+    expect(screen.getByText("Productos")).toBeInTheDocument();
+    expect(screen.getByText("Fila 5")).toBeInTheDocument();
+    expect(screen.getByText("Fila 9")).toBeInTheDocument();
+  });
+
+  it("renders the error message and editable fields", () => {
+    render(<ImportSheetErrors errors={[makeError()]} onRetry={vi.fn()} />);
+
+    expect(screen.getByText("Documento duplicado")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Editar/i }));
+    expect(screen.getByLabelText("Nombre")).toBeInTheDocument();
+    expect(screen.getByLabelText("N° documento")).toBeInTheDocument();
+  });
+
+  it("calls onRetry with the error and the edited corrected data", () => {
+    const onRetry = vi.fn();
+    render(<ImportSheetErrors errors={[makeError()]} onRetry={onRetry} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Editar/i }));
+    fireEvent.change(screen.getByLabelText("Nombre"), {
+      target: { value: "Ana Maria Perez" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Reintentar fila/i }));
+
+    expect(onRetry).toHaveBeenCalledOnce();
+    const [error, correctedData] = onRetry.mock.calls[0] as [
+      ImportSheetRowError,
+      Record<string, unknown>,
+    ];
+    expect(error.rowIndex).toBe(5);
+    expect(error.sheetId).toBe("clientes");
+    expect(correctedData.name).toBe("Ana Maria Perez");
+  });
+});

--- a/frontend/src/components/imports/ImportSheetErrors.tsx
+++ b/frontend/src/components/imports/ImportSheetErrors.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState } from "react";
+import { Pencil, RefreshCcw } from "lucide-react";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { fieldLabel, sheetLabel } from "./labels";
+import type { ImportSheetId, ImportSheetRowError } from "@/types";
+
+type EditableValues = Record<string, string>;
+
+function toStringValue(value: unknown) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  return String(value);
+}
+
+function mapErrorVariant(errorCode: string) {
+  if (errorCode.startsWith("DUPLICATE")) {
+    return "danger" as const;
+  }
+
+  if (errorCode.startsWith("INVALID")) {
+    return "warning" as const;
+  }
+
+  return "secondary" as const;
+}
+
+function groupBySheet(errors: ImportSheetRowError[]): ImportSheetId[] {
+  const order: ImportSheetId[] = [];
+  const seen = new Set<ImportSheetId>();
+  errors.forEach((error) => {
+    if (!seen.has(error.sheetId)) {
+      seen.add(error.sheetId);
+      order.push(error.sheetId);
+    }
+  });
+  return order;
+}
+
+interface ImportSheetErrorsProps {
+  errors: ImportSheetRowError[];
+  retryPending?: boolean;
+  onRetry: (
+    error: ImportSheetRowError,
+    correctedData: Record<string, unknown>,
+  ) => void;
+}
+
+export function ImportSheetErrors({
+  errors,
+  retryPending = false,
+  onRetry,
+}: ImportSheetErrorsProps) {
+  const [editingRow, setEditingRow] = useState<number | null>(null);
+  const [editValues, setEditValues] = useState<EditableValues>({});
+
+  if (errors.length === 0) {
+    return null;
+  }
+
+  const sheetOrder = groupBySheet(errors);
+
+  const startEditing = (error: ImportSheetRowError) => {
+    setEditingRow(error.rowIndex);
+    const values: EditableValues = {};
+    error.editableFields.forEach((field) => {
+      values[field] = toStringValue(error.mappedData?.[field]);
+    });
+    setEditValues(values);
+  };
+
+  const handleRetry = (error: ImportSheetRowError) => {
+    const correctedData: Record<string, unknown> = {};
+    error.editableFields.forEach((field) => {
+      correctedData[field] = editValues[field] ?? "";
+    });
+    onRetry(error, correctedData);
+  };
+
+  return (
+    <div className="rounded-2xl border border-rose-500/30 bg-rose-500/5 overflow-hidden">
+      <div className="px-3 py-2 border-b border-rose-500/20 bg-rose-500/10">
+        <p className="text-xs font-semibold uppercase tracking-wide text-rose-500">
+          Errores por hoja
+        </p>
+      </div>
+
+      <div className="divide-y divide-rose-500/10">
+        {sheetOrder.map((sheetId) => (
+          <div key={sheetId} className="p-3 space-y-2">
+            <p className="text-xs font-bold uppercase tracking-wide text-muted-foreground">
+              {sheetLabel(sheetId)}
+            </p>
+
+            {errors
+              .filter((error) => error.sheetId === sheetId)
+              .map((error) => (
+                <div
+                  key={`${error.sheetId}-${error.rowIndex}-${error.errorCode}`}
+                  data-testid={`import-error-row-${error.rowIndex}`}
+                  className="rounded-xl border border-rose-500/20 bg-background/40 p-3 space-y-2"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      <Badge variant={mapErrorVariant(error.errorCode)}>
+                        {error.errorCode}
+                      </Badge>
+                      <span className="text-xs text-muted-foreground">
+                        Fila {error.rowIndex}
+                      </span>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      onClick={() => startEditing(error)}
+                    >
+                      <Pencil className="w-3.5 h-3.5" /> Editar
+                    </Button>
+                  </div>
+
+                  <p className="text-sm text-foreground">{error.message}</p>
+
+                  {editingRow === error.rowIndex && (
+                    <div className="rounded-xl border border-accent/20 bg-background/40 p-3 space-y-3">
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                        {error.editableFields.map((field) => (
+                          <Input
+                            key={field}
+                            label={fieldLabel(field)}
+                            value={editValues[field] ?? ""}
+                            onChange={(event) =>
+                              setEditValues((previous) => ({
+                                ...previous,
+                                [field]: event.target.value,
+                              }))
+                            }
+                          />
+                        ))}
+                      </div>
+
+                      <div className="flex flex-wrap gap-2">
+                        <Button
+                          size="sm"
+                          loading={retryPending}
+                          disabled={retryPending}
+                          onClick={() => handleRetry(error)}
+                        >
+                          <RefreshCcw className="w-3.5 h-3.5" /> Reintentar fila
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => setEditingRow(null)}
+                        >
+                          Cancelar
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/imports/ImportSheetProgress.test.tsx
+++ b/frontend/src/components/imports/ImportSheetProgress.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ImportSheetProgress } from "./ImportSheetProgress";
+import type { ImportSheetStatus } from "@/types";
+
+function makeSheet(overrides: Partial<ImportSheetStatus> = {}): ImportSheetStatus {
+  return {
+    sheetId: "productos",
+    status: "PROCESSING",
+    totalRows: 10,
+    processedRows: 5,
+    imported: 4,
+    skipped: 0,
+    errors: 1,
+    warnings: 0,
+    rowErrors: [],
+    ...overrides,
+  };
+}
+
+describe("ImportSheetProgress", () => {
+  it("renders each sheet with its label and sub-status", () => {
+    render(
+      <ImportSheetProgress
+        sheets={[
+          makeSheet({ sheetId: "clientes", status: "COMPLETED" }),
+          makeSheet({ sheetId: "usuarios", status: "REJECTED" }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Clientes")).toBeInTheDocument();
+    expect(screen.getByText("COMPLETED")).toBeInTheDocument();
+    expect(screen.getByText("Usuarios")).toBeInTheDocument();
+    expect(screen.getByText("REJECTED")).toBeInTheDocument();
+  });
+
+  it("renders per-sheet counters", () => {
+    render(
+      <ImportSheetProgress
+        sheets={[makeSheet({ imported: 7, errors: 2, skipped: 1 })]}
+      />,
+    );
+
+    expect(screen.getByText(/Importados: 7/)).toBeInTheDocument();
+    expect(screen.getByText(/Errores: 2/)).toBeInTheDocument();
+    expect(screen.getByText(/Omitidos: 1/)).toBeInTheDocument();
+  });
+
+  it("computes a progress percentage from processed/total rows", () => {
+    render(
+      <ImportSheetProgress
+        sheets={[makeSheet({ processedRows: 5, totalRows: 10 })]}
+      />,
+    );
+
+    expect(screen.getByText("50%")).toBeInTheDocument();
+  });
+
+  it("shows a loading placeholder when there are no sheets yet", () => {
+    render(<ImportSheetProgress sheets={[]} isLoading />);
+    expect(screen.getByText(/Cargando estado/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/imports/ImportSheetProgress.tsx
+++ b/frontend/src/components/imports/ImportSheetProgress.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Badge } from "@/components/ui/Badge";
+import { sheetLabel } from "./labels";
+import type {
+  ImportSheetStatus,
+  ImportSheetSubStatus,
+} from "@/types";
+
+const statusVariant: Record<
+  ImportSheetSubStatus,
+  "secondary" | "warning" | "success" | "danger"
+> = {
+  PENDING: "secondary",
+  PROCESSING: "warning",
+  COMPLETED: "success",
+  REJECTED: "danger",
+  FAILED: "danger",
+};
+
+interface ImportSheetProgressProps {
+  sheets: ImportSheetStatus[];
+  isLoading?: boolean;
+}
+
+export function ImportSheetProgress({
+  sheets,
+  isLoading = false,
+}: ImportSheetProgressProps) {
+  if (isLoading && sheets.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Cargando estado de la importacion...
+      </p>
+    );
+  }
+
+  if (sheets.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Ninguna hoja reconocida en el archivo.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {sheets.map((sheet) => {
+        const percent =
+          sheet.totalRows > 0
+            ? Math.round((sheet.processedRows / sheet.totalRows) * 100)
+            : 0;
+
+        return (
+          <div
+            key={sheet.sheetId}
+            className="rounded-2xl border border-accent/20 bg-background/40 p-3 space-y-2"
+          >
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-sm font-semibold text-foreground">
+                {sheetLabel(sheet.sheetId)}
+              </span>
+              <Badge variant={statusVariant[sheet.status]}>{sheet.status}</Badge>
+            </div>
+
+            <div>
+              <div className="flex justify-between text-xs text-muted-foreground mb-1">
+                <span>
+                  {sheet.processedRows} / {sheet.totalRows} filas
+                </span>
+                <span className="font-semibold">{percent}%</span>
+              </div>
+              <div className="w-full h-2 rounded-full bg-accent/10 overflow-hidden">
+                <div
+                  className="h-2 rounded-full bg-gradient-to-r from-accent to-accent/60 transition-all duration-300"
+                  style={{ width: `${percent}%` }}
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+              <Badge variant="secondary" className="justify-center">
+                Importados: {sheet.imported}
+              </Badge>
+              <Badge variant="warning" className="justify-center">
+                Omitidos: {sheet.skipped}
+              </Badge>
+              <Badge variant="danger" className="justify-center">
+                Errores: {sheet.errors}
+              </Badge>
+              <Badge variant="primary" className="justify-center">
+                Avisos: {sheet.warnings}
+              </Badge>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/imports/ImportUpload.test.tsx
+++ b/frontend/src/components/imports/ImportUpload.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ImportUpload } from "./ImportUpload";
+
+function makeXlsx(name = "import.xlsx"): File {
+  return new File(["xlsx"], name, {
+    type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  });
+}
+
+describe("ImportUpload", () => {
+  it("renders the dropzone instructions and supports .xlsx only", () => {
+    render(<ImportUpload selectedFile={null} onFileSelected={vi.fn()} onClear={vi.fn()} />);
+
+    expect(screen.getByText(/Arrastra un archivo o haz click para subir/i)).toBeInTheDocument();
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.accept).toBe(".xlsx");
+  });
+
+  it("calls onFileSelected when a file is picked through the input", () => {
+    const onFileSelected = vi.fn();
+    render(<ImportUpload selectedFile={null} onFileSelected={onFileSelected} onClear={vi.fn()} />);
+
+    const file = makeXlsx();
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(onFileSelected).toHaveBeenCalledOnce();
+    expect(onFileSelected).toHaveBeenCalledWith(file);
+  });
+
+  it("calls onFileSelected when a file is dropped", () => {
+    const onFileSelected = vi.fn();
+    render(<ImportUpload selectedFile={null} onFileSelected={onFileSelected} onClear={vi.fn()} />);
+
+    const dropzone = screen.getByText(/Arrastra un archivo o haz click para subir/i).closest("label")!;
+    const file = makeXlsx();
+    fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
+
+    expect(onFileSelected).toHaveBeenCalledOnce();
+    expect(onFileSelected).toHaveBeenCalledWith(file);
+  });
+
+  it("shows the selected file and calls onClear when cleared", () => {
+    const onClear = vi.fn();
+    render(
+      <ImportUpload
+        selectedFile={makeXlsx("inventario.xlsx")}
+        onFileSelected={vi.fn()}
+        onClear={onClear}
+      />,
+    );
+
+    expect(screen.getByText("inventario.xlsx")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Limpiar/i }));
+    expect(onClear).toHaveBeenCalledOnce();
+  });
+
+  it("renders a validation error when one is provided", () => {
+    render(
+      <ImportUpload
+        selectedFile={null}
+        onFileSelected={vi.fn()}
+        onClear={vi.fn()}
+        error="Solo se admiten archivos .xlsx"
+      />,
+    );
+
+    expect(screen.getByText("Solo se admiten archivos .xlsx")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/imports/ImportUpload.tsx
+++ b/frontend/src/components/imports/ImportUpload.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { ChangeEvent, DragEvent, useState } from "react";
+import { AlertCircle, FileSpreadsheet, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ImportUploadProps {
+  selectedFile: File | null;
+  onFileSelected: (file: File) => void;
+  onClear: () => void;
+  error?: string | null;
+}
+
+export function ImportUpload({
+  selectedFile,
+  onFileSelected,
+  onClear,
+  error,
+}: ImportUploadProps) {
+  const [dragActive, setDragActive] = useState(false);
+
+  const handleInputFile = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null;
+    if (file) {
+      onFileSelected(file);
+    }
+  };
+
+  const handleDrop = (event: DragEvent<HTMLLabelElement>) => {
+    event.preventDefault();
+    setDragActive(false);
+    const file = event.dataTransfer.files?.[0] ?? null;
+    if (file) {
+      onFileSelected(file);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <label
+        data-testid="import-dropzone"
+        onDragOver={(event) => {
+          event.preventDefault();
+          setDragActive(true);
+        }}
+        onDragLeave={(event) => {
+          event.preventDefault();
+          setDragActive(false);
+        }}
+        onDrop={handleDrop}
+        className={cn(
+          "block rounded-2xl border border-dashed px-4 py-8 text-center cursor-pointer transition-colors",
+          dragActive
+            ? "border-accent/60 bg-accent/10"
+            : "border-accent/30 bg-background/40 hover:bg-background/60",
+        )}
+      >
+        <input
+          type="file"
+          accept=".xlsx"
+          className="hidden"
+          onChange={handleInputFile}
+        />
+        <FileSpreadsheet className="w-7 h-7 text-muted-foreground mx-auto mb-2" />
+        <p className="text-sm font-semibold text-foreground">
+          Arrastra un archivo o haz click para subir
+        </p>
+        <p className="text-xs text-muted-foreground mt-1">
+          Multi-hoja: Productos, Clientes, Proveedores, Usuarios (.xlsx)
+        </p>
+      </label>
+
+      {error && (
+        <div
+          role="alert"
+          className="flex items-center gap-2 rounded-xl border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-600 dark:text-rose-400"
+        >
+          <AlertCircle className="w-4 h-4 shrink-0" />
+          {error}
+        </div>
+      )}
+
+      {selectedFile && (
+        <div className="flex items-center justify-between gap-2 rounded-xl border border-accent/20 bg-background/40 px-3 py-2">
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-foreground truncate">
+              {selectedFile.name}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {(selectedFile.size / 1024).toFixed(1)} KB
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClear}
+            className="inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-semibold text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors"
+          >
+            <X className="w-3.5 h-3.5" />
+            Limpiar
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/imports/TemplateDownloadButton.test.tsx
+++ b/frontend/src/components/imports/TemplateDownloadButton.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { TemplateDownloadButton } from "./TemplateDownloadButton";
+
+describe("TemplateDownloadButton", () => {
+  it("renders a plantilla download button", () => {
+    render(<TemplateDownloadButton onDownload={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: /Plantilla/i })).toBeInTheDocument();
+  });
+
+  it("calls onDownload when clicked", () => {
+    const onDownload = vi.fn();
+    render(<TemplateDownloadButton onDownload={onDownload} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Plantilla/i }));
+    expect(onDownload).toHaveBeenCalledOnce();
+  });
+
+  it("disables the button while download is loading", () => {
+    render(<TemplateDownloadButton onDownload={vi.fn()} loading />);
+
+    expect(screen.getByRole("button", { name: /Plantilla/i })).toBeDisabled();
+  });
+});

--- a/frontend/src/components/imports/TemplateDownloadButton.tsx
+++ b/frontend/src/components/imports/TemplateDownloadButton.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Download } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+
+interface TemplateDownloadButtonProps {
+  onDownload: () => void;
+  loading?: boolean;
+  disabled?: boolean;
+}
+
+export function TemplateDownloadButton({
+  onDownload,
+  loading = false,
+  disabled = false,
+}: TemplateDownloadButtonProps) {
+  return (
+    <Button
+      variant="secondary"
+      onClick={onDownload}
+      loading={loading}
+      disabled={disabled}
+    >
+      <Download className="w-4 h-4" /> Plantilla
+    </Button>
+  );
+}

--- a/frontend/src/components/imports/labels.ts
+++ b/frontend/src/components/imports/labels.ts
@@ -1,0 +1,38 @@
+import type { ImportSheetId } from "@/types";
+
+export const SHEET_LABELS: Record<ImportSheetId, string> = {
+  productos: "Productos",
+  clientes: "Clientes",
+  proveedores: "Proveedores",
+  usuarios: "Usuarios",
+};
+
+export const FIELD_LABELS: Record<string, string> = {
+  name: "Nombre",
+  sku: "SKU",
+  barcode: "Código de barras",
+  category: "Categoría",
+  salePrice: "Precio venta",
+  costPrice: "Precio costo",
+  stock: "Stock",
+  minStock: "Stock mínimo",
+  taxRate: "Impuesto (%)",
+  description: "Descripción",
+  documentType: "Tipo de documento",
+  documentNumber: "N° documento",
+  email: "Email",
+  password: "Contraseña",
+  role: "Rol",
+  accountType: "Tipo de cuenta",
+  phone: "Teléfono",
+  address: "Dirección",
+  contactName: "Nombre de contacto",
+};
+
+export function sheetLabel(sheetId: ImportSheetId): string {
+  return SHEET_LABELS[sheetId] ?? sheetId;
+}
+
+export function fieldLabel(field: string): string {
+  return FIELD_LABELS[field] ?? field;
+}

--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -13,6 +13,7 @@ const routeRoleMap: Array<{ prefix: string; roles: UserRole[] }> = [
   { prefix: "/dashboard", roles: ["ADMIN", "INVENTORY_USER"] },
   { prefix: "/pos", roles: ["ADMIN", "CASHIER"] },
   { prefix: "/inventory", roles: ["ADMIN", "CASHIER", "INVENTORY_USER"] },
+  { prefix: "/imports", roles: ["ADMIN", "CASHIER"] },
   { prefix: "/suppliers", roles: ["ADMIN", "INVENTORY_USER"] },
   { prefix: "/purchase-orders", roles: ["ADMIN", "INVENTORY_USER"] },
   { prefix: "/sales", roles: ["ADMIN", "CASHIER"] },

--- a/frontend/src/components/layout/Sidebar.test.tsx
+++ b/frontend/src/components/layout/Sidebar.test.tsx
@@ -147,6 +147,7 @@ describe("Sidebar", () => {
       "Ventas",
       "Clientes",
       "Inventario",
+      "Importar",
       "Categorías",
       "Proveedores",
       "Compras",
@@ -157,6 +158,71 @@ describe("Sidebar", () => {
       "Configuración",
     ]);
     expect(screen.queryByRole("link", { name: "Usuarios" })).not.toBeInTheDocument();
+  });
+
+  it("shows the Importar nav item for ADMIN users", async () => {
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { organizations },
+    });
+
+    render(<Sidebar />, { wrapper });
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith("/auth/organizations");
+    });
+
+    const link = screen.getByRole("link", { name: "Importar" });
+    expect(link).toHaveAttribute("href", "/imports");
+  });
+
+  it("shows the Importar nav item for CASHIER users", async () => {
+    useAuthMock.mockReturnValue({
+      user: {
+        id: "user-cash",
+        name: "Carlos Cajero",
+        role: "CASHIER",
+        active: true,
+        organizationId: "org-a",
+      },
+      logout: vi.fn(),
+      switchOrganization: switchOrganizationMock,
+    });
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { organizations: [organizations[0]] },
+    });
+
+    render(<Sidebar />, { wrapper });
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith("/auth/organizations");
+    });
+
+    expect(screen.getByRole("link", { name: "Importar" })).toHaveAttribute("href", "/imports");
+  });
+
+  it("hides the Importar nav item for INVENTORY_USER users", async () => {
+    useAuthMock.mockReturnValue({
+      user: {
+        id: "user-inv",
+        name: "Inventario User",
+        role: "INVENTORY_USER",
+        active: true,
+        organizationId: "org-a",
+      },
+      logout: vi.fn(),
+      switchOrganization: switchOrganizationMock,
+    });
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { organizations: [organizations[0]] },
+    });
+
+    render(<Sidebar />, { wrapper });
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith("/auth/organizations");
+    });
+
+    expect(screen.queryByRole("link", { name: "Importar" })).not.toBeInTheDocument();
   });
 
   it("hides the Salidas nav item for CASHIER users", async () => {

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -25,6 +25,7 @@ import {
   ClipboardList,
   Truck,
   Wallet,
+  FileSpreadsheet,
 } from "lucide-react";
 import { useTheme } from "@/contexts/ThemeContext";
 import { cn } from "@/lib/utils";
@@ -69,6 +70,12 @@ const navItems: NavItem[] = [
     href: "/inventory",
     icon: <Package className="w-4 h-4" />,
     roles: ["ADMIN", "CASHIER", "INVENTORY_USER"],
+  },
+  {
+    label: "Importar",
+    href: "/imports",
+    icon: <FileSpreadsheet className="w-4 h-4" />,
+    roles: ["ADMIN", "CASHIER"],
   },
   {
     label: "Categorías",

--- a/frontend/src/hooks/useImport.test.ts
+++ b/frontend/src/hooks/useImport.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+import { api } from "@/lib/api";
+import type {
+  ImportFullJobStatus,
+  ImportSheetStatus,
+  ImportSheetRowError,
+  ImportStartResponse,
+} from "@/types";
+import { useImport } from "./useImport";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    postWithFormData: vi.fn(),
+    downloadData: vi.fn(),
+  },
+}));
+
+type MockApi = {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  postWithFormData: ReturnType<typeof vi.fn>;
+  downloadData: ReturnType<typeof vi.fn>;
+};
+
+const apiMock = api as unknown as MockApi;
+
+function makeRowError(
+  overrides: Partial<ImportSheetRowError> = {},
+): ImportSheetRowError {
+  return {
+    rowIndex: 5,
+    sheetId: "productos",
+    errorCode: "INVALID_PRICE",
+    message: "Precio de venta invalido",
+    mappedData: { name: "Coca Cola", salePrice: "abc" },
+    editableFields: ["name", "salePrice"],
+    retried: false,
+    retriedSuccess: false,
+    ...overrides,
+  };
+}
+
+function makeSheet(overrides: Partial<ImportSheetStatus> = {}): ImportSheetStatus {
+  return {
+    sheetId: "productos",
+    status: "COMPLETED",
+    totalRows: 10,
+    processedRows: 10,
+    imported: 9,
+    skipped: 0,
+    errors: 1,
+    warnings: 0,
+    rowErrors: [makeRowError()],
+    ...overrides,
+  };
+}
+
+function makeFullStatus(
+  overrides: Partial<ImportFullJobStatus> = {},
+): ImportFullJobStatus {
+  return {
+    jobId: "job-1",
+    status: "COMPLETED",
+    fileName: "import.xlsx",
+    totalRows: 20,
+    processedRows: 20,
+    importedCount: 18,
+    skippedCount: 1,
+    errorCount: 1,
+    warningCount: 0,
+    sheets: [makeSheet(), makeSheet({ sheetId: "clientes", errors: 0, rowErrors: [] })],
+    errors: [makeRowError({ sheetId: "clientes" })],
+    ...overrides,
+  };
+}
+
+function makeStart(jobId = "job-1"): ImportStartResponse {
+  return { jobId, totalRows: 20, detectedColumns: ["name", "salePrice"], columnMapping: {} };
+}
+
+function wrapperWith(queryClient: QueryClient) {
+  return function wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+function makeQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+describe("useImport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMock.postWithFormData.mockResolvedValue({ data: makeStart() });
+    apiMock.get.mockResolvedValue({ data: makeFullStatus() });
+    apiMock.post.mockResolvedValue({ data: makeFullStatus() });
+    apiMock.downloadData.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("full mode", () => {
+    it("starts a full import by posting FormData to /imports/full", async () => {
+      const { result } = renderHook(() => useImport({ mode: "full" }), {
+        wrapper: wrapperWith(makeQueryClient()),
+      });
+
+      const file = new File(["xlsx"], "import.xlsx", { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" });
+      await result.current.startImport.mutateAsync(file);
+
+      expect(apiMock.postWithFormData).toHaveBeenCalledOnce();
+      const [url, formData] = apiMock.postWithFormData.mock.calls[0] as [
+        string,
+        FormData,
+      ];
+      expect(url).toBe("/imports/full");
+      expect(formData).toBeInstanceOf(FormData);
+      expect(formData.get("file")).toBe(file);
+      await waitFor(() => expect(result.current.jobId).toBe("job-1"));
+    });
+
+    it("polls the sheet-aware status from /imports/:jobId/status and exposes the sheet breakdown", async () => {
+      const queryClient = makeQueryClient();
+      const { result } = renderHook(() => useImport({ mode: "full" }), {
+        wrapper: wrapperWith(queryClient),
+      });
+
+      await result.current.startImport.mutateAsync(new File(["x"], "import.xlsx"));
+
+      await waitFor(() => expect(result.current.statusQuery.data?.sheets).toHaveLength(2));
+      expect(apiMock.get).toHaveBeenCalledWith("/imports/job-1/status");
+      expect(result.current.statusQuery.data?.sheets[0].sheetId).toBe("productos");
+      expect(result.current.statusQuery.data?.sheets[0].imported).toBe(9);
+      expect(result.current.statusQuery.data?.errors[0].sheetId).toBe("clientes");
+    });
+
+    it("retries a failed row sending its sheetId to /imports/:jobId/retry-row", async () => {
+      const { result } = renderHook(() => useImport({ mode: "full" }), {
+        wrapper: wrapperWith(makeQueryClient()),
+      });
+
+      await result.current.startImport.mutateAsync(new File(["x"], "import.xlsx"));
+      await waitFor(() => expect(result.current.jobId).toBe("job-1"));
+      await result.current.retryRow.mutateAsync({
+        rowIndex: 5,
+        sheetId: "clientes",
+        correctedData: { name: "Cliente A" },
+      });
+
+      expect(apiMock.post).toHaveBeenCalledWith("/imports/job-1/retry-row", {
+        rowIndex: 5,
+        sheetId: "clientes",
+        correctedData: { name: "Cliente A" },
+      });
+    });
+
+    it("downloads the full template from /imports/full-template", async () => {
+      const { result } = renderHook(() => useImport({ mode: "full" }), {
+        wrapper: wrapperWith(makeQueryClient()),
+      });
+
+      await result.current.downloadTemplate.mutateAsync();
+      expect(apiMock.downloadData).toHaveBeenCalledWith("/imports/full-template");
+    });
+  });
+
+  describe("products mode (backward compatible)", () => {
+    it("posts to /imports/products by default", async () => {
+      const { result } = renderHook(() => useImport(), {
+        wrapper: wrapperWith(makeQueryClient()),
+      });
+
+      await result.current.startImport.mutateAsync(new File(["x"], "products.xlsx"));
+      expect(apiMock.postWithFormData).toHaveBeenCalledWith(
+        "/imports/products",
+        expect.any(FormData),
+      );
+    });
+
+    it("downloads the products template from /imports/products/template", async () => {
+      const { result } = renderHook(() => useImport(), {
+        wrapper: wrapperWith(makeQueryClient()),
+      });
+
+      await result.current.downloadTemplate.mutateAsync();
+      expect(apiMock.downloadData).toHaveBeenCalledWith("/imports/products/template");
+    });
+
+    it("retries a product row without sending a sheetId", async () => {
+      const { result } = renderHook(() => useImport(), {
+        wrapper: wrapperWith(makeQueryClient()),
+      });
+
+      await result.current.startImport.mutateAsync(new File(["x"], "products.xlsx"));
+      await waitFor(() => expect(result.current.jobId).toBe("job-1"));
+      await result.current.retryRow.mutateAsync({
+        rowIndex: 3,
+        correctedData: { name: "Coca Cola" },
+      });
+
+      const payload = apiMock.post.mock.calls[0][1] as Record<string, unknown>;
+      expect(payload.sheetId).toBeUndefined();
+    });
+  });
+});

--- a/frontend/src/hooks/useImport.ts
+++ b/frontend/src/hooks/useImport.ts
@@ -3,17 +3,43 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
-import type { ImportJobStatus, ImportStartResponse } from "@/types";
+import type { UseQueryResult } from "@tanstack/react-query";
+import type {
+  ImportFullJobStatus,
+  ImportJobStatus,
+  ImportSheetId,
+  ImportStartResponse,
+} from "@/types";
 
-type RetryPayload = {
+export type ImportMode = "products" | "full";
+
+export type RetryRowPayload = {
   rowIndex: number;
   correctedData: Record<string, unknown>;
+  /** Required for multi-sheet imports; omitted for product-only retries. */
+  sheetId?: ImportSheetId;
 };
 
-export function useImport() {
+/**
+ * Generalizes the product-only importer to the multi-sheet importer.
+ * Pass `{ mode: "full" }` to use `POST /imports/full`, the sheet-aware
+ * `/imports/:jobId/status` and `/imports/:jobId/retry-row` (sending `sheetId`),
+ * and `GET /imports/full-template`. The default `"products"` mode preserves the
+ * legacy product-import endpoints and query keys, so the existing
+ * `ImportSection` keeps working unchanged.
+ */
+export function useImport<TMode extends ImportMode = "products">(
+  options: { mode?: TMode } = {},
+) {
+  const mode: ImportMode = options.mode ?? "products";
+  const isFull = mode === "full";
   const queryClient = useQueryClient();
   const [jobId, setJobId] = useState<string | null>(null);
   const [startData, setStartData] = useState<ImportStartResponse | null>(null);
+
+  const startUrl = isFull ? "/imports/full" : "/imports/products";
+  const templateUrl = isFull ? "/imports/full-template" : "/imports/products/template";
+  const statusQueryKey = ["imports", isFull ? "full" : "products", jobId];
 
   const startImport = useMutation({
     mutationFn: (file: File) => {
@@ -21,7 +47,7 @@ export function useImport() {
       formData.append("file", file);
 
       return api
-        .postWithFormData<ImportStartResponse>("/imports/products", formData)
+        .postWithFormData<ImportStartResponse>(startUrl, formData)
         .then((res) => res.data);
     },
     onSuccess: (data) => {
@@ -30,11 +56,11 @@ export function useImport() {
     },
   });
 
-  const statusQuery = useQuery({
-    queryKey: ["imports", "products", jobId],
+  const statusQuery = useQuery<ImportJobStatus | ImportFullJobStatus>({
+    queryKey: statusQueryKey,
     queryFn: () =>
       api
-        .get<ImportJobStatus>(`/imports/${jobId}/status`)
+        .get<ImportJobStatus | ImportFullJobStatus>(`/imports/${jobId}/status`)
         .then((res) => res.data),
     enabled: !!jobId,
     refetchInterval: (query) => {
@@ -48,13 +74,16 @@ export function useImport() {
   });
 
   const retryRow = useMutation({
-    mutationFn: (payload: RetryPayload) => {
+    mutationFn: (payload: RetryRowPayload) => {
       if (!jobId) {
         throw new Error("No hay un trabajo de importacion activo");
       }
 
       return api
-        .post<ImportJobStatus>(`/imports/${jobId}/retry-row`, payload)
+        .post<ImportJobStatus | ImportFullJobStatus>(
+          `/imports/${jobId}/retry-row`,
+          payload,
+        )
         .then((res) => res.data);
     },
     onSuccess: (data) => {
@@ -62,18 +91,18 @@ export function useImport() {
         return;
       }
 
-      queryClient.setQueryData(["imports", "products", jobId], data);
+      queryClient.setQueryData(statusQueryKey, data);
       queryClient.invalidateQueries({ queryKey: ["products"] });
     },
   });
 
   const downloadTemplate = useMutation({
-    mutationFn: () => api.downloadData("/imports/products/template"),
+    mutationFn: () => api.downloadData(templateUrl),
   });
 
   const reset = () => {
     if (jobId) {
-      queryClient.removeQueries({ queryKey: ["imports", "products", jobId] });
+      queryClient.removeQueries({ queryKey: statusQueryKey });
     }
 
     setJobId(null);
@@ -86,7 +115,9 @@ export function useImport() {
     jobId,
     startData,
     startImport,
-    statusQuery,
+    statusQuery: statusQuery as UseQueryResult<
+      TMode extends "full" ? ImportFullJobStatus : ImportJobStatus
+    >,
     retryRow,
     downloadTemplate,
     reset,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -357,8 +357,21 @@ export interface ImportEvent {
   timestamp: string;
 }
 
+/** The four entity sheets processed by the multi-sheet importer. */
+export type ImportSheetId = "productos" | "clientes" | "proveedores" | "usuarios";
+
+/** Per-sheet lifecycle sub-status inside a job's per-sheet breakdown. */
+export type ImportSheetSubStatus =
+  | "PENDING"
+  | "PROCESSING"
+  | "COMPLETED"
+  | "REJECTED"
+  | "FAILED";
+
 export interface ImportRowError {
   rowIndex: number;
+  /** Originating sheet for the failed row. Present on multi-sheet imports. */
+  sheetId?: ImportSheetId;
   rawData: Record<string, string>;
   mappedData: Record<string, unknown>;
   errorCode: string;
@@ -367,6 +380,50 @@ export interface ImportRowError {
   retried: boolean;
   retriedSuccess?: boolean;
   editableFields: string[];
+}
+
+/** A row error from a multi-sheet import, always carrying its sheetId. */
+export interface ImportSheetRowError {
+  rowIndex: number;
+  sheetId: ImportSheetId;
+  errorCode: string;
+  message: string;
+  field?: string;
+  mappedData?: Record<string, unknown>;
+  editableFields: string[];
+  retried: boolean;
+  retriedSuccess?: boolean;
+}
+
+/** Per-sheet counters and sub-status returned in a job's per-sheet breakdown. */
+export interface ImportSheetStatus {
+  sheetId: ImportSheetId;
+  status: ImportSheetSubStatus;
+  totalRows: number;
+  processedRows: number;
+  imported: number;
+  skipped: number;
+  errors: number;
+  warnings: number;
+  missingRequiredFields?: string[];
+  planLimitRejected?: boolean;
+  planLimitMessage?: string;
+  rowErrors: ImportSheetRowError[];
+}
+
+/** Full (multi-sheet) import job status: global counters + per-sheet breakdown. */
+export interface ImportFullJobStatus {
+  jobId: string;
+  status: "PARSING" | "PROCESSING" | "COMPLETED" | "FAILED";
+  fileName: string;
+  totalRows: number;
+  processedRows: number;
+  importedCount: number;
+  skippedCount: number;
+  errorCount: number;
+  warningCount: number;
+  sheets: ImportSheetStatus[];
+  errors: ImportSheetRowError[];
 }
 
 export interface ImportJobStatus {


### PR DESCRIPTION
Closes #2

## Summary
Slice 5/5 — the frontend `/imports` page for the multi-hoja importer. PR1–PR4 (merged) delivered the backend engine/handlers/orchestrator/controller; this slice adds the client that uploads a 4-sheet `.xlsx`, polls the sheet-aware status, shows per-sheet progress, retries failed rows inline with their `sheetId`, and downloads the on-the-fly template.

- Adds `frontend/src/app/imports/page.tsx` wired through `useImport({ mode: "full" })`.
- Generalizes `useImport` (backward compatible default `products` mode keeps the existing `ImportSection` intact).
- Reuses `lib/api.ts` (`postWithFormData`, `downloadData`) and the existing `Button`/`Badge`/`Input` UI + `cn()`.

## Changes
| File | Change |
|------|--------|
| `frontend/src/types/index.ts` | Add `sheets[]` per-sheet breakdown, `ImportSheetRowError`, `ImportFullJobStatus`; `sheetId` on `ImportRowError` |
| `frontend/src/hooks/useImport.ts` | Generalize to `/imports/full`, sheet-aware status/retry (sends `sheetId`), `/imports/full-template` |
| `frontend/src/hooks/useImport.test.ts` | RED-first tests (7) for full + backward-compatible modes |
| `frontend/src/components/imports/ImportUpload.tsx` | Drag & drop `.xlsx` dropzone with validation + selected-file chip |
| `frontend/src/components/imports/TemplateDownloadButton.tsx` | Template download action |
| `frontend/src/components/imports/ImportSheetProgress.tsx` | Per-sheet sub-status, counters, progress bar |
| `frontend/src/components/imports/ImportSheetErrors.tsx` | Per-sheet error table with inline `sheetId`-aware retry |
| `frontend/src/components/imports/labels.ts` | Shared sheet/field label helpers |
| `frontend/src/app/imports/page.tsx` | Upload → poll → per-sheet results → retry → template wiring |
| `frontend/src/app/imports/page.test.tsx` | RED-first tests (5) |
| `frontend/src/components/layout/Sidebar.tsx` + `DashboardLayout.tsx` | `/imports` nav entry + role map (ADMIN/CASHIER) |
| `frontend/src/components/layout/Sidebar.test.tsx` | RED-first tests (3) |

## Test Plan
- [x] `cd frontend && npm run test` — **308 passed, 1 failed** (the single failure is the pre-existing `CategoryStackedChart.test.tsx` tooltip assertion, unrelated to this slice and present on `master` baseline).
- [x] `cd frontend && npx tsc --noEmit` — 0 errors.
- [x] `cd frontend && npm run lint` — 0 new problems; the 4 `react-hooks/set-state-in-effect` errors are pre-existing in `settings/*` pages and `CurrencyInput`.

## Notes / Deferred
- The multi-sheet importer processes one job per upload; the product-only `/imports/products` surface is untouched and coexists on the inventory page.
- Known deferred follow-up (unchanged since PR4): the supplier alias table (PR1) doesn't map address/contactName/bank/accountNumber, so those supplier fields are silently dropped on import; fixing it is outside this slice.
- `type:*` labels do not exist on MeperPOS; merged PRs carry none, so this follows the same chain convention.

## Contributor Checklist
- [x] Linked an approved issue (#2)
- [x] Conventional commit format (5 commits, no AI attribution)
- [x] Tests/docs updated with behavior
