### PR TITLE
test(security): two-org isolation for customers, categories, suppliers, purchase-orders + living authz matrix

### DIFF
--- a/backend/src/categories/categories.service.int.spec.ts
+++ b/backend/src/categories/categories.service.int.spec.ts
@@ -1,0 +1,90 @@
+import { NotFoundException } from '@nestjs/common';
+import { CategoriesService } from './categories.service';
+import {
+  setupTwoOrgFixture,
+  type TwoOrgFixture,
+} from '../testing/two-org-fixture';
+
+describe('CategoriesService — Integration (Query Isolation)', () => {
+  let prisma: TwoOrgFixture['prisma'];
+  let fixture: TwoOrgFixture;
+  let service: CategoriesService;
+  let categoryAOrgId: string;
+  let categoryBOrgId: string;
+
+  beforeAll(async () => {
+    fixture = await setupTwoOrgFixture('categories-int');
+    prisma = fixture.prisma;
+    service = new CategoriesService(prisma as never);
+
+    const categoryA = await prisma.category.create({
+      data: {
+        name: 'Cat INT A',
+        organizationId: fixture.orgAId,
+        active: true,
+      },
+    });
+    categoryAOrgId = categoryA.id;
+
+    const categoryB = await prisma.category.create({
+      data: {
+        name: 'Cat INT B',
+        organizationId: fixture.orgBId,
+        active: true,
+      },
+    });
+    categoryBOrgId = categoryB.id;
+  });
+
+  afterAll(() =>
+    fixture.teardown(async () => {
+      await prisma.category.deleteMany({
+        where: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+      });
+    }),
+  );
+
+  it('cross-org detail read returns 404 and leaks no foreign data', async () => {
+    await expect(
+      service.findOne(categoryBOrgId, fixture.orgAId),
+    ).rejects.toThrow(NotFoundException);
+    await expect(
+      service.findOne(categoryBOrgId, fixture.orgAId),
+    ).rejects.toThrow('Category not found');
+  });
+
+  it('list returns zero foreign-org rows under search and pagination', async () => {
+    const list = await service.findAll(fixture.orgAId, 1, 10);
+    expect(list.data.map((category) => category.id)).toEqual([categoryAOrgId]);
+
+    const searched = await service.findAll(fixture.orgAId, 1, 10, 'Cat INT B');
+    expect(searched.data).toHaveLength(0);
+    expect(searched.meta.total).toBe(0);
+
+    const paged = await service.findAll(fixture.orgAId, 2, 10);
+    expect(paged.data).toHaveLength(0);
+  });
+
+  it('cross-org update is denied and the foreign row stays unchanged', async () => {
+    await expect(
+      service.update(categoryBOrgId, { name: 'Hijacked' }, fixture.orgAId),
+    ).rejects.toThrow(NotFoundException);
+
+    const unchanged = await prisma.category.findUniqueOrThrow({
+      where: { id: categoryBOrgId },
+    });
+    expect(unchanged.name).toBe('Cat INT B');
+  });
+
+  it('cross-org delete is denied and the foreign row stays intact', async () => {
+    await expect(
+      service.remove(categoryBOrgId, fixture.orgAId),
+    ).rejects.toThrow(NotFoundException);
+
+    const intact = await prisma.category.findUniqueOrThrow({
+      where: { id: categoryBOrgId },
+    });
+    expect(intact.active).toBe(true);
+    expect(intact.name).toBe('Cat INT B');
+  });
+});

--- a/backend/src/common/matrix-coverage.spec.ts
+++ b/backend/src/common/matrix-coverage.spec.ts
@@ -1,0 +1,131 @@
+import { NestFactory } from '@nestjs/core';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { AppModule } from '../app.module';
+
+/**
+ * Living authorization-matrix coverage gate (issue #48, spec 1.R3).
+ *
+ * Builds the OpenAPI document from AppModule exactly like main.ts does, then
+ * asserts that:
+ *  1. every path×method exposed by the backend has a row in
+ *     docs/authorization-matrix.md, and
+ *  2. every test file referenced by a matrix row exists on disk.
+ *
+ * Route drift (a new/renamed/removed endpoint without a matrix update) or a
+ * stale test reference fails the suite, and therefore CI.
+ */
+
+// __dirname = backend/src/common → repository root is three levels up.
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const MATRIX_PATH = path.join(REPO_ROOT, 'docs', 'authorization-matrix.md');
+
+interface MatrixRow {
+  route: string;
+  method: string;
+  testReference: string | null;
+}
+
+function parseMatrixMarkdown(content: string): MatrixRow[] {
+  const rows: MatrixRow[] = [];
+
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    // Route rows look like: | /api/products | GET | ADMIN, MEMBER | org-scoped | backend/src/... |
+    if (!trimmed.startsWith('| /')) {
+      continue;
+    }
+
+    const cells = trimmed
+      .split('|')
+      .map((cell) => cell.trim())
+      .filter((cell) => cell.length > 0);
+
+    if (cells.length < 5) {
+      continue;
+    }
+
+    const [route, method, , , testReference] = cells;
+    rows.push({
+      route,
+      method: method.toUpperCase(),
+      testReference: testReference === '—' ? null : testReference,
+    });
+  }
+
+  return rows;
+}
+
+function buildMatrixKey(route: string, method: string): string {
+  return `${method} ${route}`;
+}
+
+/**
+ * Normalizes an OpenAPI path to the matrix's human-facing convention:
+ * the global `api` prefix is prepended (SwaggerModule documents routes
+ * without it) and `{param}` braces become `:param`.
+ */
+function openApiPathToMatrixRoute(openApiPath: string): string {
+  const matrixPath = openApiPath.replace(/\{([^}]+)\}/g, ':$1');
+  return `/api${matrixPath === '/' ? '' : matrixPath}`;
+}
+
+describe('Authorization matrix coverage (docs/authorization-matrix.md)', () => {
+  let openApiKeys: string[];
+  let matrixRows: MatrixRow[];
+
+  beforeAll(async () => {
+    const app = await NestFactory.create(AppModule, { logger: false });
+    try {
+      const config = new DocumentBuilder()
+        .setTitle('MeperPOS API')
+        .setVersion('1.0')
+        .build();
+      const document = SwaggerModule.createDocument(app, config);
+
+      openApiKeys = Object.entries(document.paths ?? {}).flatMap(
+        ([route, methods]) =>
+          Object.keys(methods as Record<string, unknown>)
+            .filter((method) => method !== 'parameters')
+            .map((method) =>
+              buildMatrixKey(
+                openApiPathToMatrixRoute(route),
+                method.toUpperCase(),
+              ),
+            ),
+      );
+    } finally {
+      await app.close();
+    }
+
+    matrixRows = parseMatrixMarkdown(fs.readFileSync(MATRIX_PATH, 'utf-8'));
+  });
+
+  it('backend exposes at least one route for the coverage gate to be meaningful', () => {
+    expect(openApiKeys.length).toBeGreaterThan(0);
+  });
+
+  it('matrix contains at least one route row for the coverage gate to be meaningful', () => {
+    expect(matrixRows.length).toBeGreaterThan(0);
+  });
+
+  it('every OpenAPI path×method has a row in the matrix', () => {
+    const matrixKeys = new Set(
+      matrixRows.map((row) => buildMatrixKey(row.route, row.method)),
+    );
+
+    const missing = openApiKeys.filter((key) => !matrixKeys.has(key));
+
+    expect(missing).toEqual([]);
+  });
+
+  it('every test file referenced by a matrix row exists on disk', () => {
+    const missingReferences = matrixRows
+      .filter((row) => row.testReference !== null)
+      .filter((row) => !fs.existsSync(path.join(REPO_ROOT, row.testReference!)))
+      .map((row) => `${row.method} ${row.route} → ${row.testReference}`);
+
+    expect(missingReferences).toEqual([]);
+  });
+});

--- a/backend/src/customers/customers.service.int.spec.ts
+++ b/backend/src/customers/customers.service.int.spec.ts
@@ -1,0 +1,113 @@
+import { NotFoundException } from '@nestjs/common';
+import { CustomersService } from './customers.service';
+import {
+  setupTwoOrgFixture,
+  type TwoOrgFixture,
+} from '../testing/two-org-fixture';
+
+// Minimal mock for the dependency not under test (only invalidateCache is used)
+const planLimitServiceMock = {};
+
+describe('CustomersService — Integration (Query Isolation)', () => {
+  let prisma: TwoOrgFixture['prisma'];
+  let fixture: TwoOrgFixture;
+  let service: CustomersService;
+  const documentNumber = 'INT-DOC-' + Date.now();
+  let customerAOrgId: string;
+  let customerBOrgId: string;
+
+  beforeAll(async () => {
+    fixture = await setupTwoOrgFixture('customers-int');
+    prisma = fixture.prisma;
+    service = new CustomersService(
+      prisma as never,
+      planLimitServiceMock as never,
+    );
+
+    // Create customer with the same document number in both orgs
+    const customerA = await prisma.customer.create({
+      data: {
+        name: 'Customer Org1',
+        documentType: 'CC',
+        documentNumber,
+        organizationId: fixture.orgAId,
+      },
+    });
+    customerAOrgId = customerA.id;
+
+    const customerB = await prisma.customer.create({
+      data: {
+        name: 'Customer Org2',
+        documentType: 'CC',
+        documentNumber,
+        organizationId: fixture.orgBId,
+      },
+    });
+    customerBOrgId = customerB.id;
+  });
+
+  afterAll(() =>
+    fixture.teardown(async () => {
+      await prisma.customer.deleteMany({
+        where: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+      });
+    }),
+  );
+
+  it('cross-org detail read returns 404 and leaks no foreign data', async () => {
+    await expect(
+      service.findOne(customerBOrgId, fixture.orgAId),
+    ).rejects.toThrow(NotFoundException);
+    await expect(
+      service.findOne(customerBOrgId, fixture.orgAId),
+    ).rejects.toThrow('Customer not found');
+  });
+
+  it('list returns zero foreign-org rows under search, segment and pagination', async () => {
+    const list = await service.findAll(fixture.orgAId, 1, 10);
+    expect(list.data.map((customer) => customer.id)).toEqual([customerAOrgId]);
+
+    const searched = await service.findAll(
+      fixture.orgAId,
+      1,
+      10,
+      'Customer Org2',
+    );
+    expect(searched.data).toHaveLength(0);
+    expect(searched.meta.total).toBe(0);
+
+    const byForeignDocument = await service.findAll(
+      fixture.orgAId,
+      1,
+      10,
+      documentNumber,
+    );
+    expect(byForeignDocument.data.map((c) => c.id)).toEqual([customerAOrgId]);
+
+    const paged = await service.findAll(fixture.orgAId, 2, 10);
+    expect(paged.data).toHaveLength(0);
+  });
+
+  it('cross-org update is denied and the foreign row stays unchanged', async () => {
+    await expect(
+      service.update(customerBOrgId, { name: 'Hijacked' }, fixture.orgAId),
+    ).rejects.toThrow(NotFoundException);
+
+    const unchanged = await prisma.customer.findUniqueOrThrow({
+      where: { id: customerBOrgId },
+    });
+    expect(unchanged.name).toBe('Customer Org2');
+  });
+
+  it('cross-org delete is denied and the foreign row stays intact', async () => {
+    await expect(
+      service.remove(customerBOrgId, fixture.orgAId),
+    ).rejects.toThrow(NotFoundException);
+
+    const intact = await prisma.customer.findUniqueOrThrow({
+      where: { id: customerBOrgId },
+    });
+    expect(intact.active).toBe(true);
+    expect(intact.name).toBe('Customer Org2');
+  });
+});

--- a/backend/src/purchase-orders/purchase-orders.service.int.spec.ts
+++ b/backend/src/purchase-orders/purchase-orders.service.int.spec.ts
@@ -1,0 +1,196 @@
+import { NotFoundException } from '@nestjs/common';
+import { PurchaseOrdersService } from './purchase-orders.service';
+import {
+  setupTwoOrgFixture,
+  type TwoOrgFixture,
+} from '../testing/two-org-fixture';
+
+// Minimal mock: only create() consumes the sequence service and this spec
+// seeds PurchaseOrder rows directly through Prisma.
+const sequenceServiceMock = {};
+
+describe('PurchaseOrdersService — Integration (Query Isolation)', () => {
+  let prisma: TwoOrgFixture['prisma'];
+  let fixture: TwoOrgFixture;
+  let service: PurchaseOrdersService;
+  let orderAOrgId: string;
+  let orderBOrgId: string;
+  let supplierBOrgId: string;
+
+  beforeAll(async () => {
+    fixture = await setupTwoOrgFixture('purchase-orders-int');
+    prisma = fixture.prisma;
+    service = new PurchaseOrdersService(
+      prisma as never,
+      sequenceServiceMock as never,
+    );
+
+    // Build the supplier + product + order chain for both orgs (same order
+    // number per org: @@unique([organizationId, orderNumber]) allows it).
+    const suppliers = await Promise.all([
+      prisma.supplier.create({
+        data: {
+          name: 'PO Supplier A',
+          documentNumber: 'PO-SUP-A-' + Date.now(),
+          organizationId: fixture.orgAId,
+        },
+      }),
+      prisma.supplier.create({
+        data: {
+          name: 'PO Supplier B',
+          documentNumber: 'PO-SUP-B-' + Date.now(),
+          organizationId: fixture.orgBId,
+        },
+      }),
+    ]);
+    supplierBOrgId = suppliers[1].id;
+
+    const categories = await Promise.all([
+      prisma.category.create({
+        data: { name: 'PO Cat A', organizationId: fixture.orgAId },
+      }),
+      prisma.category.create({
+        data: { name: 'PO Cat B', organizationId: fixture.orgBId },
+      }),
+    ]);
+
+    const products = await Promise.all([
+      prisma.product.create({
+        data: {
+          name: 'PO Product A',
+          sku: 'PO-PROD-A-' + Date.now(),
+          costPrice: 100,
+          salePrice: 200,
+          categoryId: categories[0].id,
+          organizationId: fixture.orgAId,
+        },
+      }),
+      prisma.product.create({
+        data: {
+          name: 'PO Product B',
+          sku: 'PO-PROD-B-' + Date.now(),
+          costPrice: 100,
+          salePrice: 200,
+          categoryId: categories[1].id,
+          organizationId: fixture.orgBId,
+        },
+      }),
+    ]);
+
+    const [orderA, orderB] = await Promise.all([
+      prisma.purchaseOrder.create({
+        data: {
+          orderNumber: 1,
+          supplierId: suppliers[0].id,
+          createdById: fixture.userAId,
+          status: 'DRAFT',
+          organizationId: fixture.orgAId,
+          items: {
+            create: {
+              productId: products[0].id,
+              qtyOrdered: 5,
+              unitCost: 100,
+              subtotal: 500,
+              organizationId: fixture.orgAId,
+            },
+          },
+        },
+      }),
+      prisma.purchaseOrder.create({
+        data: {
+          orderNumber: 1,
+          supplierId: suppliers[1].id,
+          createdById: fixture.userBId,
+          status: 'DRAFT',
+          organizationId: fixture.orgBId,
+          items: {
+            create: {
+              productId: products[1].id,
+              qtyOrdered: 5,
+              unitCost: 100,
+              subtotal: 500,
+              organizationId: fixture.orgBId,
+            },
+          },
+        },
+      }),
+    ]);
+    orderAOrgId = orderA.id;
+    orderBOrgId = orderB.id;
+  });
+
+  afterAll(() =>
+    fixture.teardown(async () => {
+      await prisma.purchaseOrderItem.deleteMany({
+        where: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+      });
+      await prisma.purchaseOrder.deleteMany({
+        where: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+      });
+      await prisma.product.deleteMany({
+        where: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+      });
+      await prisma.category.deleteMany({
+        where: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+      });
+      await prisma.supplier.deleteMany({
+        where: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+      });
+    }),
+  );
+
+  it('cross-org detail read returns 404 and leaks no foreign data', async () => {
+    await expect(service.findOne(orderBOrgId, fixture.orgAId)).rejects.toThrow(
+      NotFoundException,
+    );
+    await expect(service.findOne(orderBOrgId, fixture.orgAId)).rejects.toThrow(
+      'Orden de compra no encontrada',
+    );
+  });
+
+  it('list returns zero foreign-org rows under supplier, status and pagination filters', async () => {
+    const list = await service.findAll(fixture.orgAId, {});
+    expect(list.data.map((order) => order.id)).toEqual([orderAOrgId]);
+
+    // Foreign supplier id intersected with org scope must yield no rows
+    const byForeignSupplier = await service.findAll(fixture.orgAId, {
+      supplierId: supplierBOrgId,
+    });
+    expect(byForeignSupplier.data).toHaveLength(0);
+
+    const byForeignQuery = await service.findAll(fixture.orgAId, {
+      q: 'PO Supplier B',
+    });
+    expect(byForeignQuery.data).toHaveLength(0);
+
+    const paged = await service.findAll(fixture.orgAId, { page: 2 });
+    expect(paged.data).toHaveLength(0);
+  });
+
+  it('cross-org update is denied and the foreign row stays unchanged', async () => {
+    await expect(
+      service.update(orderBOrgId, { notes: 'Hijacked' }, fixture.orgAId),
+    ).rejects.toThrow(NotFoundException);
+
+    const unchanged = await prisma.purchaseOrder.findUniqueOrThrow({
+      where: { id: orderBOrgId },
+    });
+    expect(unchanged.notes).toBeNull();
+    expect(unchanged.status).toBe('DRAFT');
+  });
+
+  it('cross-org confirm and cancel are denied and the foreign row stays intact', async () => {
+    await expect(service.confirm(orderBOrgId, fixture.orgAId)).rejects.toThrow(
+      NotFoundException,
+    );
+    await expect(
+      service.cancel(orderBOrgId, { reason: 'Hijacked' }, fixture.orgAId),
+    ).rejects.toThrow(NotFoundException);
+
+    const intact = await prisma.purchaseOrder.findUniqueOrThrow({
+      where: { id: orderBOrgId },
+    });
+    expect(intact.status).toBe('DRAFT');
+    expect(intact.cancelReason).toBeNull();
+  });
+});

--- a/backend/src/suppliers/suppliers.service.int.spec.ts
+++ b/backend/src/suppliers/suppliers.service.int.spec.ts
@@ -1,0 +1,104 @@
+import { NotFoundException } from '@nestjs/common';
+import { SuppliersService } from './suppliers.service';
+import {
+  setupTwoOrgFixture,
+  type TwoOrgFixture,
+} from '../testing/two-org-fixture';
+
+describe('SuppliersService — Integration (Query Isolation)', () => {
+  let prisma: TwoOrgFixture['prisma'];
+  let fixture: TwoOrgFixture;
+  let service: SuppliersService;
+  const documentNumber = 'INT-NIT-' + Date.now();
+  let supplierAOrgId: string;
+  let supplierBOrgId: string;
+
+  beforeAll(async () => {
+    fixture = await setupTwoOrgFixture('suppliers-int');
+    prisma = fixture.prisma;
+    service = new SuppliersService(prisma as never);
+
+    // Create supplier with the same document number in both orgs
+    const supplierA = await prisma.supplier.create({
+      data: {
+        name: 'Supplier Org1',
+        documentNumber,
+        organizationId: fixture.orgAId,
+      },
+    });
+    supplierAOrgId = supplierA.id;
+
+    const supplierB = await prisma.supplier.create({
+      data: {
+        name: 'Supplier Org2',
+        documentNumber,
+        organizationId: fixture.orgBId,
+      },
+    });
+    supplierBOrgId = supplierB.id;
+  });
+
+  afterAll(() =>
+    fixture.teardown(async () => {
+      await prisma.supplier.deleteMany({
+        where: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+      });
+    }),
+  );
+
+  it('cross-org detail read returns 404 and leaks no foreign data', async () => {
+    await expect(
+      service.findOne(supplierBOrgId, fixture.orgAId),
+    ).rejects.toThrow(NotFoundException);
+    await expect(
+      service.findOne(supplierBOrgId, fixture.orgAId),
+    ).rejects.toThrow('Proveedor no encontrado');
+  });
+
+  it('list returns zero foreign-org rows under search, status and pagination', async () => {
+    const list = await service.findAll({}, fixture.orgAId);
+    expect(list.data.map((supplier) => supplier.id)).toEqual([supplierAOrgId]);
+
+    const searched = await service.findAll(
+      { search: 'Supplier Org2' },
+      fixture.orgAId,
+    );
+    expect(searched.data).toHaveLength(0);
+    expect(searched.meta.total).toBe(0);
+
+    const byStatus = await service.findAll(
+      { status: 'active' },
+      fixture.orgAId,
+    );
+    expect(byStatus.data.map((s) => s.id)).toEqual([supplierAOrgId]);
+
+    const paged = await service.findAll({ page: 2 }, fixture.orgAId);
+    expect(paged.data).toHaveLength(0);
+  });
+
+  it('cross-org update is denied and the foreign row stays unchanged', async () => {
+    await expect(
+      service.update(supplierBOrgId, { name: 'Hijacked' }, fixture.orgAId),
+    ).rejects.toThrow(NotFoundException);
+
+    const unchanged = await prisma.supplier.findUniqueOrThrow({
+      where: { id: supplierBOrgId },
+    });
+    expect(unchanged.name).toBe('Supplier Org2');
+  });
+
+  it('cross-org deactivate and reactivate are denied and the foreign row stays intact', async () => {
+    await expect(
+      service.remove(supplierBOrgId, fixture.orgAId),
+    ).rejects.toThrow(NotFoundException);
+    await expect(
+      service.reactivate(supplierBOrgId, fixture.orgAId),
+    ).rejects.toThrow(NotFoundException);
+
+    const intact = await prisma.supplier.findUniqueOrThrow({
+      where: { id: supplierBOrgId },
+    });
+    expect(intact.active).toBe(true);
+    expect(intact.name).toBe('Supplier Org2');
+  });
+});

--- a/docs/authorization-matrix.md
+++ b/docs/authorization-matrix.md
@@ -1,0 +1,278 @@
+# Backend Authorization Matrix
+
+Living inventory of every backend route: path × method × role(s) × org-scope × test reference.
+
+- Hand-authored with judgment (roles and org-scope need human interpretation); a CI coverage spec
+  (`backend/src/common/matrix-coverage.spec.ts`) diffs this file against the OpenAPI document built
+  from `AppModule` and asserts every referenced test file exists, so route drift breaks the build.
+- Tracks issues [#47](https://github.com/MeperDonas/MeperPOS/issues/47) and
+  [#48](https://github.com/MeperDonas/MeperPOS/issues/48).
+- **Supersedes** the static 142-item matrix in
+  `docs/reportes/verify-report-multi-tenant.md:354-367`, which remains as a point-in-time audit
+  precedent but is no longer updated.
+
+## Org-scope legend
+
+| Value | Meaning |
+|---|---|
+| `org-scoped` | Route data is filtered by `organizationId` in the service layer; cross-org access must 404 (two-org isolation specs). |
+| `org-required` | Route requires an organization context (OrganizationRequiredGuard) but reads/writes a single shared org row without per-row filtering. |
+| `superadmin-global` | Only SUPER_ADMIN; operates across organizations via `X-Organization-Id`. |
+| `authenticated-global` | Requires a valid JWT but no organization context (own profile, token flows). |
+| `pre-auth-public` | No JWT required (login, refresh, health). |
+
+Roles: `OWNER`, `ADMIN`, `MEMBER`, `CASHIER`, `INVENTORY_USER` (org roles), `SUPER_ADMIN` (platform).
+"any org role" = any authenticated membership role (no `@Roles` restriction).
+
+---
+
+## app
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api | GET | public | pre-auth-public | backend/src/app.controller.spec.ts |
+| /api/health | GET | public | pre-auth-public | backend/src/app.controller.spec.ts |
+
+## auth
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/auth/login | POST | public | pre-auth-public | backend/src/auth/auth.controller.spec.ts |
+| /api/auth/select-organization | POST | partial-token holder | pre-auth-public | backend/src/auth/auth.controller.spec.ts |
+| /api/auth/organizations | GET | any authenticated | authenticated-global | backend/src/auth/auth.controller.spec.ts |
+| /api/auth/profile | GET | any authenticated | authenticated-global | backend/src/auth/auth.controller.spec.ts |
+| /api/auth/profile | PUT | any authenticated | authenticated-global | backend/src/auth/auth.controller.spec.ts |
+| /api/auth/change-password | POST | any authenticated | authenticated-global | backend/src/auth/auth.service.spec.ts |
+| /api/auth/refresh | POST | refresh-cookie holder | pre-auth-public | backend/src/auth/auth.service.spec.ts |
+| /api/auth/logout | POST | public (cookie-aware) | pre-auth-public | backend/src/auth/auth.controller.spec.ts |
+| /api/auth/select-org | POST | any authenticated | authenticated-global | backend/src/auth/auth.controller.spec.ts |
+
+## admin (platform)
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/admin/organizations | POST | SUPER_ADMIN | superadmin-global | backend/src/admin/admin.controller.spec.ts |
+| /api/admin/organizations | GET | SUPER_ADMIN | superadmin-global | backend/src/admin/admin.controller.spec.ts |
+| /api/admin/organizations/:id | GET | SUPER_ADMIN | superadmin-global | backend/src/admin/admin.controller.spec.ts |
+| /api/admin/organizations/:id/status | PATCH | SUPER_ADMIN | superadmin-global | backend/src/admin/admin.controller.spec.ts |
+| /api/admin/organizations/:id/plan | PATCH | SUPER_ADMIN | superadmin-global | backend/src/admin/admin.controller.spec.ts |
+| /api/admin/organizations/:id/transfer-owner | POST | SUPER_ADMIN | superadmin-global | backend/src/admin/admin.controller.spec.ts |
+| /api/admin/metrics | GET | SUPER_ADMIN | superadmin-global | backend/src/admin/admin.controller.spec.ts |
+| /api/admin/organizations/:id | PATCH | SUPER_ADMIN | superadmin-global | backend/src/admin/admin.controller.spec.ts |
+| /api/admin/organizations/:id/members | POST | SUPER_ADMIN | superadmin-global | backend/src/admin/admin.controller.spec.ts |
+| /api/admin/organizations/:id/members/:userId/role | PATCH | SUPER_ADMIN | superadmin-global | backend/src/admin/admin.controller.spec.ts |
+| /api/admin/organizations/:id/members/:userId | DELETE | SUPER_ADMIN | superadmin-global | backend/src/admin/admin.controller.spec.ts |
+| /api/admin/organizations/:id | DELETE | SUPER_ADMIN | superadmin-global | backend/src/admin/admin.controller.spec.ts |
+
+## billing
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/billing/payments | GET | OWNER, ADMIN | org-scoped | backend/src/billing/billing.service.spec.ts |
+| /api/billing/payments | POST | SUPER_ADMIN | org-required | backend/src/billing/billing.service.spec.ts |
+| /api/billing/status | GET | ADMIN, CASHIER, INVENTORY_USER | org-scoped | backend/src/billing/billing.service.spec.ts |
+
+## cash-registers
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/cash-registers | POST | ADMIN | org-scoped | backend/src/cash-registers/cash-registers.service.int.spec.ts |
+| /api/cash-registers | GET | ADMIN, MEMBER | org-scoped | backend/src/cash-registers/cash-registers.service.int.spec.ts |
+| /api/cash-registers/:id | GET | ADMIN, MEMBER | org-scoped | backend/src/cash-registers/cash-registers.service.int.spec.ts |
+| /api/cash-registers/:id | PUT | ADMIN | org-scoped | backend/src/cash-registers/cash-registers.service.int.spec.ts |
+| /api/cash-registers/:id | DELETE | ADMIN | org-scoped | backend/src/cash-registers/cash-registers.service.int.spec.ts |
+
+## categories
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/categories | POST | ADMIN, MEMBER | org-scoped | backend/src/categories/categories.service.int.spec.ts |
+| /api/categories | GET | ADMIN, MEMBER | org-scoped | backend/src/categories/categories.service.int.spec.ts |
+| /api/categories/:id | GET | ADMIN, MEMBER | org-scoped | backend/src/categories/categories.service.int.spec.ts |
+| /api/categories/:id | PUT | ADMIN, MEMBER | org-scoped | backend/src/categories/categories.service.int.spec.ts |
+| /api/categories/:id | DELETE | ADMIN, MEMBER | org-scoped | backend/src/categories/categories.service.int.spec.ts |
+
+## customers
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/customers | POST | ADMIN, MEMBER, CASHIER | org-scoped | backend/src/customers/customers.service.int.spec.ts |
+| /api/customers | GET | ADMIN, MEMBER, CASHIER | org-scoped | backend/src/customers/customers.service.int.spec.ts |
+| /api/customers/document/:documentNumber | GET | ADMIN, MEMBER, CASHIER | org-scoped | backend/src/customers/customers.service.int.spec.ts |
+| /api/customers/:id | GET | ADMIN, MEMBER, CASHIER | org-scoped | backend/src/customers/customers.service.int.spec.ts |
+| /api/customers/:id | PUT | ADMIN | org-scoped | backend/src/customers/customers.service.int.spec.ts |
+| /api/customers/:id | DELETE | ADMIN | org-scoped | backend/src/customers/customers.service.int.spec.ts |
+
+## expenses
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/expenses | POST | ADMIN | org-scoped | backend/src/expenses/expenses.service.int.spec.ts |
+| /api/expenses | GET | ADMIN | org-scoped | backend/src/expenses/expenses.service.int.spec.ts |
+| /api/expenses/summary/monthly | GET | ADMIN | org-scoped | backend/src/expenses/expenses.service.int.spec.ts |
+| /api/expenses/:id | GET | ADMIN | org-scoped | backend/src/expenses/expenses.service.int.spec.ts |
+| /api/expenses/:id/history | GET | ADMIN | org-scoped | backend/src/expenses/expenses.service.int.spec.ts |
+| /api/expenses/:id | PATCH | ADMIN | org-scoped | backend/src/expenses/expenses.service.int.spec.ts |
+| /api/expenses/:id/payments | POST | ADMIN | org-scoped | backend/src/expenses/expenses.service.int.spec.ts |
+| /api/expenses/:id/duplicate | POST | ADMIN | org-scoped | backend/src/expenses/expenses.service.int.spec.ts |
+| /api/expenses/:id/upload | POST | ADMIN | org-scoped | backend/src/expenses/expenses.service.int.spec.ts |
+| /api/expenses/:id | DELETE | ADMIN | org-scoped | backend/src/expenses/expenses.service.int.spec.ts |
+
+## expense-categories
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/expense-categories | GET | ADMIN | org-scoped | backend/src/expenses/expense-categories.service.spec.ts |
+| /api/expense-categories | POST | ADMIN | org-scoped | backend/src/expenses/expense-categories.service.spec.ts |
+| /api/expense-categories/:id | PATCH | ADMIN | org-scoped | backend/src/expenses/expense-categories.service.spec.ts |
+| /api/expense-categories/:id | DELETE | ADMIN | org-scoped | backend/src/expenses/expense-categories.service.spec.ts |
+
+## exports
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/exports/inventory | GET | ADMIN, MEMBER | org-scoped | backend/src/exports/exports.service.spec.ts |
+| /api/exports/sales | POST | ADMIN | org-scoped | backend/src/exports/exports.service.spec.ts |
+| /api/exports/products | POST | ADMIN, MEMBER | org-scoped | backend/src/exports/exports.service.spec.ts |
+| /api/exports/customers | POST | ADMIN | org-scoped | backend/src/exports/exports.service.spec.ts |
+| /api/exports/inventory | POST | ADMIN, MEMBER | org-scoped | backend/src/exports/exports.service.spec.ts |
+| /api/exports/expenses | POST | ADMIN | org-scoped | backend/src/exports/exports.service.spec.ts |
+| /api/exports/economic | POST | ADMIN | org-scoped | backend/src/exports/exports.service.spec.ts |
+
+## imports
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/imports/products/template | GET | ADMIN, CASHIER | org-scoped | backend/src/imports/imports.service.int.spec.ts |
+| /api/imports/products | POST | ADMIN, CASHIER | org-scoped | backend/src/imports/imports.service.int.spec.ts |
+| /api/imports/full-template | GET | ADMIN, CASHIER | org-scoped | backend/src/imports/imports.service.int.spec.ts |
+| /api/imports/full | POST | ADMIN, CASHIER | org-scoped | backend/src/imports/imports.service.int.spec.ts |
+| /api/imports/:jobId/status | GET | ADMIN, CASHIER | org-scoped | backend/src/imports/imports.service.int.spec.ts |
+| /api/imports/:jobId/retry-row | POST | ADMIN, CASHIER | org-scoped | backend/src/imports/imports.service.int.spec.ts |
+
+## plan-limits
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/plan-limits/status | GET | any authenticated | authenticated-global | backend/src/plan-limits/plan-limits.service.spec.ts |
+
+## products
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/products | POST | ADMIN, MEMBER | org-scoped | backend/src/products/products.service.int.spec.ts |
+| /api/products | GET | any org role | org-scoped | backend/src/products/products.service.int.spec.ts |
+| /api/products/low-stock | GET | ADMIN, MEMBER | org-scoped | backend/src/products/products.service.int.spec.ts |
+| /api/products/search | GET | ADMIN, MEMBER, CASHIER | org-scoped | backend/src/products/products-search.controller.spec.ts |
+| /api/products/quick-search | GET | ADMIN, MEMBER, CASHIER | org-scoped | backend/src/products/products-search.controller.spec.ts |
+| /api/products/:id | GET | any org role | org-scoped | backend/src/products/products.service.int.spec.ts |
+| /api/products/:id | PUT | ADMIN, MEMBER | org-scoped | backend/src/products/products.service.int.spec.ts |
+| /api/products/:id/deactivate | PUT | ADMIN, MEMBER | org-scoped | backend/src/products/products.service.int.spec.ts |
+| /api/products/:id/reactivate | PUT | ADMIN, MEMBER | org-scoped | backend/src/products/products.service.int.spec.ts |
+| /api/products/:id | DELETE | ADMIN, MEMBER | org-scoped | backend/src/products/products.service.int.spec.ts |
+| /api/products/upload | POST | ADMIN, MEMBER | org-scoped | backend/src/products/products.controller.spec.ts |
+| /api/products/:id/upload | POST | ADMIN, MEMBER | org-scoped | backend/src/products/products.service.int.spec.ts |
+
+Note: `GET /api/products/search` and `GET /api/products/quick-search` are declared in both
+`products-search.controller.ts` and `products.controller.ts`; one row covers the shared path×method.
+
+## purchase-orders
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/purchase-orders | POST | ADMIN, MEMBER | org-scoped | backend/src/purchase-orders/purchase-orders.service.int.spec.ts |
+| /api/purchase-orders | GET | ADMIN, MEMBER | org-scoped | backend/src/purchase-orders/purchase-orders.service.int.spec.ts |
+| /api/purchase-orders/:id | GET | ADMIN, MEMBER | org-scoped | backend/src/purchase-orders/purchase-orders.service.int.spec.ts |
+| /api/purchase-orders/:id | PATCH | ADMIN, MEMBER | org-scoped | backend/src/purchase-orders/purchase-orders.service.int.spec.ts |
+| /api/purchase-orders/:id/confirm | POST | ADMIN, MEMBER | org-scoped | backend/src/purchase-orders/purchase-orders.service.int.spec.ts |
+| /api/purchase-orders/:id/receive | POST | ADMIN, MEMBER | org-scoped | backend/src/purchase-orders/purchase-orders.service.int.spec.ts |
+| /api/purchase-orders/:id/cancel | POST | ADMIN, MEMBER | org-scoped | backend/src/purchase-orders/purchase-orders.service.int.spec.ts |
+
+## reports
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/reports/dashboard | GET | ADMIN | org-scoped | backend/src/reports/reports.service.spec.ts |
+| /api/reports/economic | GET | ADMIN | org-scoped | backend/src/reports/financial-reports.service.int.spec.ts |
+| /api/reports/economic/cash | GET | ADMIN | org-scoped | backend/src/reports/financial-reports.service.int.spec.ts |
+| /api/reports/economic/inventory | GET | ADMIN | org-scoped | backend/src/reports/financial-reports.service.int.spec.ts |
+| /api/reports/sales/payment-method | GET | ADMIN | org-scoped | backend/src/reports/reports.service.spec.ts |
+| /api/reports/sales/category | GET | ADMIN | org-scoped | backend/src/reports/reports.service.spec.ts |
+| /api/reports/sales/category-daily | GET | ADMIN | org-scoped | backend/src/reports/reports.service.spec.ts |
+| /api/reports/products/top-selling | GET | ADMIN | org-scoped | backend/src/reports/reports.service.spec.ts |
+| /api/reports/customers/statistics | GET | ADMIN | org-scoped | backend/src/reports/reports.service.spec.ts |
+| /api/reports/users/performance | GET | ADMIN | org-scoped | backend/src/reports/reports.service.spec.ts |
+| /api/reports/sales/daily | GET | ADMIN | org-scoped | backend/src/reports/reports.service.spec.ts |
+
+## sales
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/sales | POST | ADMIN, MEMBER, CASHIER | org-scoped | backend/src/sales/sales.service.int.spec.ts |
+| /api/sales | GET | ADMIN, MEMBER, CASHIER | org-scoped | backend/src/sales/sales.service.int.spec.ts |
+| /api/sales/number/:saleNumber | GET | ADMIN, MEMBER, CASHIER | org-scoped | backend/src/sales/sales.service.int.spec.ts |
+| /api/sales/:id | GET | ADMIN, MEMBER, CASHIER | org-scoped | backend/src/sales/sales.service.int.spec.ts |
+| /api/sales/:id | PUT | ADMIN | org-scoped | backend/src/sales/sales.service.int.spec.ts |
+| /api/sales/:id/force-close | POST | ADMIN | org-scoped | backend/src/sales/sales.service.int.spec.ts |
+| /api/sales/:id/receipt | POST | ADMIN, MEMBER, CASHIER | org-scoped | backend/src/sales/sales.service.int.spec.ts |
+
+## settings
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/settings | GET | ADMIN | org-required | backend/src/settings/settings.service.spec.ts |
+| /api/settings/default | GET | ADMIN | org-required | backend/src/settings/settings.service.spec.ts |
+| /api/settings | PUT | ADMIN | org-required | backend/src/settings/settings.service.spec.ts |
+| /api/settings/logo | POST | ADMIN | org-required | backend/src/settings/settings.service.spec.ts |
+| /api/settings/organization | PATCH | ADMIN | org-required | backend/src/settings/settings.service.spec.ts |
+| /api/settings/receipt-prefix | PATCH | ADMIN | org-required | backend/src/settings/settings.service.spec.ts |
+
+## suppliers
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/suppliers | POST | ADMIN, MEMBER | org-scoped | backend/src/suppliers/suppliers.service.int.spec.ts |
+| /api/suppliers | GET | ADMIN, MEMBER | org-scoped | backend/src/suppliers/suppliers.service.int.spec.ts |
+| /api/suppliers/:id | GET | ADMIN, MEMBER | org-scoped | backend/src/suppliers/suppliers.service.int.spec.ts |
+| /api/suppliers/:id | PATCH | ADMIN, MEMBER | org-scoped | backend/src/suppliers/suppliers.service.int.spec.ts |
+| /api/suppliers/:id | DELETE | ADMIN, MEMBER | org-scoped | backend/src/suppliers/suppliers.service.int.spec.ts |
+| /api/suppliers/:id/reactivate | POST | ADMIN, MEMBER | org-scoped | backend/src/suppliers/suppliers.service.int.spec.ts |
+
+## tasks
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/tasks | POST | OWNER, ADMIN, MEMBER, CASHIER, INVENTORY_USER | org-scoped | backend/src/tasks/tasks.service.spec.ts |
+| /api/tasks | GET | OWNER, ADMIN, MEMBER, CASHIER, INVENTORY_USER | org-scoped | backend/src/tasks/tasks.service.spec.ts |
+| /api/tasks/assignees | GET | OWNER, ADMIN, MEMBER, CASHIER, INVENTORY_USER | org-scoped | backend/src/tasks/tasks.service.spec.ts |
+| /api/tasks/:id/timeline | GET | OWNER, ADMIN, MEMBER, CASHIER, INVENTORY_USER | org-scoped | backend/src/tasks/tasks.service.spec.ts |
+| /api/tasks/:id | GET | OWNER, ADMIN, MEMBER, CASHIER, INVENTORY_USER | org-scoped | backend/src/tasks/tasks.service.spec.ts |
+| /api/tasks/:id | PUT | OWNER, ADMIN, MEMBER, CASHIER, INVENTORY_USER | org-scoped | backend/src/tasks/tasks.service.spec.ts |
+| /api/tasks/:id/status | PUT | OWNER, ADMIN, MEMBER, CASHIER, INVENTORY_USER | org-scoped | backend/src/tasks/tasks.service.spec.ts |
+| /api/tasks/:id | DELETE | OWNER, ADMIN, MEMBER, CASHIER, INVENTORY_USER | org-scoped | backend/src/tasks/tasks.service.spec.ts |
+
+## users
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/users | POST | ADMIN | org-scoped | backend/src/users/users.service.int.spec.ts |
+| /api/users | GET | ADMIN | org-scoped | backend/src/users/users.service.int.spec.ts |
+| /api/users/:id | PUT | ADMIN | org-scoped | backend/src/users/users.service.int.spec.ts |
+| /api/users/:id/toggle-active | PUT | ADMIN | org-scoped | backend/src/users/users.service.int.spec.ts |
+| /api/users/:id/reset-password | POST | ADMIN | org-scoped | backend/src/users/users.service.int.spec.ts |
+| /api/users/:id | DELETE | ADMIN | org-scoped | backend/src/users/users.service.int.spec.ts |
+
+---
+
+## Known residual risks (tracked, not yet fixed)
+
+The `organizationId ? { organizationId } : {}` idiom tolerates a missing org context as an implicit
+all-organizations query on some read paths. For regular org users the OrganizationRequiredGuard
+guarantees the header, so residual exposure is the superadmin-without-header path:
+
+- products: findAll, findOne, searchProducts, quickSearch
+- sales: findAll, findOne, findBySaleNumber
+- cash-registers: countByOrg (zero callers)
+
+Routed to the design owner for a follow-up inside the auth work (issue #48 slice C) or a dedicated
+micro-PR (issue #47).


### PR DESCRIPTION
## Scope (PR 2 of 6, stacked-to-main chain — issue #48)

Slice A2 of the security-hardening change. Builds on PR 1 (#106, merged): shared two-org fixture + isolation specs for cash-registers/imports/products/sales.

**Chain context:** master (dfc3255) ← 📍 this PR → next: PR 3 (security headers). Rollback boundary: revert tests/docs only, zero runtime change.

### What
- **A2.1/A2.2 — Two-org cross-org isolation specs** (spec 1.R1/1.R2) for the remaining four org-scoped families, consuming \ackend/src/testing/two-org-fixture.ts\:
  - \customers\: detail 404 + no leak, lists zero foreign rows (search/segment/pagination), update/delete denied + row unchanged
  - \categories\: same matrix
  - \suppliers\: same matrix + reactivate denial
  - \purchase-orders\: same matrix + confirm/cancel denial, foreign-supplier/filter intersection
- **A2.3 — \docs/authorization-matrix.md\**: living, hand-authored route × method × role × org-scope × test-reference matrix, module-grouped, legend (org-scoped / org-required / superadmin-global / authenticated-global / pre-auth-public), links #47/#48, supersedes the static 142-item matrix in \docs/reportes/verify-report-multi-tenant.md:354-367\.
- **A2.4 — \matrix-coverage.spec.ts\**: builds the OpenAPI document from AppModule (SwaggerModule.createDocument), parses the matrix, and asserts every path×method has a row AND every referenced test file exists on disk. Route drift fails CI structurally.

### TDD evidence (strict RED on master → GREEN)
| Family | RED result on dfc3255 | Fix needed |
|---|---|---|
| customers | 4/4 pass — no gap found | none (regression spec) |
| categories | 4/4 pass — no gap found | none (regression spec) |
| suppliers | 4/4 pass — no gap found | none (regression spec) |
| purchase-orders | 4/4 pass — no gap found | none (regression spec) |
| matrix-coverage | 1/4 failed (paths lack \pi\ prefix + \{param}\ syntax vs matrix convention) | documented normalization \openApiPathToMatrixRoute\ |

Mutation check performed: removing a matrix row makes the coverage gate fail (gate proven live), then restored.

### Matrix stats
~128 route rows across 20 module groups; every org-scoped family row references its two-org isolation spec (A1's four + expenses/users/tasks included).

### Verification
- Full gate: \cd backend && npm run test\ → **79 suites / 807 tests, all green** (real Postgres via .env.development)
- ESLint clean on all touched files

### Known residual (out of scope here, routed to design owner)
Missing-org-context tolerance (implicit all-orgs query) remains on products findAll/findOne/searchProducts/quickSearch, sales findAll/findOne/findBySaleNumber, cash-registers.countByOrg (zero callers) — superadmin-without-header path only. Tracked in the matrix's residual-risk section; follow-up recommended in PR 4 auth work or a micro-PR.

Closes part of #48. Review budget note: 912 insertions / 0 deletions; ~318 lines are the hand-authored matrix doc.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/meperdonas/meperpos/pull/107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->