### PR TITLE
feat(users): multi-org privacy guard for admin mutations

### DIFF
--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { PlanLimitsModule } from '../plan-limits/plan-limits.module';
+import { AuthModule } from '../auth/auth.module';
 import { OrganizationRequiredGuard } from '../common/guards/organization-required.guard';
 import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
 
 @Module({
-  imports: [PlanLimitsModule],
+  imports: [PlanLimitsModule, AuthModule],
   controllers: [UsersController],
   providers: [UsersService, OrganizationRequiredGuard, AdminOrganizationInterceptor],
   exports: [UsersService],

--- a/backend/src/users/users.multi-org.privacy.int.spec.ts
+++ b/backend/src/users/users.multi-org.privacy.int.spec.ts
@@ -1,0 +1,267 @@
+import 'reflect-metadata';
+import { ForbiddenException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { OrgRole, PrismaClient } from '@prisma/client';
+import * as bcrypt from 'bcryptjs';
+import { AuthService } from '../auth/auth.service';
+import { setupTwoOrgFixture, type TwoOrgFixture } from '../testing/two-org-fixture';
+import { UsersService } from './users.service';
+
+/**
+ * Multi-org privacy regression guard (spec 4.R1 + amendments 3 and 4).
+ *
+ * A user M who belongs to two organizations has ONE global identity: the
+ * User row (name, email, password, active) is shared by every organization
+ * they belong to. When org A's admin mutates M through the users boundary,
+ * org B's view of M and M's login credentials change with it — the #47
+ * accepted-risk bug. The conforming outcome (amendment 3) is DENIAL: the
+ * admin's action is rejected with ForbiddenException and B's view plus M's
+ * login state are untouched.
+ *
+ * Assertions are ordered DB-state-first so a regression fails with the
+ * exact mutated value (e.g. Received: 'Mutated By Org A') instead of a
+ * bare "promise resolved" message.
+ */
+describe('UsersService multi-org privacy — Integration (real DB)', () => {
+  let fixture: TwoOrgFixture;
+  let prisma: PrismaClient;
+  let usersService: UsersService;
+  let targetCounter = 0;
+  const targetIds: string[] = [];
+
+  const futureExpiry = () => {
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + 7);
+    return expiresAt;
+  };
+
+  /** Creates a target user with the given memberships and a known password. */
+  const createTargetUser = async (organizations: string[], password: string) => {
+    targetCounter += 1;
+    const suffix = `${Date.now()}-${targetCounter}`;
+    const user = await prisma.user.create({
+      data: {
+        email: `users-privacy-target-${suffix}@example.com`,
+        password: await bcrypt.hash(password, 10),
+        name: `Original Name ${suffix}`,
+        active: true,
+        tokenVersion: 0,
+      },
+    });
+    await prisma.organizationUser.createMany({
+      data: organizations.map((organizationId) => ({
+        userId: user.id,
+        organizationId,
+        role: OrgRole.CASHIER,
+      })),
+    });
+    targetIds.push(user.id);
+    return user;
+  };
+
+  const createActiveRefreshToken = async (userId: string) =>
+    prisma.refreshToken.create({
+      data: {
+        userId,
+        token: `refresh-hash-${userId}`,
+        organizationId: null,
+        expiresAt: futureExpiry(),
+      },
+    });
+
+  /** Records whether the admin action resolved or was rejected (and by what). */
+  const outcomeOf = async (action: () => Promise<unknown>): Promise<string> => {
+    try {
+      await action();
+      return 'resolved';
+    } catch (error) {
+      return `rejected:${(error as Error).constructor.name}`;
+    }
+  };
+
+  beforeAll(async () => {
+    fixture = await setupTwoOrgFixture('users-privacy');
+    prisma = fixture.prisma;
+
+    // Org A's acting admin. Org B has no admin here: the whole point is that
+    // B's view of M must not change, so nobody acts on B's behalf.
+    await prisma.organizationUser.create({
+      data: {
+        userId: fixture.userAId,
+        organizationId: fixture.orgAId,
+        role: OrgRole.ADMIN,
+      },
+    });
+
+    const planLimitServiceStub = { invalidateCache: jest.fn() };
+    const realAuthService = new AuthService(prisma, {} as JwtService);
+    usersService = new UsersService(
+      prisma as never,
+      planLimitServiceStub as never,
+      realAuthService,
+    );
+  });
+
+  afterAll(async () => {
+    await fixture.teardown(async () => {
+      await prisma.refreshToken.deleteMany({
+        where: { userId: { in: targetIds } },
+      });
+      await prisma.organizationUser.deleteMany({
+        where: { organizationId: { in: [fixture.orgAId, fixture.orgBId] } },
+      });
+      await prisma.user.deleteMany({ where: { id: { in: targetIds } } });
+    });
+  });
+
+  describe('multi-org target — amendment 3 denial semantics', () => {
+    it('denies name/email edits from org A and leaves B-side view and login state unchanged', async () => {
+      const target = await createTargetUser(
+        [fixture.orgAId, fixture.orgBId],
+        'OriginalPass123',
+      );
+
+      const outcome = await outcomeOf(() =>
+        usersService.update(
+          fixture.userAId,
+          target.id,
+          { name: 'Mutated By Org A', email: `mutated-${target.id}@example.com` },
+          fixture.orgAId,
+        ),
+      );
+
+      // The global User row must be byte-identical to the pre-action state.
+      const after = await prisma.user.findUnique({ where: { id: target.id } });
+      expect(after?.name).toBe(target.name);
+      expect(after?.email).toBe(target.email);
+      expect(outcome).toBe(`rejected:${ForbiddenException.name}`);
+
+      // Org B's view of M is unchanged.
+      const orgBView = await prisma.user.findMany({
+        where: { organizationUsers: { some: { organizationId: fixture.orgBId } } },
+        select: { id: true, name: true, email: true, active: true },
+      });
+      const mInOrgB = orgBView.find((u) => u.id === target.id);
+      expect(mInOrgB).toEqual({
+        id: target.id,
+        name: target.name,
+        email: target.email,
+        active: true,
+      });
+
+      // M's login state is unchanged: old password still valid.
+      const reloaded = await prisma.user.findUnique({ where: { id: target.id } });
+      expect(
+        await bcrypt.compare('OriginalPass123', reloaded!.password),
+      ).toBe(true);
+    });
+
+    it('denies password reset from org A and leaves M login state (password, tokenVersion, refresh tokens) unchanged', async () => {
+      const target = await createTargetUser(
+        [fixture.orgAId, fixture.orgBId],
+        'OriginalPass123',
+      );
+      await createActiveRefreshToken(target.id);
+
+      const outcome = await outcomeOf(() =>
+        usersService.resetPassword(
+          fixture.userAId,
+          target.id,
+          { newPassword: 'NewPass456!' },
+          fixture.orgAId,
+        ),
+      );
+
+      const after = await prisma.user.findUnique({ where: { id: target.id } });
+      expect(await bcrypt.compare('OriginalPass123', after!.password)).toBe(
+        true,
+      );
+      expect(after?.tokenVersion).toBe(0);
+
+      // M's active refresh tokens must survive untouched.
+      const tokens = await prisma.refreshToken.findMany({
+        where: { userId: target.id },
+      });
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0].revokedAt).toBeNull();
+
+      expect(outcome).toBe(`rejected:${ForbiddenException.name}`);
+    });
+
+    it('denies deactivation from org A and leaves M active for org B logins', async () => {
+      const target = await createTargetUser(
+        [fixture.orgAId, fixture.orgBId],
+        'OriginalPass123',
+      );
+
+      const outcome = await outcomeOf(() =>
+        usersService.toggleActive(fixture.userAId, target.id, fixture.orgAId),
+      );
+
+      const after = await prisma.user.findUnique({ where: { id: target.id } });
+      expect(after?.active).toBe(true);
+
+      // Deactivation is the login-killing mutation: org B must still see M active.
+      const orgBView = await prisma.user.findMany({
+        where: { organizationUsers: { some: { organizationId: fixture.orgBId } } },
+        select: { id: true, active: true },
+      });
+      const mInOrgB = orgBView.find((u) => u.id === target.id);
+      expect(mInOrgB).toEqual({ id: target.id, active: true });
+
+      expect(outcome).toBe(`rejected:${ForbiddenException.name}`);
+    });
+  });
+
+  describe('single-org target — admin flow survives (amendment 3 success path)', () => {
+    it('allows org A admin to update a single-org user', async () => {
+      const target = await createTargetUser([fixture.orgAId], 'SoloPass123');
+
+      await usersService.update(
+        fixture.userAId,
+        target.id,
+        { name: 'Renamed By Org A' },
+        fixture.orgAId,
+      );
+
+      const after = await prisma.user.findUnique({ where: { id: target.id } });
+      expect(after?.name).toBe('Renamed By Org A');
+      expect(
+        await bcrypt.compare('SoloPass123', after!.password),
+      ).toBe(true);
+    });
+
+    it('allows org A admin to toggle a single-org user', async () => {
+      const target = await createTargetUser([fixture.orgAId], 'SoloPass123');
+
+      await usersService.toggleActive(fixture.userAId, target.id, fixture.orgAId);
+
+      const after = await prisma.user.findUnique({ where: { id: target.id } });
+      expect(after?.active).toBe(false);
+    });
+
+    it('resets a single-org user password AND revokes their tokens (credential hygiene)', async () => {
+      const target = await createTargetUser([fixture.orgAId], 'SoloPass123');
+      await createActiveRefreshToken(target.id);
+
+      await usersService.resetPassword(
+        fixture.userAId,
+        target.id,
+        { newPassword: 'NewPass456!' },
+        fixture.orgAId,
+      );
+
+      const after = await prisma.user.findUnique({ where: { id: target.id } });
+      expect(await bcrypt.compare('NewPass456!', after!.password)).toBe(true);
+
+      // revocation is global, so it must only ever run behind the single-org
+      // rule — here it is expected: the reset invalidates stolen sessions.
+      expect(after?.tokenVersion).toBe(1);
+      const tokens = await prisma.refreshToken.findMany({
+        where: { userId: target.id },
+      });
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0].revokedAt).not.toBeNull();
+    });
+  });
+});

--- a/backend/src/users/users.service.int.spec.ts
+++ b/backend/src/users/users.service.int.spec.ts
@@ -102,9 +102,13 @@ describe('UsersService.resetPassword — Integration (audit parity)', () => {
 
   beforeAll(async () => {
     const planLimitServiceStub = { invalidateCache: jest.fn() };
+    const authServiceStub = {
+      revokeUserTokens: jest.fn().mockResolvedValue({ id: 'stub' }),
+    };
     usersService = new UsersService(
       prisma as never,
       planLimitServiceStub as never,
+      authServiceStub as never,
     );
     auditInterceptor = new AuditInterceptor(
       prisma as never,

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -31,11 +31,16 @@ describe('UsersService', () => {
     invalidateCache: jest.fn(),
   };
 
+  const authServiceMock = {
+    revokeUserTokens: jest.fn(),
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     service = new UsersService(
       prismaMock as never,
       planLimitServiceMock as never,
+      authServiceMock as never,
     );
   });
 
@@ -206,6 +211,7 @@ describe('UsersService', () => {
       userId: 'user-2',
       organizationId: 'org-1',
     });
+    prismaMock.organizationUser.count.mockResolvedValue(1);
     prismaMock.user.update.mockResolvedValue({ id: 'user-2' });
 
     const result = await service.resetPassword(
@@ -222,6 +228,8 @@ describe('UsersService', () => {
       where: { id: 'user-2' },
       data: { password: expect.any(String) },
     });
+    // Credential hygiene: the reset revokes the target's active sessions.
+    expect(authServiceMock.revokeUserTokens).toHaveBeenCalledWith('user-2');
     // The audit row is written by AuditInterceptor from this attached
     // context; the service must not write it manually anymore.
     expect((result as { __auditContext?: unknown }).__auditContext).toEqual({
@@ -265,6 +273,74 @@ describe('UsersService', () => {
     await expect(
       service.update('admin-1', 'user-2', { name: 'Hacked' }, 'org-1'),
     ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('refuses to update a multi-org user and leaves the global row untouched', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: 'shared-user',
+      email: 'shared@example.com',
+      name: 'Shared User',
+      active: true,
+    });
+    prismaMock.organizationUser.findFirst.mockResolvedValue({
+      id: 'ou-1',
+      userId: 'shared-user',
+      organizationId: 'org-1',
+    });
+    // The target belongs to two organizations: org admins must not mutate
+    // the global identity other organizations share.
+    prismaMock.organizationUser.count.mockResolvedValue(2);
+
+    await expect(
+      service.update('admin-1', 'shared-user', { name: 'Mutated' }, 'org-1'),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses to reset the password of a multi-org user without revoking anything', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: 'shared-user',
+      email: 'shared@example.com',
+      name: 'Shared User',
+      active: true,
+    });
+    prismaMock.organizationUser.findFirst.mockResolvedValue({
+      id: 'ou-1',
+      userId: 'shared-user',
+      organizationId: 'org-1',
+    });
+    prismaMock.organizationUser.count.mockResolvedValue(2);
+
+    await expect(
+      service.resetPassword(
+        'admin-1',
+        'shared-user',
+        { newPassword: 'NuevaClaveSegura123' },
+        'org-1',
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
+    expect(authServiceMock.revokeUserTokens).not.toHaveBeenCalled();
+  });
+
+  it('refuses to toggle a multi-org user active flag', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: 'shared-user',
+      email: 'shared@example.com',
+      name: 'Shared User',
+      active: true,
+    });
+    prismaMock.organizationUser.findFirst.mockResolvedValue({
+      id: 'ou-1',
+      userId: 'shared-user',
+      organizationId: 'org-1',
+    });
+    prismaMock.organizationUser.count.mockResolvedValue(2);
+
+    await expect(
+      service.toggleActive('admin-1', 'shared-user', 'org-1'),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
   });
 
   it('prevents removing the primary owner', async () => {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -13,6 +13,7 @@ import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { ResetUserPasswordDto } from './dto/reset-user-password.dto';
 import { PlanLimitService } from '../plan-limits/plan-limits.service';
+import { AuthService } from '../auth/auth.service';
 
 type AuditContext = {
   resource?: string;
@@ -48,6 +49,7 @@ export class UsersService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly planLimitService: PlanLimitService,
+    private readonly authService: AuthService,
   ) {}
 
   async create(createUserDto: CreateUserDto, organizationId?: string) {
@@ -117,6 +119,7 @@ export class UsersService {
     organizationId?: string,
   ) {
     const previousUser = await this.findUserOrThrow(userId, organizationId);
+    await this.assertSingleOrgTarget(userId);
 
     if (updateUserDto.email) {
       await this.ensureEmailAvailable(updateUserDto.email, userId);
@@ -184,6 +187,7 @@ export class UsersService {
     }
 
     const user = await this.findUserOrThrow(userId, organizationId);
+    await this.assertSingleOrgTarget(userId);
 
     const updatedUser = await this.prisma.user.update({
       where: { id: userId },
@@ -211,12 +215,18 @@ export class UsersService {
     organizationId: string,
   ) {
     const targetUser = await this.findUserOrThrow(userId, organizationId);
+    await this.assertSingleOrgTarget(userId);
     const hashedPassword = await bcrypt.hash(dto.newPassword, BCRYPT_ROUNDS);
 
     await this.prisma.user.update({
       where: { id: userId },
       data: { password: hashedPassword },
     });
+
+    // Credential hygiene: the reset invalidates the target's active sessions
+    // (tokenVersion bump + refresh-token revocation). Revocation is global,
+    // which is exactly why it only runs behind the single-org rule above.
+    await this.authService.revokeUserTokens(userId);
 
     // The audit row is written by AuditInterceptor (wired on the
     // reset-password route) from the attached context, reproducing the
@@ -319,6 +329,25 @@ export class UsersService {
         },
       },
     );
+  }
+
+  /**
+   * Multi-org privacy guard (spec 4.R1, design D4): the User row is a single
+   * global identity (email is the unique login key, password/active are
+   * shared by every organization the user belongs to). An org admin may only
+   * mutate users whose membership is exclusive to their organization; users
+   * shared across organizations can only be managed by a SUPER_ADMIN.
+   */
+  private async assertSingleOrgTarget(userId: string) {
+    const membershipCount = await this.prisma.organizationUser.count({
+      where: { userId },
+    });
+
+    if (membershipCount > 1) {
+      throw new ForbiddenException(
+        'This user belongs to multiple organizations, so their profile and credentials can only be managed by a SUPER_ADMIN',
+      );
+    }
   }
 
   private async ensureEmailAvailable(email: string, excludeUserId?: string) {


### PR DESCRIPTION
## Slice D — multi-org privacy guard for admin mutations (PR 5 of 6, stacked-to-main)

### The bug (issue #47 accepted risk)

A user belonging to two organizations has ONE global identity: the `User` row (name, email, password, `active`) is shared by every organization they belong to. Yet `UsersService.update` / `resetPassword` / `toggleActive` let any org admin mutate those global fields for any user who is a member of their org — silently changing what the OTHER organization sees and how the user logs in there.

**Proven on pre-fix master (RED evidence, real Postgres, two-org fixture):**

| Mutation by org A admin on multi-org user M | Pre-fix master behavior |
|---|---|
| `update(M, { name })` | M's global name actually changed — DB read back the mutated value (`Mutated By Org A`) |
| `resetPassword(M)` | M's global password actually overwritten — old password no longer compares |
| `toggleActive(M)` | M deactivated globally — org B's view flips to `active: false`, locking M out of B's login |
| single-org `resetPassword` | Reset did NOT revoke sessions: `tokenVersion` stayed 0, refresh tokens stayed active |

### The fix (design D4, mechanism c — policy guard)

- After the existing membership check, `UsersService` counts the target's memberships; **> 1 → `ForbiddenException`** directing the admin to a SUPER_ADMIN. Applied to `update`, `resetPassword` and `toggleActive` (amendment 4 includes toggle-active — same cross-org class).
- Single-org path unchanged, EXCEPT `resetPassword` now calls `revokeUserTokens(userId)` after the password write (new credential hygiene; revocation is global, which is exactly why it stays behind the single-org rule).
- Out of scope (by design): `admin.service` create-only paths, self-service `auth.service` profile/password (user acting on own identity), `remove()` (already membership-scoped).

### Amendment-3 denial semantics

For a multi-org target the conforming outcome is **DENIAL**: 403 + org B's view/credentials unchanged + M's login state (password, `tokenVersion`, active refresh tokens) unchanged. A single-org success-path scenario proves the admin flow survives.

### TDD evidence (strict TDD)

| Test | RED on master | GREEN |
|---|---|---|
| multi-org update → denied, B-view/login unchanged | ✅ name mutated in DB | ✅ |
| multi-org resetPassword → denied, login state unchanged | ✅ password overwritten, old no longer valid | ✅ |
| multi-org toggleActive → denied, M active for B | ✅ `active` flipped to `false` | ✅ |
| single-org update/toggle still succeed | ✅ passed pre-fix (regression guard) | ✅ |
| single-org reset revokes tokens | ✅ `tokenVersion` 0, tokens active | ✅ `tokenVersion` 1, tokens revoked |

Gates: backend **84 suites / 831 tests** green (baseline 83/822); frontend **63 files / 337 tests** green (zero frontend diff; `getApiErrorMessage` already surfaces the 403 to users, per design no frontend change needed).

### Chain context

```
PR1 #106 — PR2 — PR3 #108 — PR4 #109 (merged) — 📍 PR5 (this) — PR6 (slice E, runbook)
```

- Start state: master @ 13aa806 (A+B+C merged). End state: multi-org admin mutations denied + reset revocation.
- Rollback: revert this PR restores direct User mutations; no migrations, no cross-slice data dependencies.
- Follow-up: PR 6 (slice E) — secrets runbook repair, hard-ordered after C.

Closes part of #48 (spec 4.R1 + amendments 3, 4).
