### PR TITLE
fix(ci): remove shebang breaking vitest on Windows + sync quarantine comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,13 @@ jobs:
         working-directory: frontend
         run: npx tsc --noEmit
 
-      # TEMPORARY QUARANTINE: 5 pre-existing baseline failures (POS x2,
-      # Sales deep-link x2, admin spinner). continue-on-error keeps the job
-      # green while they are fixed; REMOVE this flag once they pass.
+      # TEMPORARY QUARANTINE: 4 pre-existing baseline test files are excluded
+      # via vitest.config.ts (sales page behavior, admin organizations page,
+      # AuthContext switch, CategoryStackedChart tooltip projection). The
+      # continue-on-error flag is defense-in-depth: it keeps the job green if a
+      # new baseline failure appears. Keep this comment in sync with the
+      # quarantinedBaselineProjects list in frontend/vitest.config.ts and
+      # REMOVE this flag once that list is empty.
       - name: Test (Vitest)
         working-directory: frontend
         continue-on-error: true

--- a/frontend/scripts/build-size.mjs
+++ b/frontend/scripts/build-size.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 // Build-size harness for the MeperPOS frontend.
 //
 // Usage:


### PR DESCRIPTION
Remediation of perf-refactor verify CRITICAL-1 (issue #98 cycle).

## Root cause

px vitest run exited 1 on Windows (Node 24.15.0, vitest 4.1.0): the #!/usr/bin/env node shebang in rontend/scripts/build-size.mjs broke the vitest module runner when the harness test imported the module (SyntaxError at load, 0 tests). CI was green because it runs Node 22, masking the Windows dev-loop break. Root cause proven by controlled experiment during verification (shebang-stripped identical copy loads green).

## Changes
- Remove the shebang from rontend/scripts/build-size.mjs (1 line; the script is invoked via 
ode scripts/build-size.mjs, never executed directly).
- Sync the stale quarantine comment in .github/workflows/ci.yml with the actual quarantinedBaselineProjects list in rontend/vitest.config.ts (verify WARNING-1: comment said '5 failures (POS x2, Sales deep-link x2, admin spinner)', actual list is 4 different files).

## Verification
- 
px vitest run (Windows, Node 24): exit 0 — 62/62 files, 330/330 tests (was exit 1 before the fix).
- No production code touched.

Refs #98