### PR TITLE
feat(settings): add consolidated export hub to data section

### DIFF
--- a/frontend/src/app/settings/(data)/data/page.test.tsx
+++ b/frontend/src/app/settings/(data)/data/page.test.tsx
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type {
   ImportFullJobStatus,
   ImportSheetStatus,
   ImportSheetRowError,
 } from "@/types";
+
+const { exportDataMock } = vi.hoisted(() => ({ exportDataMock: vi.fn() }));
 
 const useImportMock = vi.fn();
 const toastSuccess = vi.fn();
@@ -16,6 +18,42 @@ vi.mock("@/contexts/ToastContext", () => ({
 
 vi.mock("@/hooks/useImport", () => ({
   useImport: () => useImportMock(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: { exportData: exportDataMock },
+  };
+});
+
+vi.mock("@/components/ui/BentoSelect", () => ({
+  BentoSelect: ({
+    value,
+    onChange,
+    options,
+    placeholder,
+    label,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    options: Array<{ value: string; label: string }>;
+    placeholder?: string;
+    label?: string;
+  }) => (
+    <select
+      aria-label={label || placeholder || "Formato de exportación"}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
 }));
 
 import ImportDataSettingsPage from "./page";
@@ -93,7 +131,7 @@ describe("ImportDataSettingsPage", () => {
 
     render(<ImportDataSettingsPage />);
 
-    expect(screen.getByText("Importar datos")).toBeInTheDocument();
+    expect(screen.getByText("Importar y exportar datos")).toBeInTheDocument();
     expect(screen.getByText("Importación Multi-Hoja")).toBeInTheDocument();
     expect(screen.getByText(/Arrastra un archivo o haz click para subir/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Plantilla/i })).toBeInTheDocument();
@@ -151,5 +189,119 @@ describe("ImportDataSettingsPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Plantilla/i }));
     await waitFor(() => expect(result.downloadTemplate.mutateAsync).toHaveBeenCalledOnce());
+  });
+
+  it("renders every export tile only after expanding the export section", () => {
+    useImportMock.mockReturnValue(makeImportResult(undefined));
+
+    render(<ImportDataSettingsPage />);
+
+    // Hidden by default: the tile grid is collapsed.
+    expect(screen.queryByText("Productos")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Exportar datos/ }));
+
+    for (const title of [
+      "Productos",
+      "Ventas",
+      "Clientes",
+      "Movimientos",
+      "Gastos",
+      "Económico",
+    ]) {
+      expect(screen.getByText(title)).toBeInTheDocument();
+    }
+  });
+
+  it("toggles the export panel closed from the expanded state", () => {
+    useImportMock.mockReturnValue(makeImportResult(undefined));
+
+    render(<ImportDataSettingsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Exportar datos/ }));
+    expect(screen.getByRole("button", { name: /Ocultar exportación/ })).toBeInTheDocument();
+    expect(screen.getByText("Productos")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Ocultar exportación/ }));
+    expect(screen.getByRole("button", { name: /Exportar datos/ })).toBeInTheDocument();
+    expect(screen.queryByText("Productos")).not.toBeInTheDocument();
+  });
+
+  it("exports the products tile with the right endpoint and default format", async () => {
+    useImportMock.mockReturnValue(makeImportResult(undefined));
+    exportDataMock.mockResolvedValue(undefined);
+
+    render(<ImportDataSettingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: /Exportar datos/ }));
+
+    const productsTile = screen.getByTestId("export-tile-products");
+    fireEvent.click(within(productsTile).getByRole("button", { name: /Exportar/ }));
+
+    await waitFor(() => expect(exportDataMock).toHaveBeenCalledOnce());
+    expect(exportDataMock).toHaveBeenCalledWith(
+      "/exports/products",
+      expect.objectContaining({ type: "products", format: "excel" }),
+    );
+    expect(toastSuccess).toHaveBeenCalledWith("Exportación generada correctamente");
+  });
+
+  it("exports the sales tile with the csv format", async () => {
+    useImportMock.mockReturnValue(makeImportResult(undefined));
+    exportDataMock.mockResolvedValue(undefined);
+
+    render(<ImportDataSettingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: /Exportar datos/ }));
+
+    const salesTile = screen.getByTestId("export-tile-sales");
+    fireEvent.change(within(salesTile).getByRole("combobox"), {
+      target: { value: "csv" },
+    });
+
+    fireEvent.click(within(salesTile).getByRole("button", { name: /Exportar/ }));
+
+    await waitFor(() => expect(exportDataMock).toHaveBeenCalledOnce());
+    expect(exportDataMock).toHaveBeenCalledWith(
+      "/exports/sales",
+      expect.objectContaining({ type: "sales", format: "csv" }),
+    );
+  });
+
+  it("sends the date range payload for date-bearing tiles", async () => {
+    useImportMock.mockReturnValue(makeImportResult(undefined));
+    exportDataMock.mockResolvedValue(undefined);
+
+    render(<ImportDataSettingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: /Exportar datos/ }));
+
+    const economicTile = screen.getByTestId("export-tile-economic");
+    const [startInput, endInput] = within(economicTile).getAllByLabelText(/Desde|Hasta/);
+    fireEvent.change(startInput, { target: { value: "2026-01-01" } });
+    fireEvent.change(endInput, { target: { value: "2026-01-31" } });
+
+    fireEvent.click(within(economicTile).getByRole("button", { name: /Exportar/ }));
+
+    await waitFor(() => expect(exportDataMock).toHaveBeenCalledOnce());
+    expect(exportDataMock).toHaveBeenCalledWith(
+      "/exports/economic",
+      expect.objectContaining({
+        type: "economic",
+        startDate: "2026-01-01",
+        endDate: "2026-01-31",
+      }),
+    );
+  });
+
+  it("surfaces the error toast when a tile export fails", async () => {
+    useImportMock.mockReturnValue(makeImportResult(undefined));
+    exportDataMock.mockRejectedValue(new Error("El servidor falló"));
+
+    render(<ImportDataSettingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: /Exportar datos/ }));
+
+    const productsTile = screen.getByTestId("export-tile-products");
+    fireEvent.click(within(productsTile).getByRole("button", { name: /Exportar/ }));
+
+    await waitFor(() => expect(exportDataMock).toHaveBeenCalledOnce());
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith("El servidor falló"));
   });
 });

--- a/frontend/src/app/settings/(data)/data/page.tsx
+++ b/frontend/src/app/settings/(data)/data/page.tsx
@@ -7,17 +7,143 @@ import { ImportSheetProgress } from "@/components/imports/ImportSheetProgress";
 import { ImportSheetErrors } from "@/components/imports/ImportSheetErrors";
 import { useImport } from "@/hooks/useImport";
 import { useToast } from "@/contexts/ToastContext";
-import { getApiErrorMessage } from "@/lib/api";
+import { api, getApiErrorMessage } from "@/lib/api";
 import { Button } from "@/components/ui/Button";
 import { Badge } from "@/components/ui/Badge";
+import { BentoSelect } from "@/components/ui/BentoSelect";
+import { Input } from "@/components/ui/Input";
 import { SettingsCard } from "../../_components/SettingsCard";
 import {
   CheckCircle2,
   Database,
+  Download,
   FileSpreadsheet,
   RefreshCcw,
 } from "lucide-react";
 import type { ImportSheetRowError } from "@/types";
+
+interface ExportTileDefinition {
+  type: string;
+  title: string;
+  description: string;
+  hasDates: boolean;
+}
+
+const EXPORT_TILES: ExportTileDefinition[] = [
+  {
+    type: "products",
+    title: "Productos",
+    description: "Exporta el catálogo de productos y su stock.",
+    hasDates: false,
+  },
+  {
+    type: "sales",
+    title: "Ventas",
+    description: "Exporta las ventas del período seleccionado.",
+    hasDates: true,
+  },
+  {
+    type: "customers",
+    title: "Clientes",
+    description: "Exporta la cartera de clientes registrados.",
+    hasDates: false,
+  },
+  {
+    type: "inventory",
+    title: "Movimientos",
+    description: "Exporta los movimientos de inventario del período.",
+    hasDates: true,
+  },
+  {
+    type: "expenses",
+    title: "Gastos",
+    description: "Exporta los gastos registrados en el negocio.",
+    hasDates: false,
+  },
+  {
+    type: "economic",
+    title: "Económico",
+    description: "Exporta el reporte económico consolidado del período.",
+    hasDates: true,
+  },
+];
+
+const EXPORT_FORMATS: Array<{ value: "excel" | "csv"; label: string }> = [
+  { value: "excel", label: "Excel" },
+  { value: "csv", label: "CSV" },
+];
+
+function ExportTile({ type, title, description, hasDates }: ExportTileDefinition) {
+  const toast = useToast();
+  const [format, setFormat] = useState<"excel" | "csv">("excel");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [exporting, setExporting] = useState(false);
+
+  const handleExport = async () => {
+    setExporting(true);
+    try {
+      await api.exportData(`/exports/${type}`, {
+        format,
+        type,
+        ...(startDate && { startDate }),
+        ...(endDate && { endDate }),
+      });
+      toast.success("Exportación generada correctamente");
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "No se pudo generar la exportación"));
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  return (
+    <div
+      data-testid={`export-tile-${type}`}
+      className="flex flex-col gap-3 rounded-2xl border border-border/60 bg-card p-4"
+    >
+      <div>
+        <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+        <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+      </div>
+
+      <BentoSelect
+        value={format}
+        onChange={(value) => setFormat(value as "excel" | "csv")}
+        placeholder="Formato de exportación"
+        options={EXPORT_FORMATS}
+      />
+
+      {hasDates && (
+        <div className="grid grid-cols-2 gap-2">
+          <Input
+            type="date"
+            label="Desde"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+          />
+          <Input
+            type="date"
+            label="Hasta"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+          />
+        </div>
+      )}
+
+      <Button
+        variant="secondary"
+        size="sm"
+        type="button"
+        onClick={handleExport}
+        loading={exporting}
+        className="w-full shrink-0"
+      >
+        <Download className="w-3.5 h-3.5" aria-hidden="true" /> Exportar
+      </Button>
+    </div>
+  );
+}
 
 export default function ImportDataSettingsPage() {
   const toast = useToast();
@@ -31,6 +157,7 @@ export default function ImportDataSettingsPage() {
   } = useImport({ mode: "full" });
 
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [showExportSection, setShowExportSection] = useState(false);
 
   const status = statusQuery.data;
   const hasStarted = !!startData;
@@ -94,7 +221,7 @@ export default function ImportDataSettingsPage() {
     <div className="space-y-5">
       <div className="flex items-center gap-3 mb-5">
         <div className="w-1 h-6 rounded-full bg-primary shrink-0" />
-        <h2 className="text-xl font-bold text-foreground">Importar datos</h2>
+        <h2 className="text-xl font-bold text-foreground">Importar y exportar datos</h2>
       </div>
 
       <SettingsCard
@@ -200,6 +327,38 @@ export default function ImportDataSettingsPage() {
               Usuarios. Descarga la plantilla para conocer las columnas requeridas.
             </span>
           </div>
+        </div>
+      </SettingsCard>
+
+      <SettingsCard
+        title="Exportar datos"
+        description="Descarga los datos del negocio en formato Excel o CSV"
+        icon={<Download className="w-4 h-4 text-primary" />}
+      >
+        <div className="space-y-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <p className="max-w-xl text-sm text-muted-foreground">
+              Exporta productos, ventas, clientes, movimientos, gastos y el reporte
+              económico consolidado.
+            </p>
+            <Button
+              variant="ghost"
+              type="button"
+              onClick={() => setShowExportSection((current) => !current)}
+              className="w-full sm:w-auto shrink-0"
+            >
+              <Download className="h-4 w-4" aria-hidden="true" />
+              {showExportSection ? "Ocultar exportación" : "Exportar datos"}
+            </Button>
+          </div>
+
+          {showExportSection && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+              {EXPORT_TILES.map((tile) => (
+                <ExportTile key={tile.type} {...tile} />
+              ))}
+            </div>
+          )}
         </div>
       </SettingsCard>
     </div>

--- a/frontend/src/app/settings/layout.behavior.test.tsx
+++ b/frontend/src/app/settings/layout.behavior.test.tsx
@@ -48,7 +48,7 @@ describe("settings sub-sidebar layout", () => {
     expect(
       screen.getByRole("link", { name: "Equipo y acceso" })
     ).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Importar datos" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Importar y exportar datos" })).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Avanzado" })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Facturación" })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Localización" })).not.toBeInTheDocument();

--- a/frontend/src/app/settings/sections.ts
+++ b/frontend/src/app/settings/sections.ts
@@ -34,7 +34,7 @@ export const settingsSections: SettingsSection[] = [
   },
   {
     key: "data",
-    label: "Importar datos",
+    label: "Importar y exportar datos",
     href: "/settings/data",
     icon: Database,
   },


### PR DESCRIPTION
## Context

The multi-sheet importer was moved to an ADMIN-only settings section (PR #95). Per the owner, the plan from the start was to have BOTH import and export from settings. This PR extends that section into a unified **"Importar y exportar datos"** hub: it keeps the importer and adds a consolidated export panel.

## Changes
- Rename the settings "data" section (nav label + page title) to **"Importar y exportar datos"**.
- Add an **"Exportar datos"** card (same toggle pattern as Reports/Expenses: a ghost button that shows/hides the panel) with 6 export tiles:
  - **Productos** (`/exports/products`), **Ventas** (`/exports/sales`), **Clientes** (`/exports/customers`), **Movimientos** (`/exports/inventory`), **Gastos** (`/exports/expenses`), **Económico** (`/exports/economic`).
- Each tile: format selector (Excel/CSV) + optional date range (`Desde`/`Hasta`) for the period-based ones (Ventas, Movimientos, Económico); Export button with loading state.
- Reuses `api.exportData` + existing UI components; **additive** — the Reports and Expenses contextual exports are unchanged.

## Notes
- No `suppliers` tile exists because the backend has no `/exports/suppliers` endpoint.
- Roles: settings is ADMIN-only, so all 6 export types are reachable here (backend also allows MEMBER for `products`/`inventory`, but the section is ADMIN-only).
- Test evidence: frontend 312 passed / 1 pre-existing failure (`CategoryStackedChart.test.tsx`, unrelated). `data/page.test.tsx` 11/11. tsc --noEmit clean; no new lint problems.
