### PR TITLE
feat(auth): 30m access tokens with org-preserving refresh and cookie-only transport

### DIFF
--- a/backend/prisma/migrations/20260901194934_refresh_token_org_binding/migration.sql
+++ b/backend/prisma/migrations/20260901194934_refresh_token_org_binding/migration.sql
@@ -1,0 +1,10 @@
+-- Additive org binding for refresh tokens (issue #48, design D3.1).
+-- Nullable column + index only: legacy rows keep organizationId NULL and fall
+-- back to first-joined membership on refresh, so the migration is safe to
+-- deploy and safe to roll back.
+
+-- AlterTable
+ALTER TABLE "RefreshToken" ADD COLUMN     "organizationId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "RefreshToken_organizationId_idx" ON "RefreshToken"("organizationId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -87,18 +87,20 @@ model OrganizationUser {
 }
 
 model RefreshToken {
-  id        String    @id @default(uuid())
-  token     String    @unique
-  userId    String
-  expiresAt DateTime
-  revokedAt DateTime?
-  ipAddress String?
-  userAgent String?
-  createdAt DateTime  @default(now())
-  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id             String    @id @default(uuid())
+  token          String    @unique
+  userId         String
+  organizationId String?
+  expiresAt      DateTime
+  revokedAt      DateTime?
+  ipAddress      String?
+  userAgent      String?
+  createdAt      DateTime  @default(now())
+  user           User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
   @@index([token])
+  @@index([organizationId])
 }
 
 model OrganizationSequence {

--- a/backend/src/auth/auth-body-exposure.int.spec.ts
+++ b/backend/src/auth/auth-body-exposure.int.spec.ts
@@ -1,0 +1,178 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { PrismaClient } from '@prisma/client';
+import * as bcrypt from 'bcryptjs';
+import request from 'supertest';
+import { AppModule } from '../app.module';
+import { configureApp } from '../app-configuration';
+
+/**
+ * Auth-material exposure surface (issue #48, spec 3.R2 — design Option B).
+ *
+ * Boots the real AppModule with production wiring and drives the actual HTTP
+ * auth flows: accessToken stays in the JSON body (the documented controlled
+ * path that seeds the frontend memory store), while refreshToken is NEVER
+ * present in any response body — the httpOnly, /api/auth-scoped cookie is the
+ * only refresh transport.
+ */
+describe('Auth body exposure — cookie-only refresh transport (spec 3.R2, Option B)', () => {
+  let app: INestApplication;
+  let prisma: PrismaClient;
+  let orgAId: string;
+  let orgBId: string;
+  let singleOrgEmail: string;
+  let multiOrgEmail: string;
+
+  const password = 'Body-Exposure-Pass-123!';
+  const unique = `body-exposure-${Date.now()}`;
+
+  function findCookie(
+    cookies: string[] | undefined,
+    name: string,
+  ): string | undefined {
+    return cookies?.find((c) => c.startsWith(`${name}=`));
+  }
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication({ logger: false });
+    configureApp(app);
+    await app.init();
+
+    prisma = new PrismaClient();
+
+    const [orgA, orgB, hashed] = await Promise.all([
+      prisma.organization.create({
+        data: {
+          name: `${unique} Org A`,
+          slug: `${unique}-org-a`,
+          plan: 'BASIC',
+          active: true,
+        },
+      }),
+      prisma.organization.create({
+        data: {
+          name: `${unique} Org B`,
+          slug: `${unique}-org-b`,
+          plan: 'BASIC',
+          active: true,
+        },
+      }),
+      bcrypt.hash(password, 4),
+    ]);
+    orgAId = orgA.id;
+    orgBId = orgB.id;
+
+    const [single, multi] = await Promise.all([
+      prisma.user.create({
+        data: {
+          email: `${unique}-single@example.com`,
+          password: hashed,
+          name: 'Single Org User',
+          organizationUsers: { create: { organizationId: orgAId } },
+        },
+      }),
+      prisma.user.create({
+        data: {
+          email: `${unique}-multi@example.com`,
+          password: hashed,
+          name: 'Multi Org User',
+          organizationUsers: {
+            create: [
+              { organizationId: orgAId, joinedAt: new Date(Date.now() - 60000) },
+              { organizationId: orgBId },
+            ],
+          },
+        },
+      }),
+    ]);
+    singleOrgEmail = single.email;
+    multiOrgEmail = multi.email;
+  }, 60000);
+
+  afterAll(async () => {
+    await prisma.user.deleteMany({
+      where: { email: { in: [singleOrgEmail, multiOrgEmail] } },
+    });
+    await prisma.organization.deleteMany({
+      where: { id: { in: [orgAId, orgBId] } },
+    });
+    await prisma.$disconnect();
+    await app.close();
+  });
+
+  it('login returns accessToken but no refreshToken in the body (cookie set instead)', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: singleOrgEmail, password });
+
+    expect(res.status).toBe(201);
+    expect(res.body.accessToken).toBeDefined();
+    expect(res.body.refreshToken).toBeUndefined();
+    expect(findCookie(res.headers['set-cookie'], 'refresh_token')).toBeDefined();
+  });
+
+  it('refresh returns accessToken but no refreshToken in the body (rotated cookie only)', async () => {
+    const login = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: singleOrgEmail, password });
+    const refreshCookie = findCookie(
+      login.headers['set-cookie'],
+      'refresh_token',
+    );
+    expect(refreshCookie).toBeDefined();
+
+    const res = await request(app.getHttpServer())
+      .post('/api/auth/refresh')
+      .set('Cookie', refreshCookie as string)
+      .send({});
+
+    expect(res.status).toBe(201);
+    expect(res.body.accessToken).toBeDefined();
+    expect(res.body.refreshToken).toBeUndefined();
+    // Rotation re-issues the refresh cookie for the next cycle.
+    expect(findCookie(res.headers['set-cookie'], 'refresh_token')).toBeDefined();
+  });
+
+  it('select-organization returns accessToken but no refreshToken in the body', async () => {
+    const pre = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: multiOrgEmail, password });
+
+    expect(pre.status).toBe(201);
+    expect(pre.body.requiresOrganizationSelection).toBe(true);
+    expect(pre.body.refreshToken).toBeUndefined();
+
+    const res = await request(app.getHttpServer())
+      .post('/api/auth/select-organization')
+      .send({
+        preAuthToken: pre.body.preAuthToken,
+        organizationId: orgBId,
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.accessToken).toBeDefined();
+    expect(res.body.refreshToken).toBeUndefined();
+  });
+
+  it('select-org returns accessToken but no refreshToken in the body', async () => {
+    const login = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: multiOrgEmail, password, organizationId: orgAId });
+
+    expect(login.status).toBe(201);
+    expect(login.body.accessToken).toBeDefined();
+
+    const res = await request(app.getHttpServer())
+      .post('/api/auth/select-org')
+      .set('Authorization', `Bearer ${login.body.accessToken}`)
+      .send({ organizationId: orgBId });
+
+    expect(res.status).toBe(201);
+    expect(res.body.accessToken).toBeDefined();
+    expect(res.body.refreshToken).toBeUndefined();
+  });
+});

--- a/backend/src/auth/auth.constants.ts
+++ b/backend/src/auth/auth.constants.ts
@@ -10,3 +10,15 @@
  */
 export const ACCESS_TOKEN_TTL_SECONDS = 30 * 60;
 export const ACCESS_TOKEN_TTL_MS = ACCESS_TOKEN_TTL_SECONDS * 1000;
+
+/**
+ * Concurrent-tab refresh reuse grace (issue #48, amendment 2 / design D3.2).
+ *
+ * Tabs sharing a session keep per-tab in-memory access tokens that expire
+ * simultaneously; the losing tab presents a refresh token another tab's
+ * rotation just revoked. While a NEWER active refresh-token row for the same
+ * user exists within this window, refresh() rotates from that row instead of
+ * failing the tab with 401. Beyond the window, presentation of a revoked
+ * token is a genuine reuse signal and stays a 401.
+ */
+export const REFRESH_REUSE_GRACE_MS = 60_000;

--- a/backend/src/auth/auth.constants.ts
+++ b/backend/src/auth/auth.constants.ts
@@ -1,0 +1,12 @@
+/**
+ * Single source of truth for the access-token lifetime (issue #48, design D1).
+ *
+ * AuthService.generateTokenPair() signs access JWTs with expiresIn
+ * ACCESS_TOKEN_TTL_SECONDS and cookies.helper.ts mirrors the same lifetime as
+ * the access_token cookie maxAge via ACCESS_TOKEN_TTL_MS. Both consumers MUST
+ * keep importing these constants — token-ttl.spec.ts asserts the decoded JWT
+ * exp−iat and the cookie maxAge against them, so any drift between the JWT
+ * lifetime and the cookie fails CI structurally.
+ */
+export const ACCESS_TOKEN_TTL_SECONDS = 30 * 60;
+export const ACCESS_TOKEN_TTL_MS = ACCESS_TOKEN_TTL_SECONDS * 1000;

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -122,7 +122,11 @@ describe('AuthController after users boundary centralization', () => {
         'pre-auth-token',
         'org-1',
       );
-      expect(result).toEqual(expected);
+      // Refresh token is cookie-only: never present in the response body.
+      expect(result).toEqual({
+        accessToken: 'new-token',
+        user: { id: 'user-1', organizationId: 'org-1', role: OrgRole.ADMIN },
+      });
     });
   });
 
@@ -142,7 +146,11 @@ describe('AuthController after users boundary centralization', () => {
       const result = await controller.selectOrg(dto, req, mockRes());
 
       expect(authServiceMock.selectOrg).toHaveBeenCalledWith('user-1', 'org-1');
-      expect(result).toEqual(expected);
+      // Refresh token is cookie-only: never present in the response body.
+      expect(result).toEqual({
+        accessToken: 'new-token',
+        user: { id: 'user-1', organizationId: 'org-1', role: OrgRole.ADMIN },
+      });
     });
   });
 
@@ -241,7 +249,12 @@ describe('AuthController after users boundary centralization', () => {
       expect(authServiceMock.refresh).toHaveBeenCalledWith(
         'cookie-refresh-token',
       );
-      expect(result).toEqual(tokenPair);
+      // Rotated refresh token is cookie-only: never in the response body.
+      expect(result).toEqual({
+        accessToken: tokenPair.accessToken,
+        user: tokenPair.user,
+      });
+      expect(result).not.toHaveProperty('refreshToken');
       // Rotated pair is written back into cookies.
       expect(res.cookie).toHaveBeenCalledWith(
         ACCESS_TOKEN_COOKIE,

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -45,9 +45,11 @@ export class AuthController {
   constructor(private authService: AuthService) {}
 
   /**
-   * Dual-mode sessions: token pairs keep returning in JSON bodies (legacy
-   * Bearer frontend) while httpOnly cookies are set in addition. Cookies are
-   * only written when the service actually issued a token pair — a
+   * Session responses keep accessToken in the JSON body (the documented
+   * controlled path that seeds the frontend memory store and future native
+   * clients) while both tokens ride httpOnly cookies. The refresh token is
+   * cookie-ONLY: it is stripped from every response body. Cookies are only
+   * written when the service actually issued a token pair — a
    * requiresOrganizationSelection response has no session yet.
    */
   private setSessionCookies(
@@ -64,6 +66,20 @@ export class AuthController {
       const tokens = result as { accessToken: string; refreshToken: string };
       applyAuthCookies(res, tokens, this.existingCsrfToken(req));
     }
+  }
+
+  /** Removes the refresh token from a response body (cookie-only transport). */
+  private toResponseBody(result: unknown): unknown {
+    if (
+      typeof result === 'object' &&
+      result !== null &&
+      'refreshToken' in result
+    ) {
+      const { refreshToken: _omitted, ...body } =
+        result as Record<string, unknown>;
+      return body;
+    }
+    return result;
   }
 
   private existingCsrfToken(req: AuthRequest): string | null {
@@ -91,7 +107,7 @@ export class AuthController {
 
     this.setSessionCookies(res, req, result);
 
-    return result;
+    return this.toResponseBody(result);
   }
 
   @Post('select-organization')
@@ -108,7 +124,7 @@ export class AuthController {
 
     this.setSessionCookies(res, req, result);
 
-    return result;
+    return this.toResponseBody(result);
   }
 
   @UseGuards(JwtAuthGuard)
@@ -151,8 +167,9 @@ export class AuthController {
 
   /**
    * Accepts the refresh token from the refresh_token cookie first and falls
-   * back to the legacy body field. The rotated pair is returned in the body
-   * AND refreshed into cookies.
+   * back to the body field for native clients. The rotated refresh token is
+   * delivered ONLY via the httpOnly cookie — the response body carries the
+   * new accessToken (plus user), never the refresh token.
    */
   @Post('refresh')
   @ApiOperation({ summary: 'Refresh access token using refresh token' })
@@ -175,7 +192,7 @@ export class AuthController {
 
     applyAuthCookies(res, result, this.existingCsrfToken(req));
 
-    return result;
+    return this.toResponseBody(result);
   }
 
   /**
@@ -219,6 +236,6 @@ export class AuthController {
 
     this.setSessionCookies(res, req, result);
 
-    return result;
+    return this.toResponseBody(result);
   }
 }

--- a/backend/src/auth/auth.refresh.int.spec.ts
+++ b/backend/src/auth/auth.refresh.int.spec.ts
@@ -1,0 +1,110 @@
+import { JwtService } from '@nestjs/jwt';
+import * as crypto from 'crypto';
+import * as bcrypt from 'bcryptjs';
+import { AuthService } from './auth.service';
+import {
+  setupTwoOrgFixture,
+  type TwoOrgFixture,
+} from '../testing/two-org-fixture';
+
+/**
+ * Refresh-token session integrity (issue #48, spec 3.R1 + amendments 1-2).
+ *
+ * Real-database integration specs against AuthService: the two-org fixture
+ * seeds two organizations and a multi-org member M (org A first-joined, org B
+ * selected at login). The refresh flow must preserve the selected org
+ * (amendment 1 / design D3.1) and keep concurrent tabs alive with a 60s
+ * reuse-grace window (amendment 2 / design D3.2).
+ */
+describe('AuthService.refresh — org preservation (spec 3.R1, amendment 1)', () => {
+  let fixture: TwoOrgFixture;
+  let prisma: TwoOrgFixture['prisma'];
+  let service: AuthService;
+  let jwtService: JwtService;
+  let orgAId: string;
+  let orgBId: string;
+  let multiOrgUserId: string;
+  let multiOrgEmail: string;
+
+  const password = 'Refresh-Int-Pass-123!';
+
+  beforeAll(async () => {
+    fixture = await setupTwoOrgFixture('refresh-int');
+    prisma = fixture.prisma;
+    orgAId = fixture.orgAId;
+    orgBId = fixture.orgBId;
+
+    jwtService = new JwtService({ secret: 'refresh-int-test-secret' });
+    service = new AuthService(prisma as never, jwtService);
+
+    const hashed = await bcrypt.hash(password, 4);
+    const user = await prisma.user.create({
+      data: {
+        email: `refresh-int-multi-${Date.now()}@example.com`,
+        password: hashed,
+        name: 'Multi Org Member',
+        tokenVersion: 0,
+        organizationUsers: {
+          create: [
+            { organizationId: orgAId, role: 'MEMBER', joinedAt: new Date(Date.now() - 60000) },
+            { organizationId: orgBId, role: 'MEMBER', joinedAt: new Date() },
+          ],
+        },
+      },
+    });
+    multiOrgUserId = user.id;
+    multiOrgEmail = user.email;
+  }, 30000);
+
+  afterAll(async () => {
+    await fixture.teardown(async () => {
+      await prisma.refreshToken.deleteMany({
+        where: { userId: multiOrgUserId },
+      });
+    });
+  });
+
+  function decodeOrg(accessToken: string): string | null {
+    const payload = jwtService.verify(accessToken) as {
+      organizationId: string | null;
+    };
+    return payload.organizationId;
+  }
+
+  it('login honors the explicitly selected organization (sanity precondition)', async () => {
+    const result = await service.login({
+      email: multiOrgEmail,
+      password,
+      organizationId: orgBId,
+    });
+
+    expect(decodeOrg(result.accessToken)).toBe(orgBId);
+  });
+
+  it('refresh preserves the selected organization (org B stays org B)', async () => {
+    const login = await service.login({
+      email: multiOrgEmail,
+      password,
+      organizationId: orgBId,
+    });
+
+    const refreshed = await service.refresh(login.refreshToken);
+
+    expect(decodeOrg(refreshed.accessToken)).toBe(orgBId);
+  });
+
+  it('refresh of a legacy null-org row falls back to first-joined membership (migration safety)', async () => {
+    const raw = crypto.randomBytes(40).toString('hex');
+    const hash = crypto.createHash('sha256').update(raw).digest('hex');
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + 7);
+
+    await prisma.refreshToken.create({
+      data: { userId: multiOrgUserId, token: hash, expiresAt },
+    });
+
+    const refreshed = await service.refresh(raw);
+
+    expect(decodeOrg(refreshed.accessToken)).toBe(orgAId);
+  });
+});

--- a/backend/src/auth/auth.refresh.int.spec.ts
+++ b/backend/src/auth/auth.refresh.int.spec.ts
@@ -108,3 +108,127 @@ describe('AuthService.refresh — org preservation (spec 3.R1, amendment 1)', ()
     expect(decodeOrg(refreshed.accessToken)).toBe(orgAId);
   });
 });
+
+describe('AuthService.refresh — 60s concurrent-tab reuse grace (spec 3.R1, amendment 2)', () => {
+  let fixture: TwoOrgFixture;
+  let prisma: TwoOrgFixture['prisma'];
+  let service: AuthService;
+  let jwtService: JwtService;
+  let orgAId: string;
+  let orgBId: string;
+  let multiOrgUserId: string;
+  let multiOrgEmail: string;
+
+  const password = 'Refresh-Grace-Pass-123!';
+
+  function sha256(raw: string): string {
+    return crypto.createHash('sha256').update(raw).digest('hex');
+  }
+
+  /** Revokes every active row for the member so each test starts isolated. */
+  async function revokeAllActiveRows(): Promise<void> {
+    await prisma.refreshToken.updateMany({
+      where: { userId: multiOrgUserId, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+  }
+
+  beforeAll(async () => {
+    fixture = await setupTwoOrgFixture('refresh-grace');
+    prisma = fixture.prisma;
+    orgAId = fixture.orgAId;
+    orgBId = fixture.orgBId;
+
+    jwtService = new JwtService({ secret: 'refresh-int-test-secret' });
+    service = new AuthService(prisma as never, jwtService);
+
+    const hashed = await bcrypt.hash(password, 4);
+    const user = await prisma.user.create({
+      data: {
+        email: `refresh-grace-multi-${Date.now()}@example.com`,
+        password: hashed,
+        name: 'Multi Org Tab Sharer',
+        tokenVersion: 0,
+        organizationUsers: {
+          create: [
+            { organizationId: orgAId, role: 'MEMBER', joinedAt: new Date(Date.now() - 60000) },
+            { organizationId: orgBId, role: 'MEMBER', joinedAt: new Date() },
+          ],
+        },
+      },
+    });
+    multiOrgUserId = user.id;
+    multiOrgEmail = user.email;
+  }, 30000);
+
+  afterAll(async () => {
+    await fixture.teardown(async () => {
+      await prisma.refreshToken.deleteMany({
+        where: { userId: multiOrgUserId },
+      });
+    });
+  });
+
+  function decodeOrg(accessToken: string): string | null {
+    const payload = jwtService.verify(accessToken) as {
+      organizationId: string | null;
+    };
+    return payload.organizationId;
+  }
+
+  it('keeps the losing tab alive: a just-revoked token within 60s of a newer active row issues a fresh pair bound to that row org', async () => {
+    await revokeAllActiveRows();
+
+    // Both tabs share the session cookie holding this raw refresh token.
+    const shared = await service.login({
+      email: multiOrgEmail,
+      password,
+      organizationId: orgBId,
+    });
+
+    // Tab A wins the rotation: the shared row is revoked and replaced by a
+    // newer active row for the same user (created seconds ago).
+    await service.refresh(shared.refreshToken);
+
+    // Tab B presents the same (now revoked) raw token moments later.
+    const tabB = await service.refresh(shared.refreshToken);
+
+    expect(decodeOrg(tabB.accessToken)).toBe(orgBId);
+  });
+
+  it('rejects a revoked token with 401 when the newest active row is older than the 60s grace window', async () => {
+    await revokeAllActiveRows();
+
+    const rawRevoked = crypto.randomBytes(40).toString('hex');
+    const rawNewer = crypto.randomBytes(40).toString('hex');
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + 7);
+    const sixtyOneSecondsAgo = new Date(Date.now() - 61_000);
+
+    // The replacement row exists and is active, but was created 61s ago —
+    // outside the grace window. Presenting the revoked token is a genuine
+    // reuse signal and must stay a 401.
+    await prisma.refreshToken.create({
+      data: {
+        userId: multiOrgUserId,
+        token: sha256(rawRevoked),
+        organizationId: orgBId,
+        expiresAt,
+        revokedAt: sixtyOneSecondsAgo,
+      },
+    });
+    await prisma.refreshToken.create({
+      data: {
+        userId: multiOrgUserId,
+        token: sha256(rawNewer),
+        organizationId: orgBId,
+        expiresAt,
+        createdAt: sixtyOneSecondsAgo,
+      },
+    });
+
+    await expect(service.refresh(rawRevoked)).rejects.toThrow(
+      'Refresh token revoked',
+    );
+  });
+});

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -4,6 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { OrgRole, OrgStatus, PlanType } from '@prisma/client';
 import * as bcrypt from 'bcryptjs';
 import { AuthService } from './auth.service';
+import { ACCESS_TOKEN_TTL_SECONDS } from './auth.constants';
 import { PrismaService } from '../prisma/prisma.service';
 
 jest.mock('bcryptjs');
@@ -235,7 +236,7 @@ describe('AuthService', () => {
           role: OrgRole.ADMIN,
           tokenVersion: 1,
         }),
-        { expiresIn: '8h' },
+        { expiresIn: ACCESS_TOKEN_TTL_SECONDS },
       );
     });
 
@@ -605,7 +606,7 @@ describe('AuthService', () => {
           sub: 'user-1',
           tokenVersion: 2,
         }),
-        { expiresIn: '8h' },
+        { expiresIn: ACCESS_TOKEN_TTL_SECONDS },
       );
     });
   });

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -248,6 +248,7 @@ export class AuthService {
       data: {
         userId: user.id,
         token: refreshTokenHash,
+        organizationId: orgUser.organizationId,
         expiresAt,
         ipAddress: ipAddress ?? null,
         userAgent: userAgent ?? null,
@@ -308,16 +309,32 @@ export class AuthService {
       });
     }
 
-    const orgUser = await this.prisma.organizationUser.findFirst({
-      where: { userId: refreshToken.user.id },
-      orderBy: { joinedAt: 'asc' },
-    });
+    // Resolve the org context from the token row (design D3.1): rows issued
+    // after the org-binding migration carry the session's selected org, so a
+    // refresh cannot silently flip a multi-org user back to their first-joined
+    // organization. Legacy/null rows fall back to first-joined membership.
+    let orgUser =
+      refreshToken.organizationId !== null
+        ? await this.prisma.organizationUser.findFirst({
+            where: {
+              userId: refreshToken.user.id,
+              organizationId: refreshToken.organizationId,
+            },
+          })
+        : await this.prisma.organizationUser.findFirst({
+            where: { userId: refreshToken.user.id },
+            orderBy: { joinedAt: 'asc' },
+          });
 
     if (!orgUser) {
-      throw new UnauthorizedException('User has no organizations');
+      throw new UnauthorizedException(
+        refreshToken.organizationId !== null
+          ? 'Organization membership not found'
+          : 'User has no organizations',
+      );
     }
 
-    // Check organization status
+    // Revalidate organization status for the resolved org
     const org = await this.prisma.organization.findUnique({
       where: { id: orgUser.organizationId },
       select: { status: true },

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -16,8 +16,11 @@ import {
   UpdateProfileDto,
   ChangePasswordDto,
 } from './dto/auth.dto';
-import { OrgRole, OrgStatus } from '@prisma/client';
-import { ACCESS_TOKEN_TTL_SECONDS } from './auth.constants';
+import { OrgRole, OrgStatus, Prisma } from '@prisma/client';
+import {
+  ACCESS_TOKEN_TTL_SECONDS,
+  REFRESH_REUSE_GRACE_MS,
+} from './auth.constants';
 
 @Injectable()
 export class AuthService {
@@ -284,13 +287,48 @@ export class AuthService {
     }
 
     if (refreshToken.revokedAt) {
-      throw new UnauthorizedException('Refresh token revoked');
+      // Concurrent-tab reuse grace (design D3.2): tabs sharing a session may
+      // present a token another tab's rotation just revoked. While a NEWER
+      // active row for the same user was created within the grace window,
+      // rotate from that row instead of killing the tab with 401. Beyond the
+      // window this is a genuine reuse signal.
+      const replacement = await this.prisma.refreshToken.findFirst({
+        where: {
+          userId: refreshToken.userId,
+          revokedAt: null,
+          expiresAt: { gt: new Date() },
+          createdAt: { gte: new Date(Date.now() - REFRESH_REUSE_GRACE_MS) },
+        },
+        include: { user: true },
+        orderBy: { createdAt: 'desc' },
+      });
+
+      if (!replacement) {
+        throw new UnauthorizedException('Refresh token revoked');
+      }
+
+      return this.rotateActiveRow(replacement);
     }
 
     if (refreshToken.expiresAt < new Date()) {
       throw new UnauthorizedException('Refresh token expired');
     }
 
+    if (!refreshToken.user.active) {
+      throw new UnauthorizedException('User inactive');
+    }
+
+    return this.rotateActiveRow(refreshToken);
+  }
+
+  /**
+   * Revokes the given (active) refresh-token row and issues a fresh pair from
+   * it — the shared rotation path for both a normally presented token and a
+   * grace-window replacement row.
+   */
+  private async rotateActiveRow(
+    refreshToken: Prisma.RefreshTokenGetPayload<{ include: { user: true } }>,
+  ) {
     if (!refreshToken.user.active) {
       throw new UnauthorizedException('User inactive');
     }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -17,6 +17,7 @@ import {
   ChangePasswordDto,
 } from './dto/auth.dto';
 import { OrgRole, OrgStatus } from '@prisma/client';
+import { ACCESS_TOKEN_TTL_SECONDS } from './auth.constants';
 
 @Injectable()
 export class AuthService {
@@ -231,7 +232,7 @@ export class AuthService {
     };
 
     const accessToken = this.jwtService.sign(payload, {
-      expiresIn: '8h',
+      expiresIn: ACCESS_TOKEN_TTL_SECONDS,
     });
 
     const rawRefreshToken = crypto.randomBytes(40).toString('hex');

--- a/backend/src/auth/cookies.helper.spec.ts
+++ b/backend/src/auth/cookies.helper.spec.ts
@@ -8,6 +8,7 @@ import {
   clearAuthCookies,
   generateCsrfToken,
 } from './cookies.helper';
+import { ACCESS_TOKEN_TTL_MS } from './auth.constants';
 
 describe('cookies.helper', () => {
   const originalNodeEnv = process.env.NODE_ENV;
@@ -45,7 +46,7 @@ describe('cookies.helper', () => {
       }
     });
 
-    it('configures access_token httpOnly, site-wide, 8h maxAge', () => {
+    it('configures access_token httpOnly, site-wide, maxAge mirroring the JWT TTL', () => {
       const access = buildAuthCookies(tokens).find(
         (c) => c.name === ACCESS_TOKEN_COOKIE,
       );
@@ -55,7 +56,7 @@ describe('cookies.helper', () => {
         options: {
           httpOnly: true,
           path: '/',
-          maxAge: 8 * 60 * 60 * 1000,
+          maxAge: ACCESS_TOKEN_TTL_MS,
         },
       });
     });

--- a/backend/src/auth/cookies.helper.ts
+++ b/backend/src/auth/cookies.helper.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from 'crypto';
 import { Response } from 'express';
+import { ACCESS_TOKEN_TTL_MS } from './auth.constants';
 
 export const ACCESS_TOKEN_COOKIE = 'access_token';
 export const REFRESH_TOKEN_COOKIE = 'refresh_token';
@@ -7,9 +8,11 @@ export const CSRF_TOKEN_COOKIE = 'csrf_token';
 
 /**
  * TTLs mirror AuthService.generateTokenPair(): access JWTs are signed with
- * expiresIn '8h' and refresh-token rows expire 7 days after issuance.
+ * expiresIn ACCESS_TOKEN_TTL_SECONDS (the cookie maxAge reuses the shared
+ * ACCESS_TOKEN_TTL_MS constant from auth.constants.ts so the JWT and its
+ * cookie can never drift) and refresh-token rows expire 7 days after
+ * issuance.
  */
-const ACCESS_TOKEN_TTL_MS = 8 * 60 * 60 * 1000;
 const REFRESH_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 export interface AuthCookieOptions {

--- a/backend/src/auth/token-ttl.spec.ts
+++ b/backend/src/auth/token-ttl.spec.ts
@@ -1,0 +1,119 @@
+import { JwtService } from '@nestjs/jwt';
+import { Test, TestingModule } from '@nestjs/testing';
+import { OrgRole, OrgStatus } from '@prisma/client';
+import * as bcrypt from 'bcryptjs';
+import { AuthService } from './auth.service';
+import { ACCESS_TOKEN_TTL_MS } from './auth.constants';
+import { ACCESS_TOKEN_COOKIE, buildAuthCookies } from './cookies.helper';
+import { PrismaService } from '../prisma/prisma.service';
+
+jest.mock('bcryptjs');
+
+/**
+ * Access-token TTL contract (issue #48, spec 3.R1).
+ *
+ * Uses a REAL JwtService so the signed token's actual exp−iat is decoded and
+ * asserted — not the literal passed to sign(). The ceiling is 30 minutes
+ * (1800 seconds) per the spec; the exact value is a design decision (D1).
+ */
+describe('Access token TTL — 30-minute ceiling (spec 3.R1)', () => {
+  let service: AuthService;
+  let jwtService: JwtService;
+
+  const mockPrisma = {
+    user: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn(),
+    },
+    organizationUser: {
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+    },
+    organization: {
+      findUnique: jest.fn(),
+    },
+    refreshToken: {
+      create: jest.fn(),
+      updateMany: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: PrismaService, useValue: mockPrisma },
+        {
+          provide: JwtService,
+          useValue: new JwtService({ secret: 'ttl-test-secret' }),
+        },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+    jwtService = module.get<JwtService>(JwtService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /** Runs the single-organization login path and returns the issued pair. */
+  async function loginSingleOrg(): Promise<{ accessToken: string }> {
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: 'user-1',
+      email: 'ttl@example.com',
+      name: 'TTL User',
+      password: 'hashed-password',
+      tokenVersion: 0,
+      active: true,
+      isSuperAdmin: false,
+    });
+    mockPrisma.organizationUser.findMany.mockResolvedValue([
+      {
+        organizationId: 'org-1',
+        role: OrgRole.ADMIN,
+        organization: { status: OrgStatus.ACTIVE },
+      },
+    ]);
+    mockPrisma.refreshToken.create.mockResolvedValue({});
+
+    return service.login({
+      email: 'ttl@example.com',
+      password: 'password123',
+    });
+  }
+
+  it('signs access tokens with exp−iat ≤ 1800 seconds (30-minute ceiling)', async () => {
+    const result = await loginSingleOrg();
+
+    const payload = jwtService.verify(result.accessToken) as {
+      exp: number;
+      iat: number;
+    };
+
+    expect(payload.exp - payload.iat).toBeLessThanOrEqual(1800);
+  });
+
+  it('couples the signed JWT lifetime to ACCESS_TOKEN_TTL_MS (drift fails CI)', async () => {
+    const result = await loginSingleOrg();
+
+    const payload = jwtService.verify(result.accessToken) as {
+      exp: number;
+      iat: number;
+    };
+
+    expect(payload.exp - payload.iat).toBe(ACCESS_TOKEN_TTL_MS / 1000);
+  });
+
+  it('couples the access_token cookie maxAge to ACCESS_TOKEN_TTL_MS (mirror contract)', () => {
+    const access = buildAuthCookies({
+      accessToken: 'access-jwt',
+      refreshToken: 'raw-refresh',
+    }).find((c) => c.name === ACCESS_TOKEN_COOKIE);
+
+    expect(access?.options.maxAge).toBe(ACCESS_TOKEN_TTL_MS);
+  });
+});

--- a/backend/src/common/guards/cookie-csrf.guard.ts
+++ b/backend/src/common/guards/cookie-csrf.guard.ts
@@ -27,10 +27,12 @@ const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
  * Double-submit CSRF protection for cookie sessions.
  *
  * Requests carrying an Authorization Bearer header are token-authenticated
- * and therefore immune to cookie riding, so they are skipped entirely — this
- * keeps the current frontend (Bearer from localStorage) unaffected. Once a
- * frontend slice drops Bearer, every cross-site mutation without a matching
- * x-csrf-token header/cookie pair is rejected here.
+ * and therefore immune to cookie riding, so they are skipped entirely. The
+ * web frontend is a memory-token client that sends Bearer + cookies together
+ * on every request, so the skip is what keeps it unaffected; a cross-site
+ * attacker cannot set the Authorization header. Same-origin XSS bypasses CSRF
+ * anyway, so dropping this skip would add no real protection while coupling
+ * backend 403s to frontend header hygiene.
  */
 @Injectable()
 export class CookieCsrfGuard implements CanActivate {


### PR DESCRIPTION
## Slice C — auth-token-tightening (issue #48, PR 4 of 6, stacked-to-main)

PRs 1-3 merged (master @ 929552b). This slice lands the four co-changes of design D1-D3 in ONE PR because they are coupled: shortening the TTL amplifies the refresh-path bugs the other three changes fix.

### The four co-changes
1. **30m access-token TTL + shared constant** (\d21992\): \uth.constants.ts\ is the single source (\ACCESS_TOKEN_TTL_SECONDS\/\_MS\), consumed by BOTH \generateTokenPair\ and the access_token cookie builder. \	oken-ttl.spec.ts\ decodes the signed JWT and asserts \exp−iat === ACCESS_TOKEN_TTL_MS/1000\ AND cookie maxAge === \ACCESS_TOKEN_TTL_MS\ — JWT/cookie drift now fails CI structurally.
2. **Org-preserving refresh** (\5d22b0a\, amendment 1): \RefreshToken.organizationId\ (nullable + index) records the session org at issuance; \efresh()\ resolves the org from the row and revalidates membership + org status. Previously every silent refresh of a multi-org user flipped them back to first-joined.
3. **60s concurrent-tab reuse grace** (\d455a7e\, amendment 2): a revoked token presented while a newer active row for the same user was created within 60s rotates from that row instead of 401-ing the losing tab. Beyond 60s → 401 (genuine reuse signal).
4. **Cookie-only refresh transport** (\59051f9\ + \5971781\, spec 3.R2 Option B): refreshToken stripped from login/select-organization/refresh/select-org bodies; accessToken stays (documented controlled path). CSRF Bearer-skip kept; stale docstrings fixed. Frontend already posted \{}\ to refresh and never read refreshToken from bodies — ZERO frontend change.

### Migration safety
\20260901194934_refresh_token_org_binding\ is ADDITIVE ONLY (nullable TEXT column + index). Legacy rows keep NULL org and fall back to first-joined membership — no user is logged out; rollback restores the previous behavior harmlessly.

### TDD evidence (strict TDD)
| Unit | RED | GREEN |
|---|---|---|
| TTL ceiling | exp−iat 28800 > 1800 (genuine) | 13/13 token-ttl + cookies.helper |
| Coupling | Cannot find module './auth.constants' (structural) | drift assertions green |
| Org-preserving refresh | post-refresh claim = first-joined (genuine, real DB) | 3/3 auth.refresh.int |
| Reuse grace | losing tab got 401 'Refresh token revoked' (genuine) | 5/5 incl. 61s-boundary |
| Body strip | 4 endpoints leaked raw refreshToken (genuine, supertest + AppModule) | 4/4 auth-body-exposure.int |

### Gates
- Backend: 83 suites / 822 tests green (real Postgres, migration applied locally)
- Frontend: 63 files / 337 tests green, zero diff
- Silent refresh end-to-end: cookie refresh → new pair + rotated cookie asserted in the body-exposure spec

Refs #48