### PR TITLE
refactor(common,users): pagination helper + R3-scoped audit migration (S6, cycle close)

### DIFF
--- a/backend/src/common/utils/pagination.spec.ts
+++ b/backend/src/common/utils/pagination.spec.ts
@@ -1,0 +1,57 @@
+import { computeSkipTake } from './pagination';
+
+// Parity baseline: this helper is a drop-in replacement for the inline
+// `const skip = (page - 1) * limit;` + `take: limit` pattern previously
+// duplicated in products.service.findAll and sales.service.findAll.
+// It must reproduce that formula EXACTLY for every input — including
+// out-of-range pages and zero limits — with NO clamping.
+describe('computeSkipTake', () => {
+  const parityCases: Array<[number, number]> = [
+    [1, 10], // first page, default page size
+    [2, 20], // representative matrix case
+    [2, 10],
+    [3, 10],
+    [5, 25],
+    [10, 10],
+    [100, 50], // deep page
+    [1, 1],
+    [1, 100],
+  ];
+
+  it.each(parityCases)(
+    'matches the inline (page - 1) * limit formula for page=%i limit=%i',
+    (page, limit) => {
+      expect(computeSkipTake(page, limit)).toEqual({
+        skip: (page - 1) * limit,
+        take: limit,
+      });
+    },
+  );
+
+  it('does not clamp out-of-range inputs (exact parity with raw arithmetic)', () => {
+    expect(computeSkipTake(0, 10)).toEqual({ skip: -10, take: 10 });
+    expect(computeSkipTake(-1, 10)).toEqual({ skip: -20, take: 10 });
+    expect(computeSkipTake(999, 10)).toEqual({ skip: 9980, take: 10 });
+    expect(computeSkipTake(2, 0)).toEqual({ skip: 0, take: 0 });
+  });
+
+  it('keeps parity on a deterministic pseudo-random sweep', () => {
+    // LCG keeps the sweep reproducible; the parity contract is checked
+    // against the inline computation, not hardcoded expectations.
+    let state = 42;
+    const next = () => {
+      state = (state * 1664525 + 1013904223) % 4294967296;
+      return state / 4294967296;
+    };
+
+    for (let i = 0; i < 100; i += 1) {
+      const page = Math.floor(next() * 500); // 0..499 — includes 0 on purpose
+      const limit = Math.floor(next() * 100) + 1; // 1..100
+
+      expect(computeSkipTake(page, limit)).toEqual({
+        skip: (page - 1) * limit,
+        take: limit,
+      });
+    }
+  });
+});

--- a/backend/src/common/utils/pagination.ts
+++ b/backend/src/common/utils/pagination.ts
@@ -1,0 +1,14 @@
+/**
+ * Pagination parity helper.
+ *
+ * Drop-in replacement for the inline `const skip = (page - 1) * limit;` +
+ * `take: limit` pattern. It reproduces that formula EXACTLY for every input
+ * (no clamping of page or limit) so paginated queries keep byte-identical
+ * Prisma arguments.
+ */
+export function computeSkipTake(
+  page: number,
+  limit: number,
+): { skip: number; take: number } {
+  return { skip: (page - 1) * limit, take: limit };
+}

--- a/backend/src/products/products.service.ts
+++ b/backend/src/products/products.service.ts
@@ -9,6 +9,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { CreateProductDto, UpdateProductDto } from './dto/product.dto';
 import { CloudinaryService } from '../cloudinary/cloudinary.service';
 import { resolveEffectiveTaxRate } from '../common/utils/tax.util';
+import { computeSkipTake } from '../common/utils/pagination';
 import { PlanLimitService } from '../plan-limits/plan-limits.service';
 
 export interface PromoPricingProduct {
@@ -214,7 +215,7 @@ export class ProductsService {
     lowStock?: boolean,
     orderBy: 'name' | 'createdAt' = 'createdAt',
   ) {
-    const skip = (page - 1) * limit;
+    const { skip, take } = computeSkipTake(page, limit);
 
     const where: Record<string, unknown> = { ...(organizationId ? { organizationId } : {}) };
 
@@ -255,7 +256,7 @@ export class ProductsService {
       this.prisma.product.findMany({
         where,
         skip,
-        take: limit,
+        take,
         include: { category: true },
         orderBy: orderByClause,
       }),

--- a/backend/src/sales/sales.service.ts
+++ b/backend/src/sales/sales.service.ts
@@ -17,6 +17,7 @@ import {
 import { CacheService } from '../common/services/cache.service';
 import { SettingsService } from '../settings/settings.service';
 import { resolveEffectiveTaxRate } from '../common/utils/tax.util';
+import { computeSkipTake } from '../common/utils/pagination';
 import { computeEffectiveSalePrice } from '../products/products.service';
 import type { RequestUser } from '../common/interfaces/request-user.interface';
 import { SequenceService } from '../common/sequences/sequence.service';
@@ -299,7 +300,7 @@ export class SalesService {
     customerId?: string,
     user?: RequestUser,
   ) {
-    const skip = (page - 1) * limit;
+    const { skip, take } = computeSkipTake(page, limit);
 
     const where: Record<string, unknown> = {
       ...(organizationId ? { organizationId } : {}),
@@ -357,7 +358,7 @@ export class SalesService {
       this.prisma.sale.findMany({
         where: where as never,
         skip,
-        take: limit,
+        take,
         include: {
           customer: true,
           items: {

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -88,6 +88,8 @@ export class UsersController {
   }
 
   @Post(':id/reset-password')
+  @UseInterceptors(AuditInterceptor)
+  @AuditAction('ADMIN_PASSWORD_RESET')
   @ApiOperation({ summary: 'Reset a user password (Admin only)' })
   resetPassword(
     @Param('id') id: string,

--- a/backend/src/users/users.service.int.spec.ts
+++ b/backend/src/users/users.service.int.spec.ts
@@ -1,0 +1,243 @@
+import 'reflect-metadata';
+import { firstValueFrom, of } from 'rxjs';
+import type { CallHandler, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { PrismaClient, PlanType, OrgRole, Prisma } from '@prisma/client';
+import * as bcrypt from 'bcryptjs';
+import { UsersService } from './users.service';
+import { AuditInterceptor } from '../common/interceptors/audit.interceptor';
+import { AUDIT_ACTION_KEY } from '../common/decorators/audit.decorator';
+
+const prisma = new PrismaClient();
+
+// Audit parity contract: the expected row fields below are the PRE-migration
+// manual `auditLog.create` values that users.service.resetPassword used to
+// write (userId, action, resource, resourceId, metadata summary/targets).
+// The spec proves the route produces ONE row with IDENTICAL values when the
+// audit write moves to AuditInterceptor + attachAuditContext.
+describe('UsersService.resetPassword — Integration (audit parity)', () => {
+  let usersService: UsersService;
+  let auditInterceptor: AuditInterceptor;
+  let orgId: string;
+  let adminId: string;
+  let target1Id: string;
+  let target2Id: string;
+  let target1Email: string;
+  let target2Email: string;
+
+  const runResetPasswordThroughInterceptor = async (
+    targetUserId: string,
+    targetEmail: string,
+  ) => {
+    const dto = { newPassword: 'NuevaClaveSegura123' };
+
+    const request = {
+      method: 'POST',
+      url: `/api/users/${targetUserId}/reset-password`,
+      headers: { 'user-agent': 'jest-audit-parity' },
+      ip: '127.0.0.1',
+      params: { id: targetUserId },
+      body: dto,
+      user: {
+        sub: adminId,
+        email: 'admin-audit@example.com',
+        role: 'ADMIN',
+        organizationId: orgId,
+      },
+    };
+
+    const handler = () => undefined;
+    Reflect.defineMetadata(AUDIT_ACTION_KEY, 'ADMIN_PASSWORD_RESET', handler);
+
+    class UsersRouteFixture {}
+
+    const executionContext = {
+      getHandler: () => handler,
+      getClass: () => UsersRouteFixture,
+      switchToHttp: () => ({
+        getRequest: () => request,
+      }),
+    } as unknown as ExecutionContext;
+
+    const serviceResult = await usersService.resetPassword(
+      adminId,
+      targetUserId,
+      dto,
+      orgId,
+    );
+
+    const next: CallHandler = { handle: () => of(serviceResult) };
+
+    await firstValueFrom(auditInterceptor.intercept(executionContext, next));
+
+    return { serviceResult, targetEmail };
+  };
+
+  const waitForStableAuditRows = async (
+    where: Prisma.AuditLogWhereInput = {
+      organizationId: orgId,
+      action: 'ADMIN_PASSWORD_RESET',
+    },
+  ) => {
+    // The interceptor writes the audit row post-response (fire-and-forget
+    // promise after the observable emits), so poll until the row count is
+    // stable across two consecutive polls.
+    const fetchRows = () =>
+      prisma.auditLog.findMany({
+        where,
+        orderBy: { createdAt: 'asc' },
+      });
+
+    let previous = await fetchRows();
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      const current = await fetchRows();
+      if (current.length === previous.length) {
+        return current;
+      }
+      previous = current;
+    }
+    return previous;
+  };
+
+  beforeAll(async () => {
+    const planLimitServiceStub = { invalidateCache: jest.fn() };
+    usersService = new UsersService(
+      prisma as never,
+      planLimitServiceStub as never,
+    );
+    auditInterceptor = new AuditInterceptor(
+      prisma as never,
+      new Reflector(),
+    );
+
+    const suffix = Date.now();
+    const org = await prisma.organization.create({
+      data: {
+        name: 'Users INT Audit Org',
+        slug: `users-int-audit-${suffix}`,
+        plan: PlanType.BASIC,
+        active: true,
+      },
+    });
+    orgId = org.id;
+
+    const admin = await prisma.user.create({
+      data: {
+        email: `users-int-audit-admin-${suffix}@example.com`,
+        password: 'hash',
+        name: 'Admin User',
+        tokenVersion: 0,
+      },
+    });
+    adminId = admin.id;
+
+    target1Email = `users-int-audit-target1-${suffix}@example.com`;
+    target2Email = `users-int-audit-target2-${suffix}@example.com`;
+
+    const target1 = await prisma.user.create({
+      data: {
+        email: target1Email,
+        password: 'old-hash',
+        name: 'Target One',
+        tokenVersion: 0,
+      },
+    });
+    target1Id = target1.id;
+
+    const target2 = await prisma.user.create({
+      data: {
+        email: target2Email,
+        password: 'old-hash',
+        name: 'Target Two',
+        tokenVersion: 0,
+      },
+    });
+    target2Id = target2.id;
+
+    await prisma.organizationUser.createMany({
+      data: [
+        { userId: adminId, organizationId: orgId, role: OrgRole.ADMIN },
+        { userId: target1Id, organizationId: orgId, role: OrgRole.CASHIER },
+        { userId: target2Id, organizationId: orgId, role: OrgRole.CASHIER },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.auditLog.deleteMany({ where: { organizationId: orgId } });
+    await prisma.organizationUser.deleteMany({
+      where: { organizationId: orgId },
+    });
+    await prisma.user.deleteMany({
+      where: { id: { in: [adminId, target1Id, target2Id] } },
+    });
+    await prisma.organization.deleteMany({ where: { id: orgId } });
+    await prisma.$disconnect();
+  });
+
+  it('produces exactly one audit row identical to the pre-migration manual contract', async () => {
+    const { serviceResult } = await runResetPasswordThroughInterceptor(
+      target1Id,
+      target1Email,
+    );
+
+    // The HTTP contract of the route is unchanged.
+    expect(serviceResult).toEqual({
+      message: 'Contraseña restablecida exitosamente',
+    });
+
+    // The business op itself still rotates the password.
+    const resetUser = await prisma.user.findUnique({
+      where: { id: target1Id },
+    });
+    expect(resetUser?.password).not.toBe('old-hash');
+    expect(
+      await bcrypt.compare('NuevaClaveSegura123', resetUser!.password),
+    ).toBe(true);
+
+    const rows = await waitForStableAuditRows();
+
+    // Parity requires the route to produce EXACTLY ONE audit row. Before the
+    // migration, wiring the interceptor onto the route duplicates the manual
+    // service write with a fallback-context row.
+    expect(rows).toHaveLength(1);
+
+    const row = rows[0];
+    expect(row.userId).toBe(adminId);
+    expect(row.organizationId).toBe(orgId);
+    expect(row.action).toBe('ADMIN_PASSWORD_RESET');
+    expect(row.resource).toBe('User');
+    expect(row.resourceId).toBe(target1Id);
+
+    const metadata = row.metadata as Record<string, unknown>;
+    expect(metadata.summary).toBe(
+      `Reset password for user Target One (${target1Email})`,
+    );
+    expect(metadata.targetUserId).toBe(target1Id);
+    expect(metadata.targetUserEmail).toBe(target1Email);
+    expect(metadata.targetUserName).toBe('Target One');
+    expect(typeof metadata.timestamp).toBe('string');
+  });
+
+  it('derives the audit identity from the actual target user, not from the route URL', async () => {
+    await runResetPasswordThroughInterceptor(target2Id, target2Email);
+
+    const rows = await waitForStableAuditRows({
+      organizationId: orgId,
+      action: 'ADMIN_PASSWORD_RESET',
+      resourceId: target2Id,
+    });
+
+    // One contract row for this reset — not a manual row plus an
+    // interceptor fallback row.
+    expect(rows).toHaveLength(1);
+
+    expect(rows[0].resource).toBe('User');
+
+    const metadata = rows[0].metadata as Record<string, unknown>;
+    expect(metadata.targetUserId).toBe(target2Id);
+    expect(metadata.targetUserEmail).toBe(target2Email);
+    expect(metadata.targetUserName).toBe('Target Two');
+  });
+});

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -194,7 +194,7 @@ describe('UsersService', () => {
     );
   });
 
-  it('resets passwords from the users boundary and records the audit entry', async () => {
+  it('resets passwords from the users boundary and attaches the audit context', async () => {
     prismaMock.user.findUnique.mockResolvedValue({
       id: 'user-2',
       email: 'user2@example.com',
@@ -207,36 +207,34 @@ describe('UsersService', () => {
       organizationId: 'org-1',
     });
     prismaMock.user.update.mockResolvedValue({ id: 'user-2' });
-    prismaMock.auditLog.create.mockResolvedValue({ id: 'audit-1' });
 
-    await expect(
-      service.resetPassword(
-        'admin-1',
-        'user-2',
-        {
-          newPassword: 'NuevaClaveSegura123',
-        },
-        'org-1',
-      ),
-    ).resolves.toEqual({ message: 'Contraseña restablecida exitosamente' });
+    const result = await service.resetPassword(
+      'admin-1',
+      'user-2',
+      {
+        newPassword: 'NuevaClaveSegura123',
+      },
+      'org-1',
+    );
 
+    expect(result).toEqual({ message: 'Contraseña restablecida exitosamente' });
     expect(prismaMock.user.update).toHaveBeenCalledWith({
       where: { id: 'user-2' },
       data: { password: expect.any(String) },
     });
-    expect(prismaMock.auditLog.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          userId: 'admin-1',
-          organizationId: 'org-1',
-          action: 'ADMIN_PASSWORD_RESET',
-          resourceId: 'user-2',
-          metadata: expect.objectContaining({
-            summary: 'Reset password for user User Two (user2@example.com)',
-          }),
-        }),
-      }),
-    );
+    // The audit row is written by AuditInterceptor from this attached
+    // context; the service must not write it manually anymore.
+    expect((result as { __auditContext?: unknown }).__auditContext).toEqual({
+      resource: 'User',
+      resourceId: 'user-2',
+      summary: 'Reset password for user User Two (user2@example.com)',
+      metadata: {
+        targetUserId: 'user-2',
+        targetUserEmail: 'user2@example.com',
+        targetUserName: 'User Two',
+      },
+    });
+    expect(prismaMock.auditLog.create).not.toHaveBeenCalled();
   });
 
   it('filters findAll by organizationId when provided', async () => {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -218,24 +218,22 @@ export class UsersService {
       data: { password: hashedPassword },
     });
 
-    await this.prisma.auditLog.create({
-      data: {
-        userId: adminUserId,
-        organizationId,
-        action: 'ADMIN_PASSWORD_RESET',
+    // The audit row is written by AuditInterceptor (wired on the
+    // reset-password route) from the attached context, reproducing the
+    // pre-migration manual auditLog.create contract exactly.
+    return attachAuditContext(
+      { message: 'Contraseña restablecida exitosamente' },
+      {
         resource: 'User',
         resourceId: userId,
+        summary: `Reset password for user ${targetUser.name} (${targetUser.email})`,
         metadata: {
-          summary: `Reset password for user ${targetUser.name} (${targetUser.email})`,
           targetUserId: userId,
           targetUserEmail: targetUser.email,
           targetUserName: targetUser.name,
-          timestamp: new Date().toISOString(),
         },
       },
-    });
-
-    return { message: 'Contraseña restablecida exitosamente' };
+    );
   }
 
   async remove(adminUserId: string, userId: string, organizationId?: string) {


### PR DESCRIPTION
## Summary

Final slice of the perf-refactor cycle (issue #98). Two independently revertable work units:

1. **Pagination helper** (92a2d4a): `computeSkipTake(page, limit)` in `backend/src/common/utils/pagination.ts` replaces the inline `(page - 1) * limit` + `take: limit` pattern duplicated in `products.service.findAll` and `sales.service.findAll`. Parity-locked by spec: an explicit matrix, out-of-range no-clamp cases, and a 100-pair seeded sweep assert the helper reproduces the raw formula exactly, so Prisma query arguments are unchanged.

2. **Audit migration, R3-scoped** (6f14de2): the reset-password route now goes through `AuditInterceptor` + `@AuditAction('ADMIN_PASSWORD_RESET')`; `users.service.resetPassword` attaches its audit context instead of writing the `auditLog` row manually, matching the convention of the other audited users routes. Scoped per amendment (#404-1 / design D6): the 7 tx-coupled manual audit sites (expenses x6, purchase-orders x1) intentionally stay manual — the interceptor writes post-commit on HTTP routes only, which would break `$transaction` atomicity and drop audit rows for non-HTTP callers.

## Audit parity proof

New integration spec (`backend/src/users/users.service.int.spec.ts`) runs the real `AuditInterceptor` pipeline against real Postgres and asserts the route produces **exactly one** audit row identical to the pre-migration manual contract: `userId`, `action='ADMIN_PASSWORD_RESET'`, `resource='User'`, `resourceId`, and metadata (`summary`, `targetUserId`, `targetUserEmail`, `targetUserName`, `timestamp`). The pre-migration RED demonstrated the failure mode concretely: wiring the interceptor without the service context produced a duplicated fallback row (`resource='Users'`, generic summary, no target metadata).

## Cycle-close summary (S1-S6, issue #98)

| Slice | PR | Delivered | Status |
|---|---|---|---|
| S1 harness + code splitting | #99 | build-size + dev query-timing harnesses; /pos -2.21%, /expenses -4.61% first-load JS | merged |
| S2 inventory pagination | #100 | server-side pagination (page/limit/lowStock/orderBy), bounded requests | merged |
| S3 receipt extraction | #101 | jsPDF confined to `receipts` module behind a PDF-equality golden gate; sales.service 870 -> 597 lines | merged |
| S4 formatter unification | #102 | quick-amount buttons via deterministic es-CO `formatCurrency`; dead backend formatter deleted | merged |
| S5 reports tuning | #103 | `payment.groupBy` at both payment-loop sites (-23 queries workload); 112-test golden gate | open (parallel, independent of S6) |
| S6 audit + pagination | **this PR** | R3-scoped audit migration with parity proof + parity-locked pagination helper | ready for review |

## Verification

- Backend full Jest: **71 suites, 743/743 passed** (DB up, zero failures)
- Frontend full Vitest: **62 files, 330/330 passed**
- Build-size diff: **exit 0** — no route regressed beyond the 1% threshold (frontend unchanged since S4)
- `tsc --noEmit`: backend **68 lines = pre-existing baseline parity** (zero mentions of changed files); frontend **0 errors**

## Chain context

Stacked-to-main chain for #98. S6 was built **from `master`** — independent of S5 per the tasks dependency graph (tasks 6.1-6.4 have no dependency on 5.2).

```
#99 (S1) --- merged
#100 (S2) --- merged
#101 (S3) --- merged
#102 (S4) --- merged
#103 (S5) --- open (parallel)
#106-shaped: THIS PR (S6) --- base: master  <--
```

## Rollback

Each commit reverts independently (disjoint file sets):

- 92a2d4a — removes the helper, restores the inline formula in the two `findAll`s.
- 6f14de2 — restores the manual audit write, removes the interceptor wiring and the int spec.

Refs #98
