### PR TITLE
test(security): two-org cross-org isolation for cash-registers, imports, products, sales

### DIFF
--- a/backend/src/cash-registers/cash-registers.service.int.spec.ts
+++ b/backend/src/cash-registers/cash-registers.service.int.spec.ts
@@ -1,0 +1,90 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { CashRegistersService } from './cash-registers.service';
+import {
+  setupTwoOrgFixture,
+  type TwoOrgFixture,
+} from '../testing/two-org-fixture';
+
+const planLimitServiceMock = {};
+
+describe('CashRegistersService — Integration (Two-Org Isolation)', () => {
+  let fixture: TwoOrgFixture;
+  let service: CashRegistersService;
+  let registerAId: string;
+  let registerBId: string;
+
+  beforeAll(async () => {
+    fixture = await setupTwoOrgFixture('cash-registers-int');
+    service = new CashRegistersService(
+      fixture.prisma as never,
+      planLimitServiceMock as never,
+    );
+
+    const [registerA, registerB] = await Promise.all([
+      fixture.prisma.cashRegister.create({
+        data: { name: 'Caja A', organizationId: fixture.orgAId },
+      }),
+      fixture.prisma.cashRegister.create({
+        data: { name: 'Caja B', organizationId: fixture.orgBId },
+      }),
+    ]);
+    registerAId = registerA.id;
+    registerBId = registerB.id;
+  });
+
+  afterAll(() =>
+    fixture.teardown(async () => {
+      await fixture.prisma.cashRegister.deleteMany({
+        where: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+      });
+    }),
+  );
+
+  it('cross-org detail read returns 404 and leaks no foreign data', async () => {
+    await expect(
+      service.findOne(registerBId, fixture.orgAId),
+    ).rejects.toThrow(NotFoundException);
+    await expect(
+      service.findOne(registerBId, fixture.orgAId),
+    ).rejects.toThrow('Cash register not found');
+  });
+
+  it('list returns zero foreign-org rows', async () => {
+    const list = await service.findAll(fixture.orgAId);
+    expect(list.map((register) => register.id)).toEqual([registerAId]);
+  });
+
+  it('cross-org update is denied and the foreign row stays unchanged', async () => {
+    await expect(
+      service.update(registerBId, { name: 'Hijacked' }, fixture.orgAId),
+    ).rejects.toThrow(NotFoundException);
+
+    const unchanged = await fixture.prisma.cashRegister.findUniqueOrThrow({
+      where: { id: registerBId },
+    });
+    expect(unchanged.name).toBe('Caja B');
+  });
+
+  it('cross-org delete is denied and the foreign row stays intact', async () => {
+    await expect(
+      service.remove(registerBId, fixture.orgAId),
+    ).rejects.toThrow(NotFoundException);
+
+    const stillThere = await fixture.prisma.cashRegister.findUniqueOrThrow({
+      where: { id: registerBId },
+    });
+    expect(stillThere.name).toBe('Caja B');
+  });
+
+  it('missing organization context is a hard error, never an all-orgs read', async () => {
+    // url-identifier-policy §1: a missing organization context is a hard
+    // error, never an implicit "all organizations" query (expenses
+    // requireOrganizationId convention).
+    await expect(service.findAll(undefined)).rejects.toThrow(
+      BadRequestException,
+    );
+    await expect(
+      service.findOne(registerBId, undefined),
+    ).rejects.toThrow(BadRequestException);
+  });
+});

--- a/backend/src/cash-registers/cash-registers.service.int.spec.ts
+++ b/backend/src/cash-registers/cash-registers.service.int.spec.ts
@@ -41,12 +41,12 @@ describe('CashRegistersService — Integration (Two-Org Isolation)', () => {
   );
 
   it('cross-org detail read returns 404 and leaks no foreign data', async () => {
-    await expect(
-      service.findOne(registerBId, fixture.orgAId),
-    ).rejects.toThrow(NotFoundException);
-    await expect(
-      service.findOne(registerBId, fixture.orgAId),
-    ).rejects.toThrow('Cash register not found');
+    await expect(service.findOne(registerBId, fixture.orgAId)).rejects.toThrow(
+      NotFoundException,
+    );
+    await expect(service.findOne(registerBId, fixture.orgAId)).rejects.toThrow(
+      'Cash register not found',
+    );
   });
 
   it('list returns zero foreign-org rows', async () => {
@@ -66,9 +66,9 @@ describe('CashRegistersService — Integration (Two-Org Isolation)', () => {
   });
 
   it('cross-org delete is denied and the foreign row stays intact', async () => {
-    await expect(
-      service.remove(registerBId, fixture.orgAId),
-    ).rejects.toThrow(NotFoundException);
+    await expect(service.remove(registerBId, fixture.orgAId)).rejects.toThrow(
+      NotFoundException,
+    );
 
     const stillThere = await fixture.prisma.cashRegister.findUniqueOrThrow({
       where: { id: registerBId },
@@ -83,8 +83,8 @@ describe('CashRegistersService — Integration (Two-Org Isolation)', () => {
     await expect(service.findAll(undefined)).rejects.toThrow(
       BadRequestException,
     );
-    await expect(
-      service.findOne(registerBId, undefined),
-    ).rejects.toThrow(BadRequestException);
+    await expect(service.findOne(registerBId, undefined)).rejects.toThrow(
+      BadRequestException,
+    );
   });
 });

--- a/backend/src/cash-registers/cash-registers.service.ts
+++ b/backend/src/cash-registers/cash-registers.service.ts
@@ -18,7 +18,9 @@ export class CashRegistersService {
 
   async create(dto: CreateCashRegisterDto, organizationId: string | undefined) {
     if (!organizationId) {
-      throw new BadRequestException('Organization ID is required for this operation');
+      throw new BadRequestException(
+        'Organization ID is required for this operation',
+      );
     }
     const existing = await this.prisma.cashRegister.findFirst({
       where: { organizationId, name: dto.name },
@@ -81,9 +83,15 @@ export class CashRegistersService {
     return register;
   }
 
-  async update(id: string, dto: UpdateCashRegisterDto, organizationId: string | undefined) {
+  async update(
+    id: string,
+    dto: UpdateCashRegisterDto,
+    organizationId: string | undefined,
+  ) {
     if (!organizationId) {
-      throw new BadRequestException('Organization ID is required for this operation');
+      throw new BadRequestException(
+        'Organization ID is required for this operation',
+      );
     }
     await this.findOne(id, organizationId);
 
@@ -118,7 +126,9 @@ export class CashRegistersService {
 
   async remove(id: string, organizationId: string | undefined) {
     if (!organizationId) {
-      throw new BadRequestException('Organization ID is required for this operation');
+      throw new BadRequestException(
+        'Organization ID is required for this operation',
+      );
     }
     await this.findOne(id, organizationId);
 

--- a/backend/src/cash-registers/cash-registers.service.ts
+++ b/backend/src/cash-registers/cash-registers.service.ts
@@ -50,16 +50,28 @@ export class CashRegistersService {
     return cashRegister;
   }
 
+  private requireOrganizationId(organizationId: string | undefined): string {
+    if (!organizationId) {
+      throw new BadRequestException(
+        'Organization ID is required for this operation',
+      );
+    }
+    return organizationId;
+  }
+
   async findAll(organizationId: string | undefined) {
     return this.prisma.cashRegister.findMany({
-      where: { ...(organizationId ? { organizationId } : {}) },
+      where: { organizationId: this.requireOrganizationId(organizationId) },
       orderBy: { createdAt: 'desc' },
     });
   }
 
   async findOne(id: string, organizationId: string | undefined) {
     const register = await this.prisma.cashRegister.findFirst({
-      where: { id, ...(organizationId ? { organizationId } : {}) },
+      where: {
+        id,
+        organizationId: this.requireOrganizationId(organizationId),
+      },
     });
 
     if (!register) {

--- a/backend/src/expenses/expenses.service.int.spec.ts
+++ b/backend/src/expenses/expenses.service.int.spec.ts
@@ -1,8 +1,7 @@
-import { PrismaClient, Prisma, PlanType } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { formatDateInBogota } from '../common/utils/bogota-date';
 import { ExpensesService } from './expenses.service';
-
-const prisma = new PrismaClient();
+import { setupTwoOrgFixture, type TwoOrgFixture } from '../testing/two-org-fixture';
 
 const cloudinaryServiceMock = {
   uploadImage: jest.fn(),
@@ -10,11 +9,13 @@ const cloudinaryServiceMock = {
 };
 
 describe('ExpensesService — Integration (Isolation + Payments + Summary)', () => {
-  let service: ExpensesService;
+  let prisma: TwoOrgFixture['prisma'];
   let orgAId: string;
   let orgBId: string;
   let userAId: string;
   let userBId: string;
+  let service: ExpensesService;
+  let fixture: TwoOrgFixture;
   let catArriendoId: string;
   let catCajaMenorId: string;
   let catOrgBId: string;
@@ -46,52 +47,17 @@ describe('ExpensesService — Integration (Isolation + Payments + Summary)', () 
   });
 
   beforeAll(async () => {
+    fixture = await setupTwoOrgFixture('expenses-int');
+    prisma = fixture.prisma;
+    orgAId = fixture.orgAId;
+    orgBId = fixture.orgBId;
+    userAId = fixture.userAId;
+    userBId = fixture.userBId;
+
     service = new ExpensesService(
       prisma as never,
       cloudinaryServiceMock as never,
     );
-
-    const [orgA, orgB] = await Promise.all([
-      prisma.organization.create({
-        data: {
-          name: 'Expenses INT Org A',
-          slug: 'expenses-int-a-' + Date.now(),
-          plan: PlanType.BASIC,
-          active: true,
-        },
-      }),
-      prisma.organization.create({
-        data: {
-          name: 'Expenses INT Org B',
-          slug: 'expenses-int-b-' + Date.now(),
-          plan: PlanType.BASIC,
-          active: true,
-        },
-      }),
-    ]);
-    orgAId = orgA.id;
-    orgBId = orgB.id;
-
-    const [userA, userB] = await Promise.all([
-      prisma.user.create({
-        data: {
-          email: 'expenses-int-user-a@example.com',
-          password: 'hash',
-          name: 'Test User A',
-          tokenVersion: 0,
-        },
-      }),
-      prisma.user.create({
-        data: {
-          email: 'expenses-int-user-b@example.com',
-          password: 'hash',
-          name: 'Test User B',
-          tokenVersion: 0,
-        },
-      }),
-    ]);
-    userAId = userA.id;
-    userBId = userB.id;
 
     const [catArriendo, catCajaMenor, catOrgB] = await Promise.all([
       prisma.expenseCategory.create({
@@ -109,27 +75,22 @@ describe('ExpensesService — Integration (Isolation + Payments + Summary)', () 
     catOrgBId = catOrgB.id;
   });
 
-  afterAll(async () => {
-    await prisma.expensePayment.deleteMany({
-      where: { organizationId: { in: [orgAId, orgBId] } },
-    });
-    await prisma.auditLog.deleteMany({
-      where: { organizationId: { in: [orgAId, orgBId] } },
-    });
-    await prisma.expense.deleteMany({
-      where: { organizationId: { in: [orgAId, orgBId] } },
-    });
-    await prisma.expenseCategory.deleteMany({
-      where: { organizationId: { in: [orgAId, orgBId] } },
-    });
-    await prisma.user.deleteMany({
-      where: { id: { in: [userAId, userBId] } },
-    });
-    await prisma.organization.deleteMany({
-      where: { id: { in: [orgAId, orgBId] } },
-    });
-    await prisma.$disconnect();
-  });
+  afterAll(() =>
+    fixture.teardown(async () => {
+      await prisma.expensePayment.deleteMany({
+        where: { organizationId: { in: [orgAId, orgBId] } },
+      });
+      await prisma.auditLog.deleteMany({
+        where: { organizationId: { in: [orgAId, orgBId] } },
+      });
+      await prisma.expense.deleteMany({
+        where: { organizationId: { in: [orgAId, orgBId] } },
+      });
+      await prisma.expenseCategory.deleteMany({
+        where: { organizationId: { in: [orgAId, orgBId] } },
+      });
+    }),
+  );
 
   it('isolates organizations: cross-org reads 404 and lists never leak', async () => {
     const created = await service.create(

--- a/backend/src/expenses/expenses.service.int.spec.ts
+++ b/backend/src/expenses/expenses.service.int.spec.ts
@@ -1,7 +1,9 @@
-import { Prisma } from '@prisma/client';
 import { formatDateInBogota } from '../common/utils/bogota-date';
 import { ExpensesService } from './expenses.service';
-import { setupTwoOrgFixture, type TwoOrgFixture } from '../testing/two-org-fixture';
+import {
+  setupTwoOrgFixture,
+  type TwoOrgFixture,
+} from '../testing/two-org-fixture';
 
 const cloudinaryServiceMock = {
   uploadImage: jest.fn(),

--- a/backend/src/imports/imports.service.int.spec.ts
+++ b/backend/src/imports/imports.service.int.spec.ts
@@ -1,0 +1,111 @@
+import * as ExcelJS from 'exceljs';
+import { NotFoundException } from '@nestjs/common';
+import { ImportsService } from './imports.service';
+import { MultiSheetImportService } from './multi-sheet-import.service';
+import {
+  setupTwoOrgFixture,
+  type TwoOrgFixture,
+} from '../testing/two-org-fixture';
+
+// Handlers are stubbed: isolation specs exercise job ownership, not imports.
+const productsServiceStub = { create: jest.fn() };
+const planLimitsStub = { invalidateCache: jest.fn() };
+
+const NOT_FOUND_MESSAGE = 'No se encontró la importacion solicitada';
+
+const PRODUCTS_CSV = [
+  'Nombre,SKU,Categoria,Precio Venta,Precio Costo,Stock,Stock Minimo',
+  'Producto Org A,SKU-INT-A,General,5000,3500,10,1',
+].join('\n');
+
+async function buildMultiSheetFile(): Promise<Express.Multer.File> {
+  const workbook = new ExcelJS.Workbook();
+  const sheet = workbook.addWorksheet('Productos');
+  sheet.addRow(['Nombre', 'Precio Venta', 'Stock']);
+  sheet.addRow(['Producto Multi Org A', 5000, 10]);
+  const buffer = await workbook.xlsx.writeBuffer();
+  return {
+    originalname: 'full.xlsx',
+    buffer: Buffer.from(buffer as ArrayBuffer),
+  } as unknown as Express.Multer.File;
+}
+
+describe('ImportsService — Integration (Two-Org Isolation)', () => {
+  let fixture: TwoOrgFixture;
+  let service: ImportsService;
+  let multiSheetService: MultiSheetImportService;
+  let jobAId: string;
+  let multiSheetJobAId: string;
+
+  beforeAll(async () => {
+    fixture = await setupTwoOrgFixture('imports-int');
+    service = new ImportsService(
+      fixture.prisma as never,
+      productsServiceStub as never,
+    );
+    multiSheetService = new MultiSheetImportService(
+      fixture.prisma as never,
+      planLimitsStub as never,
+      productsServiceStub as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+
+    const started = await service.startProductsImport(
+      {
+        originalname: 'products.csv',
+        buffer: Buffer.from(PRODUCTS_CSV, 'utf-8'),
+      } as unknown as Express.Multer.File,
+      fixture.userAId,
+      fixture.orgAId,
+    );
+    jobAId = started.jobId;
+
+    const multiSheetStarted = await multiSheetService.startFullImport(
+      await buildMultiSheetFile(),
+      fixture.userAId,
+      fixture.orgAId,
+    );
+    multiSheetJobAId = multiSheetStarted.jobId;
+  });
+
+  afterAll(() => fixture.teardown());
+
+  it('nonexistent job returns 404', () => {
+    expect(() =>
+      service.getImportStatus('missing-job', fixture.userAId),
+    ).toThrow(NotFoundException);
+  });
+
+  it('cross-org job status read returns 404 (same as nonexistent), not 403', () => {
+    expect(() => service.getImportStatus(jobAId, fixture.userBId)).toThrow(
+      NotFoundException,
+    );
+    expect(() => service.getImportStatus(jobAId, fixture.userBId)).toThrow(
+      NOT_FOUND_MESSAGE,
+    );
+  });
+
+  it('cross-org retry is denied with 404 and leaves the job unchanged', async () => {
+    const before = service.getImportStatus(jobAId, fixture.userAId);
+
+    await expect(
+      service.retryImportRow(jobAId, fixture.userBId, {
+        rowIndex: 1,
+        correctedData: {},
+      }),
+    ).rejects.toThrow(NotFoundException);
+
+    const after = service.getImportStatus(jobAId, fixture.userAId);
+    expect(after.importedCount).toBe(before.importedCount);
+    expect(after.errorCount).toBe(before.errorCount);
+    expect(after.status).toBe(before.status);
+  });
+
+  it('multi-sheet cross-org job access returns 404 (not 403)', () => {
+    expect(() =>
+      multiSheetService.getImportStatus(multiSheetJobAId, fixture.userBId),
+    ).toThrow(NotFoundException);
+  });
+});

--- a/backend/src/imports/imports.service.ts
+++ b/backend/src/imports/imports.service.ts
@@ -1,7 +1,6 @@
 import {
   BadRequestException,
   ConflictException,
-  ForbiddenException,
   Injectable,
   NotFoundException,
   OnModuleDestroy,
@@ -990,7 +989,9 @@ export class ImportsService implements OnModuleDestroy {
     }
 
     if (job.userId !== userId) {
-      throw new ForbiddenException('No tienes acceso a esta importacion');
+      // Same response as a nonexistent job: a foreign id must not confirm
+      // existence (url-identifier-policy §5).
+      throw new NotFoundException('No se encontró la importacion solicitada');
     }
 
     return job;

--- a/backend/src/imports/multi-sheet-import.service.ts
+++ b/backend/src/imports/multi-sheet-import.service.ts
@@ -1,7 +1,6 @@
 import {
   BadRequestException,
   ConflictException,
-  ForbiddenException,
   Injectable,
   NotFoundException,
   OnModuleDestroy,
@@ -629,7 +628,9 @@ export class MultiSheetImportService implements OnModuleDestroy {
       throw new NotFoundException('No se encontro la importacion solicitada');
     }
     if (job.userId !== userId) {
-      throw new ForbiddenException('No tienes acceso a esta importacion');
+      // Same response as a nonexistent job: a foreign id must not confirm
+      // existence (url-identifier-policy §5).
+      throw new NotFoundException('No se encontro la importacion solicitada');
     }
     return job;
   }

--- a/backend/src/products/products.service.int.spec.ts
+++ b/backend/src/products/products.service.int.spec.ts
@@ -1,55 +1,46 @@
-import { PrismaClient, Prisma, PlanType } from '@prisma/client';
+import { Prisma, PlanType } from '@prisma/client';
+import { NotFoundException } from '@nestjs/common';
 import { ProductsService } from './products.service';
-
-const prisma = new PrismaClient();
+import {
+  setupTwoOrgFixture,
+  type TwoOrgFixture,
+} from '../testing/two-org-fixture';
 
 // Minimal mocks for dependencies not under test
 const cloudinaryServiceMock = {};
 const planLimitServiceMock = {};
 
 describe('ProductsService — Integration (Query Isolation)', () => {
+  let prisma: TwoOrgFixture['prisma'];
+  let fixture: TwoOrgFixture;
   let service: ProductsService;
-  let org1Id: string;
-  let org2Id: string;
   const sku = 'INT-SKU-' + Date.now();
+  let productAOrgId: string;
+  let productBOrgId: string;
+  let catBOrgId: string;
 
   beforeAll(async () => {
+    fixture = await setupTwoOrgFixture('products-int');
+    prisma = fixture.prisma;
     service = new ProductsService(
       prisma as never,
       cloudinaryServiceMock as never,
       planLimitServiceMock as never,
     );
 
-    // Create two orgs
-    const org1 = await prisma.organization.create({
-      data: {
-        name: 'Org 1 INT',
-        slug: 'org1-int-' + Date.now(),
-        plan: PlanType.BASIC,
-        active: true,
-      },
-    });
-    const org2 = await prisma.organization.create({
-      data: {
-        name: 'Org 2 INT',
-        slug: 'org2-int-' + Date.now(),
-        plan: PlanType.BASIC,
-        active: true,
-      },
-    });
-    org1Id = org1.id;
-    org2Id = org2.id;
-
     // Create category per org
-    const cat1 = await prisma.category.create({
-      data: { name: 'Cat INT 1', organizationId: org1Id, active: true },
-    });
-    const cat2 = await prisma.category.create({
-      data: { name: 'Cat INT 2', organizationId: org2Id, active: true },
-    });
+    const [catA, catB] = await Promise.all([
+      prisma.category.create({
+        data: { name: 'Cat INT A', organizationId: fixture.orgAId, active: true },
+      }),
+      prisma.category.create({
+        data: { name: 'Cat INT B', organizationId: fixture.orgBId, active: true },
+      }),
+    ]);
+    catBOrgId = catB.id;
 
     // Create product with same SKU in both orgs
-    await prisma.product.create({
+    const productA = await prisma.product.create({
       data: {
         name: 'Product Org1',
         sku,
@@ -59,12 +50,13 @@ describe('ProductsService — Integration (Query Isolation)', () => {
         stock: 10,
         minStock: 1,
         active: true,
-        categoryId: cat1.id,
-        organizationId: org1Id,
+        categoryId: catA.id,
+        organizationId: fixture.orgAId,
       },
     });
+    productAOrgId = productA.id;
 
-    await prisma.product.create({
+    const productB = await prisma.product.create({
       data: {
         name: 'Product Org2',
         sku,
@@ -74,34 +66,101 @@ describe('ProductsService — Integration (Query Isolation)', () => {
         stock: 20,
         minStock: 2,
         active: true,
-        categoryId: cat2.id,
-        organizationId: org2Id,
+        categoryId: catB.id,
+        organizationId: fixture.orgBId,
       },
     });
+    productBOrgId = productB.id;
   });
 
-  afterAll(async () => {
-    await prisma.product.deleteMany({ where: { sku } });
-    await prisma.category.deleteMany({
-      where: { name: { in: ['Cat INT 1', 'Cat INT 2'] } },
-    });
-    await prisma.organization.deleteMany({
-      where: { id: { in: [org1Id, org2Id] } },
-    });
-    await prisma.$disconnect();
-  });
+  afterAll(() =>
+    fixture.teardown(async () => {
+      await prisma.product.deleteMany({
+        where: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+      });
+      await prisma.category.deleteMany({
+        where: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+      });
+    }),
+  );
 
   it('should return only the product belonging to the requested organization when searching by SKU', async () => {
     const productOrg1 = await prisma.product.findFirst({
-      where: { sku, organizationId: org1Id },
+      where: { sku, organizationId: fixture.orgAId },
     });
     expect(productOrg1).not.toBeNull();
     expect(productOrg1!.name).toBe('Product Org1');
 
     const productOrg2 = await prisma.product.findFirst({
-      where: { sku, organizationId: org2Id },
+      where: { sku, organizationId: fixture.orgBId },
     });
     expect(productOrg2).not.toBeNull();
     expect(productOrg2!.name).toBe('Product Org2');
+  });
+
+  it('cross-org detail read returns 404 and leaks no foreign data', async () => {
+    await expect(
+      service.findOne(productBOrgId, fixture.orgAId),
+    ).rejects.toThrow(NotFoundException);
+    await expect(
+      service.findOne(productBOrgId, fixture.orgAId),
+    ).rejects.toThrow('Product not found');
+  });
+
+  it('list returns zero foreign-org rows under filters and pagination', async () => {
+    const list = await service.findAll(fixture.orgAId, 1, 10);
+    expect(list.data.map((product) => product.id)).toEqual([productAOrgId]);
+
+    const searched = await service.findAll(
+      fixture.orgAId,
+      1,
+      10,
+      'Product Org2',
+    );
+    expect(searched.data).toHaveLength(0);
+    expect(searched.meta.total).toBe(0);
+
+    const byForeignCategory = await service.findAll(
+      fixture.orgAId,
+      1,
+      10,
+      undefined,
+      catBOrgId,
+    );
+    expect(byForeignCategory.data).toHaveLength(0);
+
+    const paged = await service.findAll(fixture.orgAId, 2, 10);
+    expect(paged.data).toHaveLength(0);
+  });
+
+  it('cross-org update is denied and the foreign row stays unchanged', async () => {
+    await expect(
+      service.update(
+        productBOrgId,
+        { name: 'Hijacked' },
+        fixture.userAId,
+        fixture.orgAId,
+      ),
+    ).rejects.toThrow(NotFoundException);
+
+    const unchanged = await prisma.product.findUniqueOrThrow({
+      where: { id: productBOrgId },
+    });
+    expect(unchanged.name).toBe('Product Org2');
+  });
+
+  it('cross-org deactivate and delete are denied and the foreign row stays intact', async () => {
+    await expect(
+      service.deactivate(productBOrgId, fixture.orgAId),
+    ).rejects.toThrow(NotFoundException);
+    await expect(
+      service.remove(productBOrgId, fixture.orgAId),
+    ).rejects.toThrow(NotFoundException);
+
+    const intact = await prisma.product.findUniqueOrThrow({
+      where: { id: productBOrgId },
+    });
+    expect(intact.active).toBe(true);
+    expect(intact.name).toBe('Product Org2');
   });
 });

--- a/backend/src/products/products.service.int.spec.ts
+++ b/backend/src/products/products.service.int.spec.ts
@@ -1,4 +1,4 @@
-import { Prisma, PlanType } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { NotFoundException } from '@nestjs/common';
 import { ProductsService } from './products.service';
 import {
@@ -31,10 +31,18 @@ describe('ProductsService — Integration (Query Isolation)', () => {
     // Create category per org
     const [catA, catB] = await Promise.all([
       prisma.category.create({
-        data: { name: 'Cat INT A', organizationId: fixture.orgAId, active: true },
+        data: {
+          name: 'Cat INT A',
+          organizationId: fixture.orgAId,
+          active: true,
+        },
       }),
       prisma.category.create({
-        data: { name: 'Cat INT B', organizationId: fixture.orgBId, active: true },
+        data: {
+          name: 'Cat INT B',
+          organizationId: fixture.orgBId,
+          active: true,
+        },
       }),
     ]);
     catBOrgId = catB.id;
@@ -153,9 +161,9 @@ describe('ProductsService — Integration (Query Isolation)', () => {
     await expect(
       service.deactivate(productBOrgId, fixture.orgAId),
     ).rejects.toThrow(NotFoundException);
-    await expect(
-      service.remove(productBOrgId, fixture.orgAId),
-    ).rejects.toThrow(NotFoundException);
+    await expect(service.remove(productBOrgId, fixture.orgAId)).rejects.toThrow(
+      NotFoundException,
+    );
 
     const intact = await prisma.product.findUniqueOrThrow({
       where: { id: productBOrgId },

--- a/backend/src/sales/sales.service.int.spec.ts
+++ b/backend/src/sales/sales.service.int.spec.ts
@@ -1,4 +1,4 @@
-import { Prisma, PlanType } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { NotFoundException } from '@nestjs/common';
 import { SalesService } from './sales.service';
 import { SequenceService } from '../common/sequences/sequence.service';
@@ -52,10 +52,18 @@ describe('SalesService — Integration (Numbering + Isolation)', () => {
     const year = new Date().getFullYear();
     const [categoryA, categoryB] = await Promise.all([
       prisma.category.create({
-        data: { name: 'Sales INT Cat', organizationId: fixture.orgAId, active: true },
+        data: {
+          name: 'Sales INT Cat',
+          organizationId: fixture.orgAId,
+          active: true,
+        },
       }),
       prisma.category.create({
-        data: { name: 'Sales INT Cat B', organizationId: fixture.orgBId, active: true },
+        data: {
+          name: 'Sales INT Cat B',
+          organizationId: fixture.orgBId,
+          active: true,
+        },
       }),
     ]);
 
@@ -145,10 +153,14 @@ describe('SalesService — Integration (Numbering + Isolation)', () => {
   afterAll(() =>
     fixture.teardown(async () => {
       await prisma.saleItem.deleteMany({
-        where: { sale: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } } },
+        where: {
+          sale: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+        },
       });
       await prisma.payment.deleteMany({
-        where: { sale: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } } },
+        where: {
+          sale: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+        },
       });
       await prisma.sale.deleteMany({
         where: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
@@ -175,8 +187,16 @@ describe('SalesService — Integration (Numbering + Isolation)', () => {
     const dto1 = buildSaleDto(productId, customerId);
     const dto2 = buildSaleDto(productId, customerId);
 
-    const sale1 = await salesService.create(dto1, fixture.userAId, fixture.orgAId);
-    const sale2 = await salesService.create(dto2, fixture.userAId, fixture.orgAId);
+    const sale1 = await salesService.create(
+      dto1,
+      fixture.userAId,
+      fixture.orgAId,
+    );
+    const sale2 = await salesService.create(
+      dto2,
+      fixture.userAId,
+      fixture.orgAId,
+    );
 
     expect(sale1.saleNumber).toBe(1);
     expect(sale2.saleNumber).toBe(2);

--- a/backend/src/sales/sales.service.int.spec.ts
+++ b/backend/src/sales/sales.service.int.spec.ts
@@ -1,24 +1,39 @@
-import { PrismaClient, Prisma, PlanType } from '@prisma/client';
+import { Prisma, PlanType } from '@prisma/client';
+import { NotFoundException } from '@nestjs/common';
 import { SalesService } from './sales.service';
 import { SequenceService } from '../common/sequences/sequence.service';
 import { CacheService } from '../common/services/cache.service';
 import { SettingsService } from '../settings/settings.service';
 import { ReceiptsService } from '../receipts/receipts.service';
-
-const prisma = new PrismaClient();
+import {
+  setupTwoOrgFixture,
+  type TwoOrgFixture,
+} from '../testing/two-org-fixture';
 
 const cloudinaryServiceMock = {
   uploadImage: jest.fn(),
 };
 
 describe('SalesService — Integration (Numbering + Isolation)', () => {
+  let prisma: TwoOrgFixture['prisma'];
+  let fixture: TwoOrgFixture;
   let salesService: SalesService;
-  let orgId: string;
-  let userId: string;
   let productId: string;
   let customerId: string;
+  let productBOrgId: string;
+  let customerBOrgId: string;
+  let saleBOrgId: string;
+
+  const buildSaleDto = (productId: string, customerId: string) => ({
+    customerId,
+    items: [{ productId, quantity: 1 }],
+    payments: [{ method: 'CASH' as const, amount: 1190 }],
+  });
 
   beforeAll(async () => {
+    fixture = await setupTwoOrgFixture('sales-int');
+    prisma = fixture.prisma;
+
     const settingsService = new SettingsService(
       prisma as never,
       cloudinaryServiceMock as never,
@@ -34,115 +49,193 @@ describe('SalesService — Integration (Numbering + Isolation)', () => {
       new ReceiptsService(),
     );
 
-    // Create org
-    const org = await prisma.organization.create({
-      data: {
-        name: 'Sales INT Org',
-        slug: 'sales-int-' + Date.now(),
-        plan: PlanType.BASIC,
-        active: true,
-      },
-    });
-    orgId = org.id;
-
-    // Create user
-    const user = await prisma.user.create({
-      data: {
-        email: 'sales-int-user@example.com',
-        password: 'hash',
-        name: 'Test User',
-        tokenVersion: 0,
-      },
-    });
-    userId = user.id;
-
-    // Create category + product
-    const category = await prisma.category.create({
-      data: { name: 'Sales INT Cat', organizationId: orgId, active: true },
-    });
-    const product = await prisma.product.create({
-      data: {
-        name: 'Sales INT Product',
-        sku: 'SALES-SKU-' + Date.now(),
-        salePrice: new Prisma.Decimal(1000),
-        costPrice: new Prisma.Decimal(500),
-        taxRate: new Prisma.Decimal(19),
-        stock: 100,
-        minStock: 1,
-        active: true,
-        categoryId: category.id,
-        organizationId: orgId,
-      },
-    });
-    productId = product.id;
-
-    // Create customer
-    const customer = await prisma.customer.create({
-      data: {
-        name: 'Sales INT Customer',
-        documentType: 'CC',
-        documentNumber: '12345678',
-        organizationId: orgId,
-        active: true,
-      },
-    });
-    customerId = customer.id;
-
-    // Ensure sequence exists
     const year = new Date().getFullYear();
-    await prisma.organizationSequence.create({
-      data: {
-        organizationId: orgId,
-        type: 'SALE',
-        prefix: 'REC',
-        currentNumber: 0,
-        year,
-      },
+    const [categoryA, categoryB] = await Promise.all([
+      prisma.category.create({
+        data: { name: 'Sales INT Cat', organizationId: fixture.orgAId, active: true },
+      }),
+      prisma.category.create({
+        data: { name: 'Sales INT Cat B', organizationId: fixture.orgBId, active: true },
+      }),
+    ]);
+
+    const [productA, productB] = await Promise.all([
+      prisma.product.create({
+        data: {
+          name: 'Sales INT Product',
+          sku: 'SALES-SKU-' + Date.now(),
+          salePrice: new Prisma.Decimal(1000),
+          costPrice: new Prisma.Decimal(500),
+          taxRate: new Prisma.Decimal(19),
+          stock: 100,
+          minStock: 1,
+          active: true,
+          categoryId: categoryA.id,
+          organizationId: fixture.orgAId,
+        },
+      }),
+      prisma.product.create({
+        data: {
+          name: 'Sales INT Product B',
+          sku: 'SALES-SKU-B-' + Date.now(),
+          salePrice: new Prisma.Decimal(1000),
+          costPrice: new Prisma.Decimal(500),
+          taxRate: new Prisma.Decimal(19),
+          stock: 100,
+          minStock: 1,
+          active: true,
+          categoryId: categoryB.id,
+          organizationId: fixture.orgBId,
+        },
+      }),
+    ]);
+    productId = productA.id;
+    productBOrgId = productB.id;
+
+    const [customerA, customerB] = await Promise.all([
+      prisma.customer.create({
+        data: {
+          name: 'Sales INT Customer',
+          documentType: 'CC',
+          documentNumber: '12345678',
+          organizationId: fixture.orgAId,
+          active: true,
+        },
+      }),
+      prisma.customer.create({
+        data: {
+          name: 'Sales INT Customer B',
+          documentType: 'CC',
+          documentNumber: '87654321',
+          organizationId: fixture.orgBId,
+          active: true,
+        },
+      }),
+    ]);
+    customerId = customerA.id;
+    customerBOrgId = customerB.id;
+
+    await prisma.organizationSequence.createMany({
+      data: [
+        {
+          organizationId: fixture.orgAId,
+          type: 'SALE',
+          prefix: 'REC',
+          currentNumber: 0,
+          year,
+        },
+        {
+          organizationId: fixture.orgBId,
+          type: 'SALE',
+          prefix: 'RECB',
+          currentNumber: 0,
+          year,
+        },
+      ],
     });
+
+    const saleB = await salesService.create(
+      buildSaleDto(productBOrgId, customerBOrgId),
+      fixture.userBId,
+      fixture.orgBId,
+    );
+    saleBOrgId = saleB.id;
   });
 
-  afterAll(async () => {
-    await prisma.saleItem.deleteMany({
-      where: { sale: { organizationId: orgId } },
-    });
-    await prisma.payment.deleteMany({
-      where: { sale: { organizationId: orgId } },
-    });
-    await prisma.sale.deleteMany({ where: { organizationId: orgId } });
-    await prisma.inventoryMovement.deleteMany({
-      where: { organizationId: orgId },
-    });
-    await prisma.product.deleteMany({ where: { organizationId: orgId } });
-    await prisma.category.deleteMany({ where: { organizationId: orgId } });
-    await prisma.customer.deleteMany({ where: { organizationId: orgId } });
-    await prisma.organizationSequence.deleteMany({
-      where: { organizationId: orgId },
-    });
-    await prisma.organizationUser.deleteMany({
-      where: { organizationId: orgId },
-    });
-    await prisma.user.deleteMany({ where: { id: userId } });
-    await prisma.organization.deleteMany({ where: { id: orgId } });
-    await prisma.$disconnect();
-  });
+  afterAll(() =>
+    fixture.teardown(async () => {
+      await prisma.saleItem.deleteMany({
+        where: { sale: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } } },
+      });
+      await prisma.payment.deleteMany({
+        where: { sale: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } } },
+      });
+      await prisma.sale.deleteMany({
+        where: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+      });
+      await prisma.inventoryMovement.deleteMany({
+        where: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+      });
+      await prisma.product.deleteMany({
+        where: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+      });
+      await prisma.category.deleteMany({
+        where: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+      });
+      await prisma.customer.deleteMany({
+        where: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+      });
+      await prisma.organizationSequence.deleteMany({
+        where: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+      });
+    }),
+  );
 
   it('should assign consecutive saleNumbers for two sales in the same org', async () => {
-    const dto1 = {
-      customerId,
-      items: [{ productId, quantity: 1 }],
-      payments: [{ method: 'CASH' as const, amount: 1190 }],
-    };
+    const dto1 = buildSaleDto(productId, customerId);
+    const dto2 = buildSaleDto(productId, customerId);
 
-    const dto2 = {
-      customerId,
-      items: [{ productId, quantity: 1 }],
-      payments: [{ method: 'CASH' as const, amount: 1190 }],
-    };
-
-    const sale1 = await salesService.create(dto1, userId, orgId);
-    const sale2 = await salesService.create(dto2, userId, orgId);
+    const sale1 = await salesService.create(dto1, fixture.userAId, fixture.orgAId);
+    const sale2 = await salesService.create(dto2, fixture.userAId, fixture.orgAId);
 
     expect(sale1.saleNumber).toBe(1);
     expect(sale2.saleNumber).toBe(2);
+  });
+
+  it('cross-org detail read returns 404 and leaks no foreign data', async () => {
+    await expect(
+      salesService.findOne(saleBOrgId, fixture.orgAId),
+    ).rejects.toThrow(NotFoundException);
+    await expect(
+      salesService.findOne(saleBOrgId, fixture.orgAId),
+    ).rejects.toThrow('Sale not found');
+  });
+
+  it('list returns zero foreign-org rows under filters and pagination', async () => {
+    const listA = await salesService.findAll(fixture.orgAId, 1, 10);
+    expect(
+      listA.data.every((sale) => sale.organizationId === fixture.orgAId),
+    ).toBe(true);
+    expect(listA.data.some((sale) => sale.id === saleBOrgId)).toBe(false);
+
+    const listB = await salesService.findAll(fixture.orgBId, 1, 10);
+    expect(listB.data.map((sale) => sale.id)).toEqual([saleBOrgId]);
+
+    const searched = await salesService.findAll(
+      fixture.orgAId,
+      1,
+      10,
+      undefined,
+      undefined,
+      undefined,
+      'Sales INT Customer B',
+    );
+    expect(searched.data).toHaveLength(0);
+    expect(searched.meta.total).toBe(0);
+
+    const paged = await salesService.findAll(fixture.orgBId, 2, 10);
+    expect(paged.data).toHaveLength(0);
+  });
+
+  it('cross-org update is denied and the foreign row stays unchanged', async () => {
+    const before = await prisma.sale.findUniqueOrThrow({
+      where: { id: saleBOrgId },
+    });
+
+    await expect(
+      salesService.update(
+        saleBOrgId,
+        { status: 'CANCELLED', cancelReason: 'cross-org try' },
+        fixture.userAId,
+        fixture.orgAId,
+      ),
+    ).rejects.toThrow(NotFoundException);
+
+    const after = await prisma.sale.findUniqueOrThrow({
+      where: { id: saleBOrgId },
+    });
+    expect(after.status).toBe('COMPLETED');
+    expect(after.cancelReason).toBeNull();
+    expect(after.updatedAt.getTime()).toBe(before.updatedAt.getTime());
   });
 });

--- a/backend/src/testing/two-org-fixture.ts
+++ b/backend/src/testing/two-org-fixture.ts
@@ -1,0 +1,100 @@
+import { PlanType, PrismaClient } from '@prisma/client';
+
+/**
+ * Shared two-organization integration fixture.
+ *
+ * Extracted from the expenses service integration spec pattern: a real
+ * PrismaClient, two organizations plus two users created in `beforeAll`, and
+ * deleteMany cleanup in `afterAll`. Family specs pass their own row-level
+ * deleteMany chain as the teardown's `extraCleanup` so children are removed
+ * before the fixture users and organizations.
+ */
+export interface OrgActor {
+  organizationId: string;
+  userId: string;
+}
+
+export interface TwoOrgFixture {
+  prisma: PrismaClient;
+  orgAId: string;
+  orgBId: string;
+  userAId: string;
+  userBId: string;
+  /** Credential bundle to act as an org-A or org-B user in service calls. */
+  actAs(org: 'A' | 'B'): OrgActor;
+  /**
+   * Runs the family's own cleanup first (children before parents), then
+   * removes the fixture users and organizations and disconnects the client.
+   */
+  teardown(extraCleanup?: () => Promise<void>): Promise<void>;
+}
+
+export async function setupTwoOrgFixture(
+  label: string,
+): Promise<TwoOrgFixture> {
+  const prisma = new PrismaClient();
+  const unique = `${label}-${Date.now()}`;
+
+  const [orgA, orgB] = await Promise.all([
+    prisma.organization.create({
+      data: {
+        name: `${label} Org A`,
+        slug: `${unique}-org-a`,
+        plan: PlanType.BASIC,
+        active: true,
+      },
+    }),
+    prisma.organization.create({
+      data: {
+        name: `${label} Org B`,
+        slug: `${unique}-org-b`,
+        plan: PlanType.BASIC,
+        active: true,
+      },
+    }),
+  ]);
+
+  const [userA, userB] = await Promise.all([
+    prisma.user.create({
+      data: {
+        email: `${unique}-user-a@example.com`,
+        password: 'hash',
+        name: 'Test User A',
+        tokenVersion: 0,
+      },
+    }),
+    prisma.user.create({
+      data: {
+        email: `${unique}-user-b@example.com`,
+        password: 'hash',
+        name: 'Test User B',
+        tokenVersion: 0,
+      },
+    }),
+  ]);
+
+  return {
+    prisma,
+    orgAId: orgA.id,
+    orgBId: orgB.id,
+    userAId: userA.id,
+    userBId: userB.id,
+    actAs(org) {
+      return org === 'A'
+        ? { organizationId: orgA.id, userId: userA.id }
+        : { organizationId: orgB.id, userId: userB.id };
+    },
+    async teardown(extraCleanup) {
+      if (extraCleanup) {
+        await extraCleanup();
+      }
+      await prisma.user.deleteMany({
+        where: { id: { in: [userA.id, userB.id] } },
+      });
+      await prisma.organization.deleteMany({
+        where: { id: { in: [orgA.id, orgB.id] } },
+      });
+      await prisma.$disconnect();
+    },
+  };
+}


### PR DESCRIPTION
Part of #48 (security-hardening) — **PR 1 of 6**, slice A1 of the org-authorization-audit phase (stacked-to-main chain, base: master).

## Scope
- **Shared two-org fixture** (\ackend/src/testing/two-org-fixture.ts\): real PrismaClient, two organizations + users in \eforeAll\, deleteMany cleanup in \fterAll\, \ctAs(A|B)\ helpers — extracted from the \expenses.service.int.spec.ts\ pattern. Expenses/products/sales int-specs refactored onto it with zero assertion changes (pre-existing tests stay green byte-for-byte).
- **Isolation specs (spec 1.R1/1.R2)** for four families: cross-org detail read → 404 + no foreign data in body; lists → zero foreign-org rows under filters/pagination; cross-org mutation → 404 + target row unchanged.

## TDD evidence (strict RED on master → minimal GREEN)
| Family | RED on master? | Exact failure reason | Fix |
|---|---|---|---|
| cash-registers | YES (genuine gap) | \indAll(undefined)\ resolved rows from 4 different organizations; \indOne(id, undefined)\ resolves foreign rows — missing-org context silently degrades to an all-orgs query (violates url-identifier-policy §1) | \equireOrganizationId\ (expenses convention) on read paths (35f9bcf) |
| imports | YES (genuine gap) | Foreign-user job access threw \ForbiddenException\ (403 existence leak) at \imports.service.ts:993\ and \multi-sheet-import.service.ts:632\; spec 1.R1 requires 404, same as nonexistent (policy §5) | Both \getJobOrThrow\s now return the identical 404 as a nonexistent job (fad15e5) |
| products | no gap found | 5/5 passed on master — kept as full-strength regression spec | none |
| sales | no gap found | 4/4 passed on master — kept as full-strength regression spec | none |

## Verification
- RED run against pre-fix behavior: cash-registers 1 failing / imports 3 failing, with the exact reasons above.
- GREEN gate: \cd backend && npm run test\ → **74 suites / 787 tests, all green** (includes 22 tests across the five int-spec families).
- ESLint clean on all touched files (pre-existing warnings in untouched import-service code left alone).

## Chain context
- 📍 **This PR (1/6)**: fixture + isolation specs for cash-registers, imports, products, sales
- PR 2 (A2): isolation specs for customers, categories, suppliers, purchase-orders + \docs/authorization-matrix.md\ + matrix-coverage spec
- PR 3–6: security-header verification → auth-token tightening → global-user privacy → secrets-runbook repair
- Rollback: revert this PR — tests/docs only; runtime delta is limited to the two minimal service fixes (cash-registers read-path org guard; imports 404 conversion)

## Notes / follow-ups recorded for A2
- \cash-registers.countByOrg\ (currently zero callers) and the missing-org read paths of \products\ (findAll/findOne/searchProducts/quickSearch) and \sales\ (findAll/findOne) still tolerate undefined organization context (same policy §1 class). Left untouched: this slice fixes only the spec-asserted denial gaps (no refactors, no drive-by changes). No list endpoints exist for imports (in-memory jobs) — the mutation surface is retry-row, covered.