### PR TITLE
refactor(pos): unify quick-amount currency formatting through formatCurrency (S4)

### DIFF
--- a/backend/src/common/constants/locale.constants.spec.ts
+++ b/backend/src/common/constants/locale.constants.spec.ts
@@ -1,0 +1,21 @@
+import { CURRENCY, LOCALE, TIMEZONE } from './locale.constants';
+
+/**
+ * Exact-string characterization tests (S4 task 4.1).
+ * These constants are consumed by settings defaults and the receipts PDF
+ * renderer (golden-equality gated in S3) — a silent change here would alter
+ * every generated receipt and currency default. Lock the exact values.
+ */
+describe('locale.constants', () => {
+  it('exports the COP currency code', () => {
+    expect(CURRENCY).toBe('COP');
+  });
+
+  it('exports the es-CO locale tag', () => {
+    expect(LOCALE).toBe('es-CO');
+  });
+
+  it('exports the America/Bogota IANA timezone', () => {
+    expect(TIMEZONE).toBe('America/Bogota');
+  });
+});

--- a/frontend/src/components/pos/PaymentConfirmationModal.test.tsx
+++ b/frontend/src/components/pos/PaymentConfirmationModal.test.tsx
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
+import type { ComponentProps } from "react";
 import { render, screen } from "@testing-library/react";
 import { PaymentConfirmationModal } from "./PaymentConfirmationModal";
-import type { CartItem, PaymentMethod } from "@/types";
+import type { CartItem } from "@/types";
+
+// PaymentMethod is defined locally (unexported) inside the component; derive it
+// from the component's props so this test's type always matches its contract.
+type PaymentMethod = ComponentProps<typeof PaymentConfirmationModal>["paymentMethods"][number];
 
 /**
  * S4 task 4.1 characterization baseline: locks the CURRENT currency output of

--- a/frontend/src/components/pos/PaymentConfirmationModal.test.tsx
+++ b/frontend/src/components/pos/PaymentConfirmationModal.test.tsx
@@ -9,8 +9,8 @@ import type { CartItem, PaymentMethod } from "@/types";
  * formatCurrency (task 4.2). The summary rows already use formatCurrency, so
  * their assertions must stay IDENTICAL across 4.1 and 4.2 — any change there
  * is drift beyond the user-accepted quick-amount delta (amendment #404-3).
- * The quick-cash buttons render raw `${amount.toLocaleString()}` today;
- * this file documents the before-value ("$10.000" under the es-CO runtime).
+ * The quick-cash buttons used to render a raw, browser-locale dependent
+ * amount; this file documented the before-value ("$10.000" under es-CO).
  */
 
 const mockCartItem: CartItem = {
@@ -83,15 +83,22 @@ describe("PaymentConfirmationModal currency output", () => {
     expect(screen.queryByText("Cambio")).not.toBeInTheDocument();
   });
 
-  it("renders quick cash amounts with the current raw locale output", () => {
+  it("renders quick cash amounts through formatCurrency (deterministic es-CO)", () => {
     render(<PaymentConfirmationModal {...baseProps} />);
 
-    // Before-value (raw toLocaleString, runtime default locale): "$10.000"
-    expect(screen.getByRole("button", { name: "$10.000" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "$20.000" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "$50.000" })).toBeInTheDocument();
+    // After-value (formatCurrency, deterministic es-CO, amendment #404-3):
+    // "$ 10.000" with a no-break space between symbol and amount.
     expect(
-      screen.getByRole("button", { name: "$100.000" }),
+      screen.getByRole("button", { name: `$${NBSP}10.000` }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: `$${NBSP}20.000` }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: `$${NBSP}50.000` }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: `$${NBSP}100.000` }),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/pos/PaymentConfirmationModal.test.tsx
+++ b/frontend/src/components/pos/PaymentConfirmationModal.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PaymentConfirmationModal } from "./PaymentConfirmationModal";
+import type { CartItem, PaymentMethod } from "@/types";
+
+/**
+ * S4 task 4.1 characterization baseline: locks the CURRENT currency output of
+ * the payment confirmation modal before routing the quick-cash buttons through
+ * formatCurrency (task 4.2). The summary rows already use formatCurrency, so
+ * their assertions must stay IDENTICAL across 4.1 and 4.2 — any change there
+ * is drift beyond the user-accepted quick-amount delta (amendment #404-3).
+ * The quick-cash buttons render raw `${amount.toLocaleString()}` today;
+ * this file documents the before-value ("$10.000" under the es-CO runtime).
+ */
+
+const mockCartItem: CartItem = {
+  productId: "prod-1",
+  product: {
+    id: "prod-1",
+    name: "Aceite motor 1L",
+    sku: "ACE-001",
+    barcode: null,
+    description: null,
+    costPrice: 9000,
+    salePrice: 15000,
+    taxRate: 19,
+    stock: 10,
+    minStock: 2,
+    imageUrl: null,
+    categoryId: "cat-1",
+    active: true,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    organizationId: "org-1",
+    version: 1,
+  },
+  quantity: 2,
+  unitPrice: 15000,
+  originalUnitPrice: 15000,
+  availableStock: 10,
+  discountAmount: 0,
+};
+
+const baseProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  onConfirm: vi.fn(),
+  cart: [mockCartItem],
+  subtotal: 45000,
+  taxAmount: 8550,
+  total: 53550,
+  selectedMethod: "CASH" as const,
+  paymentMethods: [{ type: "CASH", amount: 5000 }] as PaymentMethod[],
+  onPaymentMethodChange: vi.fn(),
+};
+
+// formatCurrency inserts a no-break space (U+00A0) after the "$" symbol.
+// Testing Library collapses node whitespace before matching string matchers,
+// so getByText queries use regular spaces. getByRole name matchers preserve
+// the exact accessible name and need the literal NBSP instead.
+const fmtText = (amount: string) => `$ ${amount}`;
+const NBSP = "\u00A0";
+
+describe("PaymentConfirmationModal currency output", () => {
+  it("renders summary amounts through formatCurrency (pre/post invariant)", () => {
+    render(<PaymentConfirmationModal {...baseProps} />);
+
+    // These strings are identical before and after task 4.2 — formatCurrency
+    // output with the es-CO no-break space after the symbol.
+    expect(screen.getByText(fmtText("45.000"))).toBeInTheDocument(); // Subtotal
+    expect(screen.getByText(fmtText("8.550"))).toBeInTheDocument(); // Impuestos
+    expect(screen.getByText(`-${fmtText("0")}`)).toBeInTheDocument(); // Descuentos
+    expect(screen.getByText(fmtText("53.550"))).toBeInTheDocument(); // Total
+    expect(screen.getByText(fmtText("5.000"))).toBeInTheDocument(); // Pagado
+    expect(screen.getByText(fmtText("48.550"))).toBeInTheDocument(); // Faltante
+    expect(
+      screen.getByRole("button", {
+        name: `Completar con Efectivo ($${NBSP}48.550)`,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(fmtText("30.000"))).toBeInTheDocument(); // Cart line total (2 x 15.000)
+    // change = 0 with these props → row absent
+    expect(screen.queryByText("Cambio")).not.toBeInTheDocument();
+  });
+
+  it("renders quick cash amounts with the current raw locale output", () => {
+    render(<PaymentConfirmationModal {...baseProps} />);
+
+    // Before-value (raw toLocaleString, runtime default locale): "$10.000"
+    expect(screen.getByRole("button", { name: "$10.000" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "$20.000" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "$50.000" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "$100.000" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/pos/PaymentConfirmationModal.tsx
+++ b/frontend/src/components/pos/PaymentConfirmationModal.tsx
@@ -321,7 +321,7 @@ export function PaymentConfirmationModal({
                     }}
                     className="text-xs"
                   >
-                    ${amount.toLocaleString()}
+                    {formatCurrency(amount)}
                   </Button>
                 ))}
               </div>

--- a/frontend/src/components/pos/QuickAmountButtons.test.tsx
+++ b/frontend/src/components/pos/QuickAmountButtons.test.tsx
@@ -5,12 +5,12 @@ import { QuickAmountButtons } from "./QuickAmountButtons";
 
 /**
  * S4 task 4.1 characterization baseline: locks the CURRENT currency output
- * before the formatCurrency unification (task 4.2). The bill buttons render
- * raw `${amount.toLocaleString()}`, which is browser-locale dependent — this
- * file documents the before-value ("$10.000" under the es-CO runtime default).
- * Task 4.2 updates the bill-button expectations to the deterministic es-CO
- * formatCurrency output (accepted presentation delta, amendment #404-3).
- * The exact-amount button already uses formatCurrency and must not change.
+ * before the formatCurrency unification (task 4.2). The bill buttons used to
+ * render a raw, browser-locale dependent amount — this file documented the
+ * before-value ("$10.000" under the es-CO runtime default) and task 4.2
+ * updated the expectations to the deterministic es-CO formatCurrency output
+ * (accepted presentation delta, amendment #404-3).
+ * The exact-amount button already used formatCurrency and must not change.
  *
  * Note on exact strings: formatCurrency inserts a no-break space (U+00A0)
  * after the "$" symbol. The accessible name used by getByRole preserves it,
@@ -21,15 +21,22 @@ import { QuickAmountButtons } from "./QuickAmountButtons";
 const NBSP = "\u00A0";
 
 describe("QuickAmountButtons", () => {
-  it("renders bill amounts with the current raw locale output", () => {
+  it("renders bill amounts through formatCurrency (deterministic es-CO)", () => {
     render(<QuickAmountButtons total={50000} onAmountSelect={vi.fn()} />);
 
-    // Before-value (raw toLocaleString, runtime default locale): "$10.000"
-    expect(screen.getByRole("button", { name: "$10.000" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "$20.000" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "$50.000" })).toBeInTheDocument();
+    // After-value (formatCurrency, deterministic es-CO, amendment #404-3):
+    // "$ 10.000" with a no-break space between symbol and amount.
     expect(
-      screen.getByRole("button", { name: "$100.000" }),
+      screen.getByRole("button", { name: `$${NBSP}10.000` }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: `$${NBSP}20.000` }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: `$${NBSP}50.000` }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: `$${NBSP}100.000` }),
     ).toBeInTheDocument();
   });
 
@@ -50,7 +57,7 @@ describe("QuickAmountButtons", () => {
       <QuickAmountButtons total={50000} onAmountSelect={onAmountSelect} />,
     );
 
-    await user.click(screen.getByRole("button", { name: "$20.000" }));
+    await user.click(screen.getByRole("button", { name: `$${NBSP}20.000` }));
 
     expect(onAmountSelect).toHaveBeenCalledWith(20000);
   });

--- a/frontend/src/components/pos/QuickAmountButtons.test.tsx
+++ b/frontend/src/components/pos/QuickAmountButtons.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QuickAmountButtons } from "./QuickAmountButtons";
+
+/**
+ * S4 task 4.1 characterization baseline: locks the CURRENT currency output
+ * before the formatCurrency unification (task 4.2). The bill buttons render
+ * raw `${amount.toLocaleString()}`, which is browser-locale dependent — this
+ * file documents the before-value ("$10.000" under the es-CO runtime default).
+ * Task 4.2 updates the bill-button expectations to the deterministic es-CO
+ * formatCurrency output (accepted presentation delta, amendment #404-3).
+ * The exact-amount button already uses formatCurrency and must not change.
+ *
+ * Note on exact strings: formatCurrency inserts a no-break space (U+00A0)
+ * after the "$" symbol. The accessible name used by getByRole preserves it,
+ * so role-name matchers below use NBSP. (getByText collapses node whitespace
+ * instead — see PaymentConfirmationModal.test.tsx.)
+ */
+
+const NBSP = "\u00A0";
+
+describe("QuickAmountButtons", () => {
+  it("renders bill amounts with the current raw locale output", () => {
+    render(<QuickAmountButtons total={50000} onAmountSelect={vi.fn()} />);
+
+    // Before-value (raw toLocaleString, runtime default locale): "$10.000"
+    expect(screen.getByRole("button", { name: "$10.000" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "$20.000" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "$50.000" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "$100.000" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the exact-amount button through formatCurrency", () => {
+    render(<QuickAmountButtons total={50000} onAmountSelect={vi.fn()} />);
+
+    expect(
+      screen.getByRole("button", {
+        name: `Exacto ($${NBSP}50.000)`,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("selects a bill amount on click", async () => {
+    const user = userEvent.setup();
+    const onAmountSelect = vi.fn();
+    render(
+      <QuickAmountButtons total={50000} onAmountSelect={onAmountSelect} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "$20.000" }));
+
+    expect(onAmountSelect).toHaveBeenCalledWith(20000);
+  });
+});

--- a/frontend/src/components/pos/QuickAmountButtons.tsx
+++ b/frontend/src/components/pos/QuickAmountButtons.tsx
@@ -26,7 +26,7 @@ export function QuickAmountButtons({ total, onAmountSelect, disabled = false }: 
               disabled={disabled}
               className="text-sm hover:scale-105 transition-transform"
             >
-              ${amount.toLocaleString()}
+              {formatCurrency(amount)}
             </Button>
           ))}
         </div>


### PR DESCRIPTION
## Summary

Slice S4 of the perf-refactor change (issue #98): formatter unification. Routes the last two raw currency render sites in the POS through the canonical `formatCurrency` helper (deterministic es-CO output instead of browser-locale-dependent `toLocaleString`), guarded by characterization tests captured before the change.

Two commits, strict TDD:

1. `2fcde19` — **test(pos): capture currency output baseline before formatCurrency unification**
   - `frontend/src/components/pos/QuickAmountButtons.test.tsx` (new): locks the current bill-button output and the already-`formatCurrency` exact-amount button, plus a click-selection behavior test.
   - `frontend/src/components/pos/PaymentConfirmationModal.test.tsx` (new): locks the summary amounts (Subtotal/Impuestos/Descuentos/Total/Pagado/Faltante/Cambio/cart lines) as a pre/post invariant, and the quick-cash button output.
   - `backend/src/common/constants/locale.constants.spec.ts` (new): exact-string characterization for `CURRENCY`/`LOCALE`/`TIMEZONE` (consumed by settings defaults and the S3 receipts PDF renderer).

2. `ade6226` — **refactor(pos): route quick amount buttons through formatCurrency**
   - `QuickAmountButtons.tsx` (bill buttons) and `PaymentConfirmationModal.tsx` (quick-cash buttons) now render `formatCurrency(amount)` instead of a raw locale-dependent amount.
   - Test expectations updated to the deterministic output — **user-accepted presentation delta per amendment #404-3** (quick-amount buttons only).

### Before / after currency strings

| Element | Before (raw, locale-dependent) | After (deterministic es-CO) |
|---|---|---|
| QuickAmountButtons bills (10k/20k/50k/100k) | `$10.000` `$20.000` `$50.000` `$100.000` | `$ 10.000` `$ 20.000` `$ 50.000` `$ 100.000` |
| PaymentConfirmationModal quick-cash buttons | same as above | same as above |

Delta is a single no-break space (U+00A0) between the `$` symbol and the amount, introduced by `formatCurrency`. All other currency values in the modal already used `formatCurrency` and are proven unchanged by the invariant tests.

### Backend scope note

Design D8 listed "delete dead `sales.service` `formatCurrency`" for S4. That dead code (plus the unused `locale.constants` import) was **already deleted in S3** (commit `0a51383`); verified current code has zero `formatCurrency`/`toLocaleString` references in `backend/src/sales/`. No backend code change was needed.

## Chain Context

```
master ── PR #99 (S1 harness + code splitting) — MERGED
              │
         PR #100 (S2 inventory pagination) — OPEN
              │
         PR #101 (S3 receipt extraction) — OPEN
              │
         PR #102 (S4 formatter unification) 📍 — this PR (base master per chain strategy; branch stacked on refactor/s3-receipt-extraction)
              │
         PR 5 (S5 reports tuning) — pending
              │
         PR 6 (S6 audit scoping + pagination helper) — pending
```

- **Start state**: S3 head (`0a51383`), two raw `toLocaleString` render sites in POS.
- **End state**: zero raw `toLocaleString` in POS component source; deterministic es-CO currency output; characterization tests for constants + modal + quick buttons.
- **Out of scope**: `ThermalReceipt.tsx` (byte-protected by the S3 gate); its test helper uses an explicit `"es-CO"` locale in test code only.
- **Follow-up**: S5 (reports query tuning), S6 (audit R3 scoping + pagination helper).

## Verification

- `rg "toLocaleString" frontend/src/components/pos/` → 1 hit, test-only: `ThermalReceipt.test.tsx` regex helper with explicit `"es-CO"` locale (component source clean).
- `npx vitest run src/components/pos` → 5 files / 15 tests passed.
- `npx vitest run src/app/pos` (POS behavior gate) → 24/24 passed.
- `npx vitest run` (full frontend) → 62 files / 330 tests passed.
- `npm run test` (full backend) → 69 suites / 730 tests passed.
- Backend dead-formatter check: `rg "formatCurrency|toLocaleString" backend/src` → only `formatCurrencyCompact` in `receipts.service.ts` (intentional, moved in S3).

## Rollback

Revert this PR entirely: restores the two POS components and removes the three test files. No schema, no shared-module changes, no interaction with S2/S3 diffs.

Refs #98
