### PR TITLE
test(security): automated header verification + blocking frontend CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,18 +83,83 @@ jobs:
         working-directory: frontend
         run: npx tsc --noEmit
 
-      # TEMPORARY QUARANTINE: 4 pre-existing baseline test files are excluded
-      # via vitest.config.ts (sales page behavior, admin organizations page,
-      # AuthContext switch, CategoryStackedChart tooltip projection). The
-      # continue-on-error flag is defense-in-depth: it keeps the job green if a
-      # new baseline failure appears. Keep this comment in sync with the
-      # quarantinedBaselineProjects list in frontend/vitest.config.ts and
-      # REMOVE this flag once that list is empty.
+      # BLOCKING (issue #48, spec 2.R3): a failing frontend test fails the
+      # pipeline and blocks merge. Known-broken baseline files are quarantined
+      # in vitest.config.ts (quarantinedBaselineProjects) — keep that list in
+      # sync and shrink it as the underlying causes get fixed.
       - name: Test (Vitest)
         working-directory: frontend
-        continue-on-error: true
         run: npm run test
 
       - name: Build
         working-directory: frontend
         run: npm run build
+
+      # Served-route security-header check (issue #48, spec 2.R3): boots the
+      # built app with `next start` and asserts the six header families from
+      # next.config.ts headers() on a real response, guarding against
+      # build/deploy-time header loss that a config-level unit test misses.
+      - name: Verify security headers on a served route
+        working-directory: frontend
+        run: |
+          NEXT_TELEMETRY_DISABLED=1 npx next start -p 3100 > next-start.log 2>&1 &
+          SERVER_PID=$!
+          for i in $(seq 1 60); do
+            if curl -sf -o /dev/null http://localhost:3100/login; then
+              break
+            fi
+            sleep 1
+          done
+          if ! curl -sf -o /dev/null http://localhost:3100/login; then
+            echo "Frontend server did not come up in time"
+            cat next-start.log
+            kill $SERVER_PID || true
+            exit 1
+          fi
+          CHECK_URL=http://localhost:3100/login node --input-type=module <<'EOF'
+          const url = process.env.CHECK_URL;
+
+          // Exact-value families (must match next.config.ts securityHeaders).
+          const exact = {
+            "strict-transport-security": "max-age=63072000; includeSubDomains",
+            "x-content-type-options": "nosniff",
+            "x-frame-options": "DENY",
+            "referrer-policy": "strict-origin-when-cross-origin",
+            "permissions-policy": "camera=(), microphone=(), geolocation=()",
+          };
+          // Presence-only families (CSP value is long; asserting it stays
+          // present and non-empty is the contract of spec 2.R2).
+          const required = ["content-security-policy"];
+
+          let res;
+          try {
+            res = await fetch(url);
+          } catch (err) {
+            console.error(`Could not reach ${url}: ${err}`);
+            process.exit(1);
+          }
+
+          const failures = [];
+          for (const [header, expected] of Object.entries(exact)) {
+            const actual = res.headers.get(header);
+            if (actual !== expected) {
+              failures.push(`${header}: expected "${expected}", got "${actual}"`);
+            }
+          }
+          for (const header of required) {
+            const actual = res.headers.get(header);
+            if (!actual) {
+              failures.push(`${header}: missing`);
+            }
+          }
+
+          if (failures.length > 0) {
+            console.error(`Security header check FAILED for ${url}:`);
+            for (const failure of failures) console.error(`  - ${failure}`);
+            process.exit(1);
+          }
+          console.log(`All security header families present on ${url}`);
+          EOF
+          HEADER_CHECK_STATUS=$?
+          kill $SERVER_PID || true
+          exit $HEADER_CHECK_STATUS

--- a/backend/src/app-configuration.ts
+++ b/backend/src/app-configuration.ts
@@ -1,0 +1,20 @@
+import { INestApplication } from '@nestjs/common';
+import cookieParser from 'cookie-parser';
+import helmet from 'helmet';
+
+/**
+ * Transport/security wiring shared by the production bootstrap (main.ts) and
+ * the integration specs that boot AppModule. Keeping it in one place means a
+ * spec asserting security headers exercises the exact middleware the running
+ * server uses — removing or weakening helmet here fails the header specs and
+ * therefore CI (issue #48, spec 2.R1).
+ */
+export function configureApp(app: INestApplication): void {
+  // CSP is disabled because Swagger UI assets conflict with strict policies and this API serves no HTML to end users.
+  app.use(helmet({ contentSecurityPolicy: false }));
+
+  // Required for auth cookies: parses Cookie headers into req.cookies.
+  app.use(cookieParser());
+
+  app.setGlobalPrefix('api');
+}

--- a/backend/src/common/security-headers.int.spec.ts
+++ b/backend/src/common/security-headers.int.spec.ts
@@ -1,0 +1,77 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { AppModule } from '../app.module';
+import { configureApp } from '../app-configuration';
+
+/**
+ * Security header verification (issue #48, spec 2.R1).
+ *
+ * Boots the real AppModule with the exact wiring production applies
+ * (configureApp, shared with main.ts) and asserts that helmet's security
+ * headers ride on EVERY response — success, 401 and 404 alike.
+ *
+ * Backend CSP is intentionally disabled (Swagger UI assets conflict with
+ * strict policies and this API serves no HTML to end users — see
+ * app-configuration.ts), so CSP is deliberately NOT asserted here.
+ */
+
+const REQUIRED_HEADERS: Array<{
+  header: string;
+  expect?: string | RegExp;
+}> = [
+  { header: 'x-content-type-options', expect: 'nosniff' },
+  // helmet's frameguard defaults to SAMEORIGIN; the spec only requires the
+  // header family to be present and non-empty.
+  { header: 'x-frame-options', expect: /.+/ },
+  { header: 'strict-transport-security', expect: /^max-age=\d+/ },
+];
+
+function expectSecurityHeaders(res: request.Response): void {
+  for (const { header, expect: expected } of REQUIRED_HEADERS) {
+    const value = res.headers[header];
+    if (expected === undefined) {
+      expect(value).toBeDefined();
+    } else {
+      expect(value).toMatch(expected);
+    }
+  }
+}
+
+describe('Security headers on every backend response (helmet, spec 2.R1)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication({ logger: false });
+    configureApp(app);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET /api/health (success 2xx) carries the helmet headers', async () => {
+    const res = await request(app.getHttpServer()).get('/api/health');
+    expect(res.status).toBe(200);
+    expectSecurityHeaders(res);
+  });
+
+  it('GET /api/auth/profile without credentials (401) carries the helmet headers', async () => {
+    const res = await request(app.getHttpServer()).get('/api/auth/profile');
+    expect(res.status).toBe(401);
+    expectSecurityHeaders(res);
+  });
+
+  it('GET /api/nonexistent-route (404) carries the helmet headers', async () => {
+    const res = await request(app.getHttpServer()).get(
+      '/api/nonexistent-route',
+    );
+    expect(res.status).toBe(404);
+    expectSecurityHeaders(res);
+  });
+});

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,9 +1,8 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
-import cookieParser from 'cookie-parser';
-import helmet from 'helmet';
 import { AppModule } from './app.module';
+import { configureApp } from './app-configuration';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 import { validateJwtSecretOrExit } from './config/runtime-env';
 
@@ -13,11 +12,7 @@ async function bootstrap() {
 
   const app = await NestFactory.create(AppModule);
 
-  // CSP is disabled because Swagger UI assets conflict with strict policies and this API serves no HTML to end users.
-  app.use(helmet({ contentSecurityPolicy: false }));
-
-  // Required for auth cookies: parses Cookie headers into req.cookies.
-  app.use(cookieParser());
+  configureApp(app);
 
   const corsOrigins = (process.env.CORS_ORIGIN ?? '')
     .split(',')
@@ -37,7 +32,6 @@ async function bootstrap() {
     origin: corsOrigins.length > 0 ? corsOrigins : defaultOrigins,
     credentials: true,
   });
-  app.setGlobalPrefix('api');
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/frontend/src/app/expenses/expenses-page.evidence.test.tsx
+++ b/frontend/src/app/expenses/expenses-page.evidence.test.tsx
@@ -2,6 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
+import { getBogotaDateInputValue } from "@/lib/utils";
+
+// The page derives its default month filter from the real current date
+// (Bogotá timezone), so the expected month must be computed the same way.
+// Hard-coding it here made these tests fail at every month rollover.
+const CURRENT_MONTH = getBogotaDateInputValue().slice(0, 7);
 
 const { exportDataMock } = vi.hoisted(() => ({ exportDataMock: vi.fn() }));
 
@@ -178,7 +184,7 @@ describe("Expenses page evidence", () => {
     expect(screen.getByText(/800\.000/)).toBeTruthy();
     expect(screen.getAllByText("Arriendo").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Caja menor")).toBeTruthy();
-    expect(useExpenseSummaryMock).toHaveBeenCalledWith("2026-08");
+    expect(useExpenseSummaryMock).toHaveBeenCalledWith(CURRENT_MONTH);
   });
 
   it("renders the expense list with status badge and COP totals", () => {
@@ -193,7 +199,7 @@ describe("Expenses page evidence", () => {
     render(<ExpensesPage />);
 
     expect(useExpensesMock).toHaveBeenLastCalledWith(
-      expect.objectContaining({ month: "2026-08" }),
+      expect.objectContaining({ month: CURRENT_MONTH }),
     );
 
     fireEvent.change(screen.getByLabelText("Mes"), {

--- a/frontend/src/lib/next-headers.test.ts
+++ b/frontend/src/lib/next-headers.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+import { beforeAll, describe, expect, it } from "vitest";
+import nextConfig from "../../next.config";
+
+/**
+ * Security header verification for the Next.js frontend (issue #48, spec 2.R2).
+ *
+ * Asserts the exact header set that next.config.ts `headers()` applies to
+ * every route (`/:path*`). The expected values are hard-coded below on
+ * purpose: if someone removes or weakens a header in next.config.ts, this
+ * spec fails and blocks merge in CI.
+ *
+ * The served-route counterpart (production build + `next start`) lives in
+ * .github/workflows/ci.yml and checks the same six families on a real
+ * response, guarding against build/deploy-time header loss.
+ */
+
+interface HeaderEntry {
+  key: string;
+  value: string;
+}
+
+interface HeaderRule {
+  source: string;
+  headers: HeaderEntry[];
+}
+
+const ROUTE_SOURCE = "/:path*";
+
+/** Headers asserted with an exact value (order-insensitive). */
+const EXACT_HEADERS: Record<string, string> = {
+  "strict-transport-security": "max-age=63072000; includeSubDomains",
+  "x-content-type-options": "nosniff",
+  "x-frame-options": "DENY",
+  "referrer-policy": "strict-origin-when-cross-origin",
+  "permissions-policy": "camera=(), microphone=(), geolocation=()",
+};
+
+describe("next.config.ts security headers (spec 2.R2)", () => {
+  let routeHeaders: HeaderEntry[];
+
+  beforeAll(async () => {
+    const rules = (await nextConfig.headers?.()) as HeaderRule[] | undefined;
+    expect(rules).toBeDefined();
+
+    const rule = rules!.find((r) => r.source === ROUTE_SOURCE);
+    expect(rule).toBeDefined();
+    routeHeaders = rule!.headers;
+  });
+
+  function valueOf(header: string): string | undefined {
+    return routeHeaders.find(
+      (h) => h.key.toLowerCase() === header.toLowerCase(),
+    )?.value;
+  }
+
+  it("applies headers to every route (source /:path*)", () => {
+    expect(routeHeaders.length).toBeGreaterThan(0);
+  });
+
+  it.each(Object.entries(EXACT_HEADERS))(
+    "sets %s to the exact expected value",
+    (header, expected) => {
+      expect(valueOf(header)).toBe(expected);
+    },
+  );
+
+  it("sets a non-empty Content-Security-Policy with default-src and frame-ancestors 'none'", () => {
+    const csp = valueOf("content-security-policy");
+    expect(csp).toBeDefined();
+    expect(csp!.length).toBeGreaterThan(0);
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("frame-ancestors 'none'");
+  });
+});


### PR DESCRIPTION
## Scope (PR 3 of 6, stacked-to-main — slice B, issue #48)

Automated security-header verification for both stacks, and the CI change that makes frontend tests blocking.

- **Backend (spec 2.R1)**: new `security-headers.int.spec.ts` boots the real `AppModule` with the exact production wiring and asserts `x-content-type-options: nosniff`, `x-frame-options` and `strict-transport-security` on success (200 `/api/health`), 401 (`/api/auth/profile` unauthenticated) and 404 (`/api/nonexistent-route`) responses. Backend CSP intentionally NOT asserted (disabled for Swagger; per spec).
- **Frontend (spec 2.R2)**: new `next-headers.test.ts` asserts the six header families from `next.config.ts` `headers()` with exact values (HSTS 2y + includeSubDomains, nosniff, X-Frame-Options DENY, referrer-policy, permissions-policy) and a present, non-empty CSP.
- **CI (spec 2.R3)**: removed `continue-on-error: true` from the Vitest step (~ci.yml:95) so a failing frontend test blocks merge; added a served-route check after Build: `next start` on :3100 + node script asserting the six header families on `/login`, then kills the server.
- **Refactor**: extracted `configureApp` (`backend/src/app-configuration.ts`) so the header spec exercises the exact helmet/cookieParser wiring production uses; `main.ts` boots identically.

## TDD evidence (strict TDD)

- Backend spec: RED proven by mutation — temporarily disabling helmet in `configureApp` made all 3 tests fail (3/3 red); GREEN 3/3 after restore. `configureApp` didn't exist pre-slice, so the spec referenced production code that didn't exist yet (structural RED).
- Frontend spec: RED proven by mutation — removing `X-Frame-Options` from `next.config.ts` made the exact-value test fail (1/7 red); GREEN 7/7 after restore. Headers shipped but were previously unasserted.
- Runtime harness: full `npm run build` + `next start` + the CI header-check script executed locally -> all six families present on `/login` (exit 0).

## CI change explanation

The frontend job previously ran Vitest with `continue-on-error: true` (temporary quarantine defense). Making it blocking surfaced pre-existing issues:

1. `expenses-page.evidence.test.tsx` hard-coded month `"2026-08"` — a month-rollover time bomb that failed on 2026-09-01. Fixed by deriving the expected month via the same production util (`getBogotaDateInputValue`) the page uses; assertions unchanged in strength.
2. The quarantine list in `vitest.config.ts` (4 known-broken baseline files) now genuinely shields the blocking job; it must shrink as causes are fixed.

## Verification

- `cd backend && npm run test` -> 80 suites / 810 tests green (includes new spec).
- `cd frontend && npm run test` -> 63 files / 337 tests green (3 consecutive full runs).
- Changed lines: 255+/18- (inside the ~150-250 slice-B forecast band).

Closes the issue #48 acceptance criterion "Security headers present (test or CI check)" (specs 2.R1/2.R2/2.R3); part of the security-hardening change (#48).
