### PR TITLE
fix(auth): record org-entry audit for select-organization under policy C+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ npm-debug.log*
 
 # Prisma generated
 generated/
+# Local Pi runtime state
+.atl/

--- a/backend/src/auth/auth-login-audit.int.spec.ts
+++ b/backend/src/auth/auth-login-audit.int.spec.ts
@@ -1,0 +1,306 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { PrismaClient, Prisma } from '@prisma/client';
+import * as bcrypt from 'bcryptjs';
+import * as crypto from 'crypto';
+import request from 'supertest';
+import { AppModule } from '../app.module';
+import { configureApp } from '../app-configuration';
+
+/**
+ * Login-cycle audit durability (R-LOGIN-1..5, spec audit-event-persistence).
+ *
+ * Boots the real AppModule with production wiring and drives actual HTTP auth
+ * flows, then polls the AuditLog table through a DIRECT Prisma client (the
+ * established auth-body-exposure / users int pattern) because the interceptor
+ * writes post-response (fire-and-forget tap).
+ *
+ * Actors created directly via Prisma in beforeAll:
+ *   - single-org user (one organizationUser row)      -> R-LOGIN-1
+ *   - multi-org user (two organizationUser rows)      -> R-LOGIN-2/3/4
+ *   - superadmin (isSuperAdmin: true, NO organizationUser row) -> R-LOGIN-5
+ *
+ * Expectations:
+ *   R-LOGIN-1: single-org login (auto-resolved org) persists LOGIN_SUCCESS.
+ *   R-LOGIN-2: multi-org + valid organizationId persists LOGIN_SUCCESS;
+ *              membership-rejected 401 writes NO row.
+ *   R-LOGIN-3: multi-org without organizationId returns
+ *              requiresOrganizationSelection and writes NO row.
+ *   R-LOGIN-4: selectOrganization completes login and persists an
+ *              AUTH_ORG_SELECTED row for the selected org. RED until the
+ *              select-organization route is wired in task 4.1.
+ *   R-LOGIN-5: superadmin login (organizationId null) writes NO row
+ *              (empty-org FK guard, warn-skip).
+ */
+describe('Auth login-cycle audit rows (R-LOGIN-1..5)', () => {
+  let app: INestApplication;
+  let prisma: PrismaClient;
+  let orgAId: string;
+  let orgBId: string;
+  let singleOrgId: string;
+  let singleOrgEmail: string;
+  let multiOrgId: string;
+  let multiOrgEmail: string;
+  let superAdminId: string;
+  let superAdminEmail: string;
+
+  const password = 'Login-Audit-Pass-123!';
+  const unique = `auth-login-audit-${Date.now()}`;
+
+  const sleep = (ms: number) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
+  /**
+   * Polls AuditLog rows for a precise where filter until the count is stable
+   * across two consecutive polls (the interceptor write races the response),
+   * then returns the rows. Mirrors the stable-row helper in
+   * users.service.int.spec.ts.
+   */
+  const waitForStableAuditRows = async (
+    where: Prisma.AuditLogWhereInput,
+  ): Promise<
+    Array<{
+      id: string;
+      userId: string | null;
+      action: string;
+      resource: string;
+      organizationId: string;
+    }>
+  > => {
+    const fetchRows = () =>
+      prisma.auditLog.findMany({
+        where,
+        orderBy: { createdAt: 'asc' },
+      });
+
+    let previous = await fetchRows();
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      await sleep(50);
+      const current = await fetchRows();
+      if (current.length === previous.length) {
+        return current;
+      }
+      previous = current;
+    }
+    return previous;
+  };
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication({ logger: false });
+    configureApp(app);
+    await app.init();
+
+    prisma = new PrismaClient();
+
+    const [orgA, orgB, hashed] = await Promise.all([
+      prisma.organization.create({
+        data: {
+          name: `${unique} Org A`,
+          slug: `${unique}-org-a`,
+          plan: 'BASIC',
+          active: true,
+        },
+      }),
+      prisma.organization.create({
+        data: {
+          name: `${unique} Org B`,
+          slug: `${unique}-org-b`,
+          plan: 'BASIC',
+          active: true,
+        },
+      }),
+      bcrypt.hash(password, 4),
+    ]);
+    orgAId = orgA.id;
+    orgBId = orgB.id;
+
+    const [single, multi, superAdmin] = await Promise.all([
+      prisma.user.create({
+        data: {
+          email: `${unique}-single@example.com`,
+          password: hashed,
+          name: 'Single Org User',
+          organizationUsers: { create: { organizationId: orgAId } },
+        },
+      }),
+      prisma.user.create({
+        data: {
+          email: `${unique}-multi@example.com`,
+          password: hashed,
+          name: 'Multi Org User',
+          organizationUsers: {
+            create: [
+              {
+                organizationId: orgAId,
+                joinedAt: new Date(Date.now() - 60000),
+              },
+              { organizationId: orgBId },
+            ],
+          },
+        },
+      }),
+      prisma.user.create({
+        data: {
+          email: `${unique}-super@example.com`,
+          password: hashed,
+          name: 'Super Admin User',
+          isSuperAdmin: true,
+        },
+      }),
+    ]);
+    singleOrgId = single.id;
+    singleOrgEmail = single.email;
+    multiOrgId = multi.id;
+    multiOrgEmail = multi.email;
+    superAdminId = superAdmin.id;
+    superAdminEmail = superAdmin.email;
+  }, 60000);
+
+  afterAll(async () => {
+    await prisma.auditLog.deleteMany({
+      where: { organizationId: { in: [orgAId, orgBId] } },
+    });
+    await prisma.user.deleteMany({
+      where: {
+        id: { in: [singleOrgId, multiOrgId, superAdminId] },
+      },
+    });
+    await prisma.organization.deleteMany({
+      where: { id: { in: [orgAId, orgBId] } },
+    });
+    await prisma.$disconnect();
+    await app.close();
+  });
+
+  it('R-LOGIN-1: single-org login persists a LOGIN_SUCCESS row with the auto-resolved org', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: singleOrgEmail, password });
+
+    expect(res.status).toBe(201);
+    expect(res.body.user.organizationId).toBe(orgAId);
+
+    const rows = await waitForStableAuditRows({
+      userId: singleOrgId,
+      action: 'LOGIN_SUCCESS',
+      organizationId: orgAId,
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].userId).toBe(singleOrgId);
+    expect(rows[0].organizationId).toBe(orgAId);
+    expect(rows[0].action).toBe('LOGIN_SUCCESS');
+    expect(rows[0].resource).toBe('Auth');
+  });
+
+  it('R-LOGIN-2: multi-org login with a validated organizationId persists a LOGIN_SUCCESS row', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: multiOrgEmail, password, organizationId: orgAId });
+
+    expect(res.status).toBe(201);
+    expect(res.body.user.organizationId).toBe(orgAId);
+
+    const rows = await waitForStableAuditRows({
+      userId: multiOrgId,
+      action: 'LOGIN_SUCCESS',
+      organizationId: orgAId,
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].organizationId).toBe(orgAId);
+    expect(rows[0].action).toBe('LOGIN_SUCCESS');
+  });
+
+  it('R-LOGIN-2: multi-org login with a non-member organizationId is rejected with NO audit row', async () => {
+    const foreignOrgId = crypto.randomUUID();
+
+    const res = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: multiOrgEmail, password, organizationId: foreignOrgId });
+
+    expect(res.status).toBe(401);
+
+    // The login threw, so the interceptor tap never fires; give any (wrong)
+    // scheduled write a bounded settle window, then assert absence.
+    await sleep(400);
+    const rows = await prisma.auditLog.findMany({
+      where: {
+        userId: multiOrgId,
+        action: 'LOGIN_SUCCESS',
+        organizationId: foreignOrgId,
+      },
+    });
+    expect(rows).toHaveLength(0);
+  });
+
+  it('R-LOGIN-3: multi-org login without organizationId requires selection and writes NO row', async () => {
+    const baseline = await prisma.auditLog.count({
+      where: { userId: multiOrgId, action: 'LOGIN_SUCCESS' },
+    });
+
+    const res = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: multiOrgEmail, password });
+
+    expect(res.status).toBe(201);
+    expect(res.body.requiresOrganizationSelection).toBe(true);
+    expect(res.body.user).toBeUndefined();
+
+    await sleep(400);
+    const after = await prisma.auditLog.count({
+      where: { userId: multiOrgId, action: 'LOGIN_SUCCESS' },
+    });
+    expect(after).toBe(baseline);
+  });
+
+  it('R-LOGIN-4: selectOrganization completes login and persists an AUTH_ORG_SELECTED row for the selected org', async () => {
+    const pre = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: multiOrgEmail, password });
+
+    expect(pre.status).toBe(201);
+    expect(pre.body.requiresOrganizationSelection).toBe(true);
+
+    const res = await request(app.getHttpServer())
+      .post('/api/auth/select-organization')
+      .send({ preAuthToken: pre.body.preAuthToken, organizationId: orgBId });
+
+    expect(res.status).toBe(201);
+    expect(res.body.user.organizationId).toBe(orgBId);
+
+    const rows = await waitForStableAuditRows({
+      userId: multiOrgId,
+      action: 'AUTH_ORG_SELECTED',
+      organizationId: orgBId,
+    });
+
+    // RED until task 4.1 wires @AuditAction('AUTH_ORG_SELECTED') onto the
+    // select-organization route.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].userId).toBe(multiOrgId);
+    expect(rows[0].organizationId).toBe(orgBId);
+    expect(rows[0].action).toBe('AUTH_ORG_SELECTED');
+  });
+
+  it('R-LOGIN-5: superadmin login (organizationId null) writes NO audit row', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/api/auth/login')
+      .send({ email: superAdminEmail, password });
+
+    expect(res.status).toBe(201);
+    expect(res.body.user.organizationId).toBeNull();
+
+    // Response actor carries organizationId null -> empty-org FK guard
+    // warn-skips; bounded settle window then assert absence.
+    await sleep(400);
+    const rows = await prisma.auditLog.findMany({
+      where: { userId: superAdminId, action: 'LOGIN_SUCCESS' },
+    });
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -111,6 +111,8 @@ export class AuthController {
   }
 
   @Post('select-organization')
+  @UseInterceptors(AuditInterceptor)
+  @AuditAction('AUTH_ORG_SELECTED')
   @ApiOperation({ summary: 'Select organization and complete login' })
   async selectOrganization(
     @Body() dto: SelectOrganizationDto,

--- a/docs/sdd/audit/audit-findings.md
+++ b/docs/sdd/audit/audit-findings.md
@@ -1,0 +1,1348 @@
+# Audit Findings
+
+> **Scope:** technical audit of the repository state documented in `docs/sdd/project-baseline.md`, with targeted source verification.  
+> **Date:** 2026-09-02.  
+> **Evidence convention:** **FACT** is directly confirmed by repository evidence; **INFERENCE** is a supported consequence not reproduced at runtime; **UNKNOWN** could not be established.  
+> This artifact identifies problems and investigation targets. It does not define implementation designs or start SDD changes.
+
+## Executive Summary
+
+The audit consolidated 49 specialist candidates into **20 root-cause findings** after removing duplicates, cleanup-only observations, and unsupported claims.
+
+| Severity / status | Count |
+|---|---:|
+| CRITICAL | 0 |
+| HIGH | 11 |
+| MEDIUM | 7 |
+| LOW | 2 |
+| REQUIRES INVESTIGATION | 2 of the 20 |
+| CONFIRMED | 18 of the 20 |
+
+No finding was classified CRITICAL. Several paths can produce security, integrity, or deployment failures, but repository evidence does not prove current tenant compromise, deployed database drift, data loss in production, or a universally failing production system.
+
+Primary root causes:
+
+1. Authentication/session state is global-user scoped where session-family and organization scope are required.
+2. Multi-tenant and financial/inventory invariants rely excessively on application conventions rather than atomic/database-enforced boundaries.
+3. Critical workflows are not proven at the deployed composition boundary; some tests are globally quarantined.
+4. Runtime contracts have multiple authorities: API types, controllers, tests, documentation, CI, and platform configuration can disagree.
+5. Asynchronous imports and reporting/cache behavior assume one long-lived process and bounded data volumes.
+
+## Critical Findings
+
+None confirmed.
+
+## High Findings
+
+## AUDIT-FINDING-001
+
+### Title
+
+Refresh-token grace can cross session and organization boundaries
+
+### Category
+
+Security
+
+### Severity
+
+HIGH
+
+### Confidence
+
+HIGH
+
+### Status
+
+CONFIRMED
+
+### Evidence
+
+- `backend/src/auth/auth.service.ts:274-321` — refresh-token lookup and revoked-token grace flow.
+- `backend/src/auth/auth.service.ts:289-304` — replacement selects any recent active token for the same `userId`, without organization or lineage.
+- `backend/src/auth/auth.service.ts:329-391` — selected row determines organization context and is rotated.
+- `backend/prisma/schema.prisma:89-104` — rows have `organizationId`, but no session-family/replacement-chain identifier.
+- `backend/src/auth/auth.constants.ts:15-24` — 60-second reuse grace.
+
+### Facts
+
+- **FACT:** A revoked token can be recovered through an unrelated recent active row for the same user.
+- **FACT:** Recovery does not require equal `organizationId` or direct replacement lineage.
+- **FACT:** The replacement row's organization becomes the newly issued access-token scope.
+
+### Problem
+
+Possession of a revoked refresh token may be exchanged through a different browser session or organization during the grace window.
+
+### Root Cause
+
+Refresh-token rotation is modeled as user-wide recent-token recovery rather than a session-family, organization-bound chain.
+
+### Impact
+
+A stolen token for organization A can potentially yield credentials scoped to organization B and revoke a legitimate unrelated session.
+
+### Scope
+
+All multi-session users; cross-organization risk for users with multiple memberships.
+
+### Related Findings
+
+AUDIT-FINDING-002, AUDIT-FINDING-003.
+
+### Recommendation
+
+Bind rotation/reuse recovery to an explicit session family, direct replacement lineage, and organization scope.
+
+---
+
+## AUDIT-FINDING-002
+
+### Title
+
+Password changes do not invalidate existing sessions
+
+### Category
+
+Security
+
+### Severity
+
+HIGH
+
+### Confidence
+
+HIGH
+
+### Status
+
+CONFIRMED
+
+### Evidence
+
+- `backend/src/auth/auth.controller.ts:157-165` — change-password route.
+- `backend/src/auth/auth.service.ts:528-555` — updates only the password hash.
+- `backend/src/auth/auth.service.ts:415-426` — existing centralized token revocation is separate and unused by password change.
+- `backend/src/auth/jwt.strategy.ts:40-42` — access-token invalidation depends on `tokenVersion`.
+
+### Facts
+
+- **FACT:** Password change neither increments `tokenVersion` nor revokes refresh-token rows.
+- **FACT:** The baseline claim that change-password rotates `tokenVersion` is false.
+
+### Problem
+
+Changing a password does not terminate sessions that may already be compromised.
+
+### Root Cause
+
+Credential mutation and session-revocation responsibilities are disconnected.
+
+### Impact
+
+Stolen access tokens remain usable for their lifetime; stolen refresh tokens can continue extending access until expiry or separate revocation.
+
+### Scope
+
+All accounts, including SuperAdmin.
+
+### Related Findings
+
+AUDIT-FINDING-001.
+
+### Recommendation
+
+Treat successful password replacement as a session-security event and invalidate existing sessions.
+
+---
+
+## AUDIT-FINDING-003
+
+### Title
+
+Organization suspension enforcement has incompatible global and tenant scopes
+
+### Category
+
+Security
+
+### Severity
+
+HIGH
+
+### Confidence
+
+HIGH
+
+### Status
+
+CONFIRMED
+
+### Evidence
+
+- `backend/src/app.module.ts:73-90` — `OrganizationStatusGuard` runs globally before route authentication.
+- `backend/src/common/guards/organization-status.guard.ts:10-39` — allows requests when `request.user.orgStatus` is absent.
+- `backend/src/auth/jwt.strategy.ts:77-91` — authenticated org status is attached later by route-level JWT auth.
+- `backend/src/admin/admin.service.ts:177-193` — suspension invokes organization token revocation.
+- `backend/src/auth/auth.service.ts:478-496` — revokes all active refresh tokens and increments global `User.tokenVersion` for every member, without filtering the suspended organization.
+
+### Facts
+
+- **FACT:** The status guard normally executes before authenticated organization context exists, so it does not enforce the advertised suspended-write boundary.
+- **FACT:** The compensating suspension path invalidates every session of each member, including sessions for other organizations.
+
+### Problem
+
+The request-level boundary is ineffective in its declared placement, while the compensating revocation crosses tenant boundaries.
+
+### Root Cause
+
+Organization authorization is placed before authentication and suspension is implemented through global-user session state.
+
+### Impact
+
+Residual valid tokens could retain write access to a suspended organization, while ordinary suspension disrupts unrelated tenant sessions for multi-organization users.
+
+### Scope
+
+All tenant-scoped routes and multi-organization users.
+
+### Related Findings
+
+AUDIT-FINDING-001, AUDIT-FINDING-005.
+
+### Recommendation
+
+Evaluate suspension after verified organization context exists and scope session invalidation to the affected organization.
+
+---
+
+## AUDIT-FINDING-004
+
+### Title
+
+Declared audit events are silently skipped
+
+### Category
+
+Security
+
+### Severity
+
+HIGH
+
+### Confidence
+
+HIGH
+
+### Status
+
+CONFIRMED
+
+### Evidence
+
+- `backend/src/common/interfaces/request-user.interface.ts:3-10` — canonical actor field is `userId`.
+- `backend/src/auth/jwt.strategy.ts:56-63,83-91` — request user exposes `userId`.
+- `backend/src/common/interceptors/audit.interceptor.ts:142-153` — interceptor expects `user.sub` and skips when absent.
+- `backend/src/common/interceptors/audit.interceptor.ts:159-176` — durable rows also use `user.sub`.
+- Examples of declared events: `backend/src/products/products.controller.ts:138-177`, `backend/src/users/users.controller.ts:43-109`.
+
+### Facts
+
+- **FACT:** Normal authenticated requests carry `userId`, not `sub`.
+- **FACT:** `AuditInterceptor` deterministically follows its skip branch for those requests.
+- **FACT:** Login audit is also skipped because no authenticated request user exists yet.
+
+### Problem
+
+Operations advertised through `@AuditAction` do not create durable `AuditLog` records.
+
+### Root Cause
+
+Authentication and auditing use incompatible actor contracts, with no integration test proving emitted events.
+
+### Impact
+
+Security investigations, accountability, anomaly detection, and incident evidence are incomplete for product and user-management mutations.
+
+### Scope
+
+Every route relying on `AuditInterceptor`; service-authored audit rows are separate.
+
+### Related Findings
+
+AUDIT-FINDING-014.
+
+### Recommendation
+
+Use the canonical request-user contract and prove that each declared security event yields a durable tenant/actor-scoped record.
+
+---
+
+## AUDIT-FINDING-005
+
+### Title
+
+Import jobs are non-durable and retain stale cross-organization authority
+
+### Category
+
+Backend
+
+### Severity
+
+HIGH
+
+### Confidence
+
+HIGH
+
+### Status
+
+CONFIRMED
+
+### Evidence
+
+- `backend/src/imports/imports.service.ts:71-99,115-131` — process-local job state and 30-minute TTL.
+- `backend/src/imports/imports.service.ts:216-220` — unawaited in-process execution.
+- `backend/src/imports/multi-sheet-import.service.ts:80-111,625-645` — second process-local implementation.
+- `backend/src/imports/imports.controller.ts:139-178` — status/retry pass `jobId` and `userId`, not current organization.
+- `backend/src/imports/imports.service.ts:984-997` and `multi-sheet-import.service.ts:625-635` — ownership checks ignore active organization.
+
+### Facts
+
+- **FACT:** Restart, redeploy, or another instance loses job status, row errors, and retry data while already-written domain rows remain.
+- **FACT:** A user can switch organizations and still inspect/retry an earlier job because continuation is user-scoped only.
+- **FACT:** Retry writes using the job's stored organization without fresh membership/status verification.
+
+### Problem
+
+The API exposes an asynchronous job contract that is neither durable nor continuously authorized against tenant scope.
+
+### Root Cause
+
+Import lifecycle and authorization were modeled as singleton process memory, duplicated across two engines.
+
+### Impact
+
+Ambiguous partial imports, lost recovery data, incompatibility with scaling/redeployment, cross-context error disclosure, and writes to an organization that is no longer active in the user's session.
+
+### Scope
+
+Product and multi-sheet imports, status polling, row retry, operations support.
+
+### Related Findings
+
+AUDIT-FINDING-003, AUDIT-FINDING-006, AUDIT-FINDING-007.
+
+### Recommendation
+
+Establish one durable import lifecycle with tenant-scoped continuation authorization, idempotent row processing, and explicit recovery semantics.
+
+---
+
+## AUDIT-FINDING-006
+
+### Title
+
+Inventory and billing invariants span non-atomic writes
+
+### Category
+
+Database
+
+### Severity
+
+HIGH
+
+### Confidence
+
+HIGH
+
+### Status
+
+CONFIRMED
+
+### Evidence
+
+- `backend/src/products/products.service.ts:180-203` — product creation precedes initial inventory movement.
+- `backend/src/products/products.service.ts:369-407` — stock update precedes adjustment movement.
+- `backend/src/cash-registers/cash-registers.service.ts:35-48,114-124` — current default is cleared before replacement creation/update.
+- `backend/src/billing/payment-records.service.ts:23-45` — payment record and organization billing transition are separate writes.
+
+### Facts
+
+- **FACT:** Failure of a later write does not roll back an earlier write in these paths.
+- **FACT:** Each path represents one logical business action through multiple commits.
+
+### Problem
+
+Persisted state can violate its ledger, default-register, or billing-transition invariant after partial failure.
+
+### Root Cause
+
+Transaction policy is established ad hoc per service rather than at invariant-bearing use-case boundaries.
+
+### Impact
+
+Stock can diverge from movement history; no register may remain default; billing payments can persist without the associated organization transition.
+
+### Scope
+
+Products, inventory movements, cash registers, and billing records.
+
+### Related Findings
+
+AUDIT-FINDING-005, AUDIT-FINDING-007.
+
+### Recommendation
+
+Define atomic units of work for every invariant-bearing multi-write operation.
+
+---
+
+## AUDIT-FINDING-007
+
+### Title
+
+Expense payments and sale cancellation have concurrency races
+
+### Category
+
+Database
+
+### Severity
+
+HIGH
+
+### Confidence
+
+HIGH
+
+### Status
+
+CONFIRMED
+
+### Evidence
+
+- `backend/src/expenses/expenses.service.ts:392-416` — existing payments are read and validated before the transaction.
+- `backend/src/expenses/expenses.service.ts:418-455` — insert/status update use a later default-isolation transaction.
+- `backend/prisma/schema.prisma:454-489` — no cumulative-payment constraint.
+- `backend/src/sales/sales.service.ts:454-472` — cancellation eligibility is read before transaction.
+- `backend/src/sales/sales.service.ts:473-515` — final update is not conditional on expected status; no explicit serializable isolation or sale-row lock.
+
+### Facts
+
+- **FACT:** Two concurrent expense-payment requests can validate against the same old sum.
+- **INFERENCE:** Both can commit and exceed `Expense.total`, leaving status derived from stale sums.
+- **FACT:** Product stock and movement restoration are coupled to sale cancellation.
+- **INFERENCE:** Concurrent cancellation schedules can create duplicate returns/restock because transition ownership is unguarded.
+
+### Problem
+
+Read-before-transaction checks do not protect financial totals or one-time state transitions under contention.
+
+### Root Cause
+
+Concurrency-sensitive validation occurs outside the mutation's locking/isolation boundary.
+
+### Impact
+
+Overpaid expenses, inconsistent payment status, duplicated inventory restoration, and duplicate return movements.
+
+### Scope
+
+Expense payment and sale cancellation workflows.
+
+### Related Findings
+
+AUDIT-FINDING-006, AUDIT-FINDING-009.
+
+### Recommendation
+
+Make validation and mutation one concurrency-controlled operation and guard transitions against their expected persisted state.
+
+---
+
+## AUDIT-FINDING-008
+
+### Title
+
+Cross-table tenant ownership is not enforced by the database
+
+### Category
+
+Database
+
+### Severity
+
+HIGH
+
+### Confidence
+
+HIGH
+
+### Status
+
+CONFIRMED
+
+### Evidence
+
+- `backend/prisma/schema.prisma:164-176` — Product's organization and category relations are independent.
+- `backend/prisma/schema.prisma:260-290` — Payment/SaleItem organization and parent relations are independent.
+- `backend/prisma/schema.prisma:359-405` — purchase-order supplier/product tenant ownership is independent.
+- `backend/prisma/schema.prisma:454-491` — expense category/supplier/order/payment tenant ownership is independent.
+- `backend/prisma/migrations/20260423020000_multi_tenant_fase0/migration.sql:324-373` — single-column FKs reproduce this model.
+
+### Facts
+
+- **FACT:** Required `organizationId` columns and service filters exist.
+- **FACT:** Current FKs do not prove that referenced parent rows belong to the same organization as the child row.
+
+### Problem
+
+Cross-tenant relational consistency is an application convention rather than a database invariant.
+
+### Root Cause
+
+Tenant discriminator columns were added beside globally unique entity IDs without tenant-aware relationship constraints.
+
+### Impact
+
+Maintenance scripts, imports, raw SQL, future services, or application defects can persist cross-tenant relationships without violating current FKs.
+
+### Scope
+
+Inventory, sales, payments, purchasing, expenses, and task/audit relations.
+
+### Related Findings
+
+AUDIT-FINDING-005, AUDIT-FINDING-009.
+
+### Recommendation
+
+Define database-enforced tenant ownership invariants, prioritizing financial and inventory relationships.
+
+---
+
+## AUDIT-FINDING-009
+
+### Title
+
+Financial and inventory row invariants are not database-enforced
+
+### Category
+
+Database
+
+### Severity
+
+HIGH
+
+### Confidence
+
+HIGH
+
+### Status
+
+CONFIRMED
+
+### Evidence
+
+- `backend/prisma/schema.prisma:157-170` — product price/tax/stock/promotion fields.
+- `backend/prisma/schema.prisma:186-200` — inventory movement fields.
+- `backend/prisma/schema.prisma:231-283` — sale/payment/item amounts and quantities.
+- `backend/prisma/schema.prisma:388-401` — ordered/received quantities and PO amounts.
+- `backend/prisma/schema.prisma:454-489` — expense/payment amounts.
+- Targeted search of `backend/prisma/migrations/**/*.sql` found no database `CHECK` constraints.
+
+### Facts
+
+- **FACT:** Basic positivity, range, and equality rules are implemented mainly in services/DTOs.
+- **FACT:** The database permits row-local states such as negative values, received quantity over ordered quantity, or a movement whose arithmetic does not balance.
+
+### Problem
+
+Critical domain invariants can be bypassed by direct Prisma usage, scripts, imports, or new write paths.
+
+### Root Cause
+
+The database schema models types and relations, but not the row-level domain constraints relied upon by financial/inventory logic.
+
+### Impact
+
+Persisted financial and stock data can become internally inconsistent even while satisfying the schema.
+
+### Scope
+
+Products, inventory, sales/payments, purchase orders, and expenses.
+
+### Related Findings
+
+AUDIT-FINDING-006, AUDIT-FINDING-007, AUDIT-FINDING-008.
+
+### Recommendation
+
+Identify authoritative invariants and enforce appropriate row-local bounds/equalities at the database layer, with transactional enforcement for aggregate rules.
+
+---
+
+## AUDIT-FINDING-010
+
+### Title
+
+Production migration and provisioning procedures contradict executable scripts
+
+### Category
+
+DevOps
+
+### Severity
+
+HIGH
+
+### Confidence
+
+HIGH
+
+### Status
+
+CONFIRMED
+
+### Evidence
+
+- `docs/runbooks/runbook-despliegue-produccion.md:25-28,330-389` — claims backend prebuild applies migrations.
+- `backend/package.json:9-15` — prebuild only runs `prisma generate`; start does not migrate.
+- `backend/package.json:28-29` — migrations require a separate script.
+- `.github/workflows/ci.yml:53-63` — CI explicitly migrates because build does not.
+- `docs/runbooks/runbook-despliegue-produccion.md:69-83` — production setup runs `npm run seed` and checks a removed `Settings` table.
+- `backend/package.json:22` and `backend/prisma/seed.ts:403-439` — that command loads development mode, refuses non-development execution, and creates demo organizations/predictable bootstrap credentials if allowed.
+
+### Facts
+
+- **FACT:** The runbook's automatic-migration claim is false for versioned scripts.
+- **FACT:** The documented production seed command conflicts with its hard environment guard and represents demo seeding.
+- **UNKNOWN:** Railway may contain an unversioned pre-deploy migration command, but repository evidence cannot verify it.
+
+### Problem
+
+Operators cannot follow the documented production contract safely or verify who owns schema migration and initial provisioning.
+
+### Root Cause
+
+Deployment behavior lives partly in stale documentation and partly in an unversioned platform control plane.
+
+### Impact
+
+Code may deploy against an older schema; initial provisioning can fail or introduce demo data and predictable credentials.
+
+### Scope
+
+Railway deployment, Supabase schema, production bootstrap, rollback/readiness operations.
+
+### Related Findings
+
+AUDIT-FINDING-011, AUDIT-FINDING-019.
+
+### Recommendation
+
+Establish one verifiable owner for production migrations and a production-safe provisioning contract; align scripts, platform evidence, and runbook.
+
+---
+
+## AUDIT-FINDING-011
+
+### Title
+
+Committed migration history does not fully represent the current schema
+
+### Category
+
+Database
+
+### Severity
+
+HIGH
+
+### Confidence
+
+HIGH
+
+### Status
+
+REQUIRES INVESTIGATION
+
+### Evidence
+
+- `backend/prisma/schema.prisma:424-438` — `PaymentRecord.method` is `PaymentMethod` enum.
+- `backend/prisma/migrations/20260501195935_add_payment_record_and_org_index/migration.sql:5-15` — creates `method TEXT NOT NULL`.
+- No later committed migration converts this column.
+- `backend/prisma/migrations/20260423020000_multi_tenant_fase0/migration.sql:82-126` — adds required organization columns directly to existing tables without an in-script backfill/default.
+- `.github/workflows/ci.yml:57-63` — clean migration replay is intended, but runtime execution was outside this audit.
+
+### Facts
+
+- **FACT:** A database constructed strictly from migrations has a TEXT column where current Prisma metadata expects an enum.
+- **FACT:** The multi-tenant migration assumes affected tables are empty or externally prepared when adding NOT NULL columns.
+- **UNKNOWN:** Clean-chain deployability and live dev/prod drift were not tested; no deployed-drift claim is made.
+
+### Problem
+
+The canonical migration chain and schema are not self-consistent and encode undocumented upgrade assumptions.
+
+### Root Cause
+
+Schema evolution was reconciled in current Prisma declarations without fully reconciling historical DDL and supported upgrade paths.
+
+### Impact
+
+Fresh or legacy database upgrades can differ from generated Prisma expectations or fail on populated pre-multi-tenant databases.
+
+### Scope
+
+Database bootstrap, upgrades, CI migration evidence, PaymentRecord/billing.
+
+### Related Findings
+
+AUDIT-FINDING-010, AUDIT-FINDING-020.
+
+### Recommendation
+
+Reconcile canonical migration history with the current schema and explicitly define supported upgrade assumptions.
+
+---
+
+## Medium Findings
+
+## AUDIT-FINDING-012
+
+### Title
+
+POS cashier search is tested against an unregistered controller
+
+### Category
+
+Backend
+
+### Severity
+
+MEDIUM
+
+### Confidence
+
+HIGH
+
+### Status
+
+CONFIRMED
+
+### Evidence
+
+- `backend/src/products/products.module.ts:9-13` — only `ProductsController` is registered.
+- `backend/src/products/products-search.controller.ts:19-149` — dead duplicate permits CASHIER and emits different response contracts.
+- `backend/src/products/products.controller.ts:107-129` — live search/quick-search permit ADMIN/MEMBER only.
+- `backend/src/products/products-search.controller.spec.ts:32-46` — tests cashier access on the unregistered class.
+- `frontend/src/hooks/useProducts.ts:62-79` and `frontend/src/app/pos/page.tsx:196-206` — POS calls the live quick-search endpoint.
+
+### Facts
+
+- **FACT:** Decorators/tests on the dead controller do not prove runtime registration.
+- **FACT:** A CASHIER reaches a live route that does not authorize CASHIER.
+- **INFERENCE:** Exact scan/search from POS returns HTTP 403 for cashier sessions.
+
+### Problem
+
+Runtime route ownership, role intent, contract shape, and tests disagree for a POS-critical endpoint.
+
+### Root Cause
+
+Search was implemented in parallel without consolidating or registering one authoritative controller.
+
+### Impact
+
+Cashier barcode/SKU quick search can fail, while detached tests provide false confidence.
+
+### Scope
+
+Product search, POS, authorization matrix, Swagger/tests.
+
+### Related Findings
+
+AUDIT-FINDING-015, AUDIT-FINDING-018.
+
+### Recommendation
+
+Establish one registered search contract and align role requirements, consumers, tests, and documentation.
+
+---
+
+## AUDIT-FINDING-013
+
+### Title
+
+Frontend API contracts have multiple authorities and known runtime drift
+
+### Category
+
+Monorepo
+
+### Severity
+
+MEDIUM
+
+### Confidence
+
+HIGH
+
+### Status
+
+CONFIRMED
+
+### Evidence
+
+- `frontend/src/types/index.ts:1-681` — manually maintained API/domain types.
+- `frontend/src/types/index.ts:450-458`, `frontend/src/contexts/AuthContext.tsx:23-40`, `frontend/src/hooks/useAdmin.ts:6-42`, `frontend/src/lib/auth.ts:1-7` — overlapping user/org/role authorities.
+- `frontend/src/types/index.ts:7-15` — monetary fields typed as numbers.
+- `frontend/src/app/pos/page.tsx:302-307` — runtime code compensates for Decimal strings.
+- `frontend/src/hooks/useProducts.ts:82-100` — request bodies use `Partial<Product>`, admitting response-only fields.
+
+### Facts
+
+- **FACT:** No shared/generated package owns request/response contracts.
+- **FACT:** TypeScript declarations already disagree with wire-level decimal behavior and each other.
+
+### Problem
+
+Contract changes can remain type-correct in each application while failing at runtime or being rejected by backend validation.
+
+### Root Cause
+
+API truth is manually reconstructed in domain types, contexts, hooks, and backend DTOs.
+
+### Impact
+
+Runtime coercion, broad request types, drift-prone role/session models, and higher cross-app change cost.
+
+### Scope
+
+Frontend/backend seam across products, auth, admin, billing, and other resources.
+
+### Related Findings
+
+AUDIT-FINDING-012, AUDIT-FINDING-014.
+
+### Recommendation
+
+Assign contract ownership to one source and distinguish wire-level request and response shapes.
+
+---
+
+## AUDIT-FINDING-014
+
+### Title
+
+Global error handling exposes unexpected exception text and emits inconsistent contracts
+
+### Category
+
+Security
+
+### Severity
+
+MEDIUM
+
+### Confidence
+
+HIGH
+
+### Status
+
+CONFIRMED
+
+### Evidence
+
+- `backend/src/common/filters/http-exception.filter.ts:11-26` — public interface says message is a string.
+- `backend/src/common/filters/http-exception.filter.ts:42-55` — validation arrays pass through without normalization.
+- `backend/src/common/filters/http-exception.filter.ts:79-93` — arbitrary `Error.message` replaces the generic 500 message and is returned.
+- `backend/src/common/filters/http-exception.filter.ts:96-99` — every exception is error-logged through the same path.
+- `backend/src/imports/imports.service.ts:861-869,1042-1045` — parser/library errors provide attacker-reachable unexpected messages.
+
+### Facts
+
+- **FACT:** `message` may be `string[]` despite the declared string contract.
+- **FACT:** Non-HTTP internal/library messages cross the API boundary.
+
+### Problem
+
+Public error policy, transport normalization, and diagnostic logging are conflated.
+
+### Root Cause
+
+A catch-all filter performs shallow extraction without a canonical public/diagnostic error model.
+
+### Impact
+
+Client contract drift, possible disclosure of internal paths/infrastructure/parser details, noisy logs, and weak correlation.
+
+### Scope
+
+All backend endpoints, with an additional import-job leakage path.
+
+### Related Findings
+
+AUDIT-FINDING-004, AUDIT-FINDING-016.
+
+### Recommendation
+
+Normalize one truthful public schema and retain sanitized diagnostic context only in protected logs.
+
+---
+
+## AUDIT-FINDING-015
+
+### Title
+
+Quarantine suppresses valid frontend proof and includes obsolete security expectations
+
+### Category
+
+Testing
+
+### Severity
+
+MEDIUM
+
+### Confidence
+
+HIGH
+
+### Status
+
+CONFIRMED
+
+### Evidence
+
+- `frontend/vitest.config.ts:4-28` — four whole files are globally excluded from every configured run.
+- `.github/workflows/ci.yml:86-92` — CI runs the same default configuration and no quarantine job.
+- `frontend/src/app/admin/organizations/[id]/page.test.tsx:124-425` — broad behavior suite quarantined for one stale spinner assertion documented in `docs/design-system/KNOWN_TEST_FAILURES.md:51-62`.
+- `frontend/src/components/dashboard/CategoryStackedChart.test.tsx:19-137` — ten tests quarantined for one tooltip class drift.
+- `frontend/src/contexts/AuthContext.switch.test.tsx:50-90` — expects tokens in localStorage, contradicting current `AuthContext.tsx:47-61,93-99` and active `AuthContext.session.test.tsx:233-275`.
+
+### Facts
+
+- **FACT:** Sales, admin organizations, org switching, and dashboard chart files cannot fail CI through Vitest.
+- **FACT:** Some failures are test defects or obsolete assertions, not product regressions.
+- **UNKNOWN:** Current runtime status of all four files was not executed in this audit.
+
+### Problem
+
+Whole-file quarantine removes valid assertions and preserves retired behavior without an executable revalidation lifecycle.
+
+### Root Cause
+
+Quarantine is an unconditional exclusion list rather than governed, granular test debt.
+
+### Impact
+
+Regressions can merge in unaffected assertions, and re-enabling obsolete tests could pressure the code toward an insecure retired contract.
+
+### Scope
+
+Frontend CI, auth switching, organization administration, sales filters, dashboard charts.
+
+### Related Findings
+
+AUDIT-FINDING-012, AUDIT-FINDING-018.
+
+### Recommendation
+
+Classify each quarantined failure, keep unaffected assertions blocking, and make quarantine ownership/expiry/revalidation observable.
+
+---
+
+## AUDIT-FINDING-016
+
+### Title
+
+Settings query failures masquerade as loading or valid business state
+
+### Category
+
+Frontend
+
+### Severity
+
+MEDIUM
+
+### Confidence
+
+HIGH
+
+### Status
+
+CONFIRMED
+
+### Evidence
+
+- `frontend/src/app/settings/(locale)/locale/page.tsx:9-17` — failed/missing data remains “loading”.
+- `frontend/src/app/settings/(advanced)/advanced/page.tsx:20-41` — same state collapse.
+- `frontend/src/app/settings/(billing)/billing/page.tsx:66-79` — three queries but incomplete loading/error handling.
+- `frontend/src/app/settings/(billing)/billing/page.tsx:134-145` — fallback plan/status displayed when billing response is absent.
+- `frontend/src/app/settings/(billing)/billing/page.tsx:322-367` — payment failure becomes empty history.
+
+### Facts
+
+- **FACT:** Query error, absent data, loading, and empty business state are not consistently distinguished.
+- **FACT:** Billing can render “Basic”/“Active” without a successful authoritative response.
+
+### Problem
+
+Users receive permanent loading screens or fabricated fallback state after API failure.
+
+### Root Cause
+
+No shared query-state contract separates loading, error, empty, and authoritative success.
+
+### Impact
+
+Operational/support decisions may rely on false subscription state; failures have no recovery path.
+
+### Scope
+
+Locale, advanced, billing/payment settings; pattern may exist elsewhere but was confirmed only here.
+
+### Related Findings
+
+AUDIT-FINDING-013, AUDIT-FINDING-014.
+
+### Recommendation
+
+Establish explicit query-state behavior; never substitute business defaults for failed API responses.
+
+---
+
+## AUDIT-FINDING-017
+
+### Title
+
+Reports combine unbounded workloads, process-local cache, and broad responsibilities
+
+### Category
+
+Performance
+
+### Severity
+
+MEDIUM
+
+### Confidence
+
+HIGH
+
+### Status
+
+CONFIRMED
+
+### Evidence
+
+- `backend/src/reports/reports.service.ts:406-1313` — one service owns financial, cash, inventory, dashboard, category, customer, user, and daily reports.
+- `backend/src/reports/reports.service.ts:565-621,915-981,1118-1179,1269-1311` — broad ranges materialize and aggregate matching history in Node.
+- `backend/src/reports/reports.service.ts:679-763` — dashboard runs twelve DB operations on cache miss.
+- `backend/src/common/services/cache.service.ts:9-51` — cache is process-local.
+- `backend/src/sales/sales.service.ts:278,578` — sales mutation clears only dashboard cache.
+- `backend/src/products/products.service.ts:230-235,475-488` — substring search lacks corresponding specialized indexes in committed migrations.
+
+### Facts
+
+- **FACT:** Several report endpoints lack row/range bounds and use in-memory aggregation.
+- **FACT:** Financial and dashboard cache ownership/invalidation differs and is process-local.
+- **INFERENCE:** Memory, transfer, and latency scale with tenant history; multiple instances can disagree until TTL.
+- **UNKNOWN:** Production cardinalities and query plans.
+
+### Problem
+
+Reporting query, accounting, response, and cache responsibilities share one volume-sensitive boundary.
+
+### Root Cause
+
+Reports accumulated endpoint-specific strategies without explicit cost/range and cache-coherence ownership.
+
+### Impact
+
+Volume-dependent latency/memory growth, potentially stale financial responses, and large change blast radius.
+
+### Scope
+
+Reports, dashboard, economic exports, sales/expense mutation invalidation.
+
+### Related Findings
+
+AUDIT-FINDING-014, AUDIT-FINDING-019.
+
+### Recommendation
+
+Define cohesive read models, explicit query-cost/range policy, representative query-plan evidence, and tenant-aware cache ownership.
+
+---
+
+## AUDIT-FINDING-018
+
+### Title
+
+Critical business flows are not proven at the deployed application seam
+
+### Category
+
+Testing
+
+### Severity
+
+MEDIUM
+
+### Confidence
+
+HIGH
+
+### Status
+
+CONFIRMED
+
+### Evidence
+
+- `backend/package.json:17,21,102-104` — E2E uses a separate command outside default Jest project.
+- `.github/workflows/ci.yml:61-63` — CI runs only default backend tests.
+- `backend/test/tax-precedence.e2e-spec.ts:23-49,89-112` and `categories-taxrate.e2e-spec.ts:15-49` — partial applications with mocked Prisma/guards.
+- `backend/test/app.e2e-spec.ts:10-23` — imports AppModule but does not apply shared production bootstrap and tests unprefixed `/`.
+- `frontend/src/app/pos/page.behavior.test.tsx:187-253,490-511` — mocks API/domain seams.
+- `backend/src/sales/sales.service.int.spec.ts:33-50,145-261` — tests service/DB directly and sequentially.
+
+### Facts
+
+- **FACT:** Existing tests prove useful components/services, but not real `/api` routing, cookies/CSRF/guards/error shape and POS payload as one seam.
+- **FACT:** No browser-level runner exists in frontend dependencies/scripts.
+- **FACT:** Existing backend E2E suites are not CI-blocking.
+
+### Problem
+
+The primary revenue path and security/runtime composition can drift between individually tested layers without one test failing.
+
+### Root Cause
+
+Test layers stop below the deployed composition boundary and are routed inconsistently through CI commands.
+
+### Impact
+
+POS payload, authentication, CSRF, DTO, route, and transactional behavior can become mutually incompatible; database concurrency guarantees remain mainly sequentially tested.
+
+### Scope
+
+POS sale, authentication, product search, backend bootstrap, critical transaction behavior.
+
+### Related Findings
+
+AUDIT-FINDING-001 through 004, AUDIT-FINDING-012, AUDIT-FINDING-015.
+
+### Recommendation
+
+Prioritize a small set of real-composition tests for critical journeys and make explicit which unit/integration/E2E layers block CI.
+
+---
+
+## Low Findings
+
+## AUDIT-FINDING-019
+
+### Title
+
+Operational policy, release branch, and observability have no repository authority
+
+### Category
+
+DevOps
+
+### Severity
+
+LOW
+
+### Confidence
+
+HIGH
+
+### Status
+
+REQUIRES INVESTIGATION
+
+### Evidence
+
+- `.github/workflows/ci.yml:3-7` and `.git/refs/remotes/origin/HEAD:1` — automation/repository target `master`.
+- `docs/guias/03-flujo-git-y-convenciones.md:5-20,68-69` — contributor policy targets `main`.
+- `docs/runbooks/runbook-despliegue-produccion.md:119-124,307-328` — uses ambiguous `main/master`.
+- `.github/workflows/ci.yml:45-63,78-102` — no lint or backend E2E despite documented “Linters, Tests y Build”.
+- `backend/docker-compose.yml:1-5` vs `.github/workflows/ci.yml:14-19` — PostgreSQL 15 locally, 17 in CI; production major unknown.
+- `backend/src/app.controller.ts:17-31` and `docs/runbooks/runbook-despliegue-produccion.md:407-413,488-493` — health only checks DB; operations depend on manual platform-log review.
+- No versioned Railway/Vercel deployment configuration exists.
+
+### Facts
+
+- **FACT:** Written release/quality policy and automation disagree.
+- **FACT:** Effective platform migration hook, branch, Node/Postgres version, alerts, and rollback settings are not auditable from the repo.
+- **UNKNOWN:** Hosted branch protection and platform configuration.
+
+### Problem
+
+Release and operational behavior depends on undocumented or stale external state.
+
+### Root Cause
+
+The production control plane and documentation evolved independently from repository automation.
+
+### Impact
+
+Contributor mistakes, checks bypassed by branch mismatch, environment-specific migration behavior, and delayed incident detection.
+
+### Scope
+
+GitHub, CI, Railway, Vercel, Supabase, local development and operations.
+
+### Related Findings
+
+AUDIT-FINDING-010, AUDIT-FINDING-017, AUDIT-FINDING-020.
+
+### Recommendation
+
+Declare one release/quality/runtime policy and preserve reviewable non-secret evidence of effective platform configuration and observability ownership.
+
+---
+
+## AUDIT-FINDING-020
+
+### Title
+
+Repository guidance and retired capabilities remain active-looking
+
+### Category
+
+Documentation
+
+### Severity
+
+LOW
+
+### Confidence
+
+HIGH
+
+### Status
+
+CONFIRMED
+
+### Evidence
+
+- `AGENTS.md:55-83` and identical `CLAUDE.md` — describe localStorage JWT, three roles, Settings model, Manrope/256px sidebar, live registration and two products controllers.
+- `frontend/src/lib/session.ts:1-21`, `frontend/src/lib/auth.ts:1-7`, `backend/src/products/products.module.ts:9-13` — current code contradicts those claims.
+- `frontend/src/app/register/page.tsx:26-39`, `backend/src/auth/auth.controller.ts:91-241` — self-registration is intentionally absent.
+- `backend/src/auth/auth.service.ts:32-56`, `backend/src/auth/dto/auth.dto.ts:33-52`, `backend/src/common/guards/cookie-csrf.guard.ts:19` — residual register service/DTO/CSRF policy remains.
+- `docs/runbooks/runbook-despliegue-produccion.md:108-110,409-413` vs `backend/src/main.ts:49-64` — production runbook requires Swagger while production disables it.
+
+### Facts
+
+- **FACT:** Multiple active-looking guides contradict executable behavior.
+- **FACT:** Public registration absence is intentional; treating it as a missing feature is a false positive.
+- **FACT:** Dead register/search artifacts preserve retired contracts.
+
+### Problem
+
+Humans and coding agents are given incorrect architecture, security, and operational instructions.
+
+### Root Cause
+
+There is no maintained documentation authority or complete capability-retirement process.
+
+### Impact
+
+Incorrect changes, false audit conclusions, unsafe runbook actions, and accidental re-exposure of retired behavior.
+
+### Scope
+
+Agent instructions, READMEs, architecture docs, auth/search residual code, deployment runbook.
+
+### Related Findings
+
+AUDIT-FINDING-010, AUDIT-FINDING-012, AUDIT-FINDING-019.
+
+### Recommendation
+
+Establish one current guidance source, clearly mark historical documents, and retire capabilities across code, policy, tests, and docs as one unit.
+
+## Requires Investigation
+
+The following findings are counted in the 20 findings above and must not be stated as confirmed production failures:
+
+1. **AUDIT-FINDING-011 — migration deployability/live drift.** The committed PaymentRecord mismatch is confirmed, but clean-chain execution and deployed `_prisma_migrations` state are UNKNOWN. Verification requires a disposable clean database plus read-only inspection of deployed migration metadata under explicit operational authorization.
+2. **AUDIT-FINDING-019 — effective hosted control plane.** Branch protection, Railway/Vercel production branches, migration hooks, runtime versions, rollback policy, and alerting are UNKNOWN because they are not versioned.
+
+Not promoted without evidence:
+
+- Dependency CVEs (no advisory report was available and no audit command was run).
+- Production database drift or data corruption.
+- Exploitable SQL injection/XSS.
+- Current runtime failures of all quarantined tests.
+- Production performance severity without cardinalities and query plans.
+
+## Findings Relationships
+
+| Root-cause cluster | Findings | Consolidated symptoms |
+|---|---|---|
+| Session/tenant scope mismatch | 001, 002, 003, 005 | Refresh crossover, password sessions, suspension behavior, stale import authority |
+| Missing invariant ownership | 006, 007, 008, 009 | Partial writes, concurrency races, tenant FK gaps, weak row constraints |
+| Contract/runtime split | 004, 012, 013, 014, 016, 020 | Audit actor mismatch, dead controller tests, type drift, errors, misleading UI/docs |
+| Proof below production seam | 015, 018 | Whole-file quarantine, obsolete tests, E2E not blocking/full composition absent |
+| Deployment/control-plane drift | 010, 011, 019, 020 | Migration owner, seed/runbook, branch/policy/platform unknowns |
+| Single-process/volume assumptions | 005, 017, 019 | Ephemeral jobs, process-local cache, broad reporting, weak operations telemetry |
+
+## SDD Candidates
+
+Recommended independent future change candidates (not started):
+
+1. **Session and tenant authorization lifecycle** — findings 001–003; include password revocation, session families, org-scoped suspension/revocation.
+2. **Durable tenant-authorized import lifecycle** — finding 005; findings 006/008/009 are constraints, not necessarily the same change.
+3. **Financial and inventory invariant boundaries** — findings 006–009, sliced by invariant if forecast exceeds review capacity.
+4. **Production migration/provisioning authority** — findings 010–011; first prove clean-chain/deployed state.
+5. **Product-search runtime contract** — finding 012; focused route/role/test reconciliation.
+6. **API contract authority and error model** — findings 013–014; may require separate slices.
+7. **Critical-path test architecture** — findings 015 and 018.
+8. **Reporting read-model/cost/cache contract** — finding 017 after representative performance evidence.
+
+## Non-SDD Improvements
+
+- Remove or formally adopt unused RHF/Zod/resolver dependencies as one cleanup item; no browser-bundle impact was proven.
+- Declare direct ownership of `uuid` or use an existing platform primitive; current resolution relies on ExcelJS's transitive dependency (`backend/src/cloudinary/cloudinary.service.ts:1-7`, `backend/package-lock.json:6047-6062,11496-11503`).
+- Complete the intentional retirement of public registration after confirming no external consumer.
+- Decide and document settings navigation intent for `/settings/billing`, `/settings/locale`, and `/settings/advanced`; current tests deliberately keep them hidden (`frontend/src/app/settings/sections.ts:16-40`, `layout.behavior.test.tsx:44-57`).
+- Align Swagger/runbook wording and root agent guidance without treating every stale sentence as an independent finding.
+- Add consistent upload limits/type validation to organization logo upload (`backend/src/settings/settings.controller.ts:66-75`); this can be grouped with upload-policy cleanup unless operational evidence raises severity.
+
+## Summary Matrix
+
+| ID | Finding | Category | Severity | Confidence | Root Cause | SDD Candidate |
+|---|---|---|---|---|---|---|
+| 001 | Refresh grace crosses session/org boundaries | Security | HIGH | HIGH | User-wide token recovery | YES |
+| 002 | Password change leaves sessions valid | Security | HIGH | HIGH | Credential/session lifecycle split | YES |
+| 003 | Suspension guard/revocation scope mismatch | Security | HIGH | HIGH | Auth order + global user state | YES |
+| 004 | Declared audit events are skipped | Security | HIGH | HIGH | Request-user contract mismatch | YES |
+| 005 | Import jobs non-durable and stale-authorized | Backend | HIGH | HIGH | Process-local duplicated job model | YES |
+| 006 | Inventory/billing multi-writes non-atomic | Database | HIGH | HIGH | Ad hoc transaction boundaries | YES |
+| 007 | Expense/cancellation concurrency races | Database | HIGH | HIGH | Validation outside lock/isolation | YES |
+| 008 | Cross-table tenant ownership not DB-enforced | Database | HIGH | HIGH | Independent tenant/entity FKs | MAYBE |
+| 009 | Financial/inventory checks absent in DB | Database | HIGH | HIGH | Invariants live only in services | MAYBE |
+| 010 | Production migration/provisioning contradiction | DevOps | HIGH | HIGH | Stale runbook + unversioned platform | YES |
+| 011 | Migration history differs from schema | Database | HIGH | HIGH | Historical DDL not reconciled | YES |
+| 012 | Cashier POS search hits wrong live contract | Backend | MEDIUM | HIGH | Dead parallel controller | YES |
+| 013 | API contract authorities drift | Monorepo | MEDIUM | HIGH | Manual duplicated contracts | YES |
+| 014 | Error model leaks/inconsistent shape | Security | MEDIUM | HIGH | Catch-all shallow normalization | YES |
+| 015 | Quarantine suppresses valid proof | Testing | MEDIUM | HIGH | Whole-file unmanaged exclusion | NO |
+| 016 | Settings failures show false state/loading | Frontend | MEDIUM | HIGH | Missing query-state contract | MAYBE |
+| 017 | Reports are unbounded/process-local cached | Performance | MEDIUM | HIGH | Mixed read-model/cost ownership | MAYBE |
+| 018 | Critical flow lacks deployed-seam proof | Testing | MEDIUM | HIGH | Test layers stop below composition | YES |
+| 019 | Release/ops policy lacks repo authority | DevOps | LOW | HIGH | External/stale control-plane truth | MAYBE |
+| 020 | Active guidance preserves retired truth | Documentation | LOW | HIGH | No documentation/retirement authority | NO |

--- a/docs/sdd/audit/triage.md
+++ b/docs/sdd/audit/triage.md
@@ -1,0 +1,467 @@
+# Audit Findings Triage
+
+> **Scope:** final technical triage of `docs/sdd/audit/audit-findings.md`, using `docs/sdd/project-baseline.md` as architectural context and targeted verification against current source.  
+> **Date:** 2026-09-02.  
+> No code, configuration, dependency, GitHub Issue, proposal, specification, design, or task was created or modified by this triage.
+
+## Confirmed Findings
+
+### AUDIT-FINDING-001 — CONFIRMED
+
+- **Severity:** HIGH
+- **Impact:** During the 60-second reuse grace window, a revoked refresh token for a user with multiple sessions can select an unrelated active token, potentially changing the resulting organization scope and revoking an unrelated session.
+- **Root cause:** Recovery selects any recent active token by `userId`, without session-family, direct-replacement, or organization lineage.
+- **Scope:** Multi-session users; cross-organization impact requires multi-organization membership.
+- **Independent GitHub Issue:** **No** — group into the session/tenant authorization lifecycle issue with 002 and 003.
+- **Grouping:** Same issue cluster as 002 and 003; distinct failure mode within that issue.
+- **Evidence:** `backend/src/auth/auth.service.ts:289-310,329-391`; `backend/prisma/schema.prisma:89-104`; `backend/src/auth/auth.constants.ts:15-24`.
+
+### AUDIT-FINDING-002 — CONFIRMED
+
+- **Severity:** HIGH
+- **Impact:** A password change does not terminate already-issued access or refresh sessions; a stolen token can remain usable after the user changes the password.
+- **Root cause:** Password mutation is disconnected from the centralized token-revocation path.
+- **Scope:** All accounts using `POST /auth/change-password`, including SuperAdmin.
+- **Independent GitHub Issue:** **No** — group with 001 and 003 under session/tenant authorization lifecycle.
+- **Grouping:** Same issue as 001/003 at GitHub level; keep as a separately named acceptance slice.
+- **Evidence:** `backend/src/auth/auth.controller.ts:157-165`; `backend/src/auth/auth.service.ts:415-426,528-555`; `backend/src/auth/jwt.strategy.ts:40-42`.
+
+### AUDIT-FINDING-003 — CONFIRMED
+
+- **Severity:** HIGH, with one impact qualifier below.
+- **Impact:** The global organization-status guard runs before route-level authentication and therefore does not evaluate authenticated organization status in its declared position. Separately, suspension increments global `User.tokenVersion`, invalidating sessions for other organizations. The possibility of a residual write window after suspension is **not** confirmed and requires investigation.
+- **Root cause:** Organization status enforcement depends on `request.user` before it exists, while suspension revocation is global-user scoped.
+- **Scope:** Tenant write routes and multi-organization users.
+- **Independent GitHub Issue:** **No** — group with 001 and 002.
+- **Grouping:** Session/tenant authorization lifecycle. Do not merge with import authorization (005).
+- **Evidence:** `backend/src/app.module.ts:73-90`; `backend/src/common/guards/organization-status.guard.ts:10-39`; `backend/src/auth/jwt.strategy.ts:77-91`; `backend/src/admin/admin.service.ts:177-193`; `backend/src/auth/auth.service.ts:478-496`.
+
+### AUDIT-FINDING-004 — CONFIRMED
+
+- **Severity:** HIGH
+- **Impact:** Live routes marked with `@AuditAction` do not produce durable audit records when authenticated requests expose `userId` but the interceptor requires `sub`. This reduces accountability and incident evidence.
+- **Root cause:** Authentication and audit layers use incompatible request-user contracts.
+- **Scope:** Routes using `AuditInterceptor`; login's actor-availability path is also not covered by this interceptor.
+- **Independent GitHub Issue:** **Yes** — audit event persistence and actor contract.
+- **Grouping:** Related to API contracts (013) and error handling (014), but not a duplicate.
+- **Evidence:** `backend/src/common/interfaces/request-user.interface.ts:3-10`; `backend/src/auth/jwt.strategy.ts:56-63,83-91`; `backend/src/common/interceptors/audit.interceptor.ts:142-176`; `backend/src/products/products.controller.ts:138-177`; `backend/src/users/users.controller.ts:43-109`.
+
+### AUDIT-FINDING-005 — CONFIRMED
+
+- **Severity:** HIGH
+- **Impact:** Restart, redeploy, or another instance loses import status/errors/retry state while prior row writes remain. A user changing organizations can continue a job using only global `userId`, and retry writes use the stored organization without fresh membership/status verification.
+- **Root cause:** Two duplicated process-local job lifecycles combine ephemeral state with user-only continuation authorization.
+- **Scope:** Product and multi-sheet imports, polling, row retries, and operational recovery.
+- **Independent GitHub Issue:** **Yes** — durable, tenant-authorized import lifecycle.
+- **Grouping:** Related to runtime/control-plane investigation (019), but not merged; the defect is in application behavior.
+- **Evidence:** `backend/src/imports/imports.service.ts:71-99,115-131,216-220,984-997`; `backend/src/imports/multi-sheet-import.service.ts:80-111,625-645`; `backend/src/imports/imports.controller.ts:139-178`.
+
+### AUDIT-FINDING-006 — CONFIRMED
+
+- **Severity:** HIGH
+- **Impact:** Partial failure can leave product stock without its inventory movement, remove all default cash registers before replacement succeeds, or persist a billing payment without the associated organization transition.
+- **Root cause:** Invariant-bearing multi-write actions are not consistently enclosed in one transaction.
+- **Scope:** Products/inventory, cash registers, and billing payment records.
+- **Independent GitHub Issue:** **Yes**, as the atomicity slice of the financial/inventory invariant cluster.
+- **Grouping:** Cluster with 007, 008, and 009; do not merge into one unbounded issue.
+- **Evidence:** `backend/src/products/products.service.ts:180-203,369-407`; `backend/src/cash-registers/cash-registers.service.ts:35-48,114-124`; `backend/src/billing/payment-records.service.ts:23-45`.
+
+### AUDIT-FINDING-007 — CONFIRMED
+
+- **Severity:** HIGH
+- **Impact:** Concurrent expense-payment requests can validate against the same prior sum; concurrent cancellation requests can both restore stock and create return movements. These outcomes are inferred from the schedule, not runtime-reproduced.
+- **Root cause:** Validation and one-time transition ownership occur outside a concurrency-controlled mutation boundary.
+- **Scope:** Expense payments and sale cancellation.
+- **Independent GitHub Issue:** **Yes**, as the concurrency slice of the financial/inventory invariant cluster.
+- **Grouping:** Related to 006 and 009; distinct because its trigger is competing writers.
+- **Evidence:** `backend/src/expenses/expenses.service.ts:392-455`; `backend/src/sales/sales.service.ts:454-515`; `backend/prisma/schema.prisma:454-489`.
+
+### AUDIT-FINDING-008 — CONFIRMED
+
+- **Severity:** HIGH risk/design weakness; exploitability is conditional.
+- **Impact:** The database permits child and referenced parent rows from different organizations because foreign keys validate IDs independently, not tenant equality. No current bad row or normal API exploit was demonstrated.
+- **Root cause:** Tenant discriminator columns were added without tenant-aware composite relationship enforcement.
+- **Scope:** Product/category, sales/items/payments, purchasing, expenses, tasks, and audit-related relations.
+- **Independent GitHub Issue:** **Yes**, as a tenant-integrity database slice, if constraint scope is approved.
+- **Grouping:** Financial/inventory/tenant invariant cluster with 006, 007, and 009; not duplicate of row-local constraints.
+- **Evidence:** `backend/prisma/schema.prisma:164-176,260-290,359-405,454-491`; `backend/prisma/migrations/20260423020000_multi_tenant_fase0/migration.sql:324-373`.
+
+### AUDIT-FINDING-009 — CONFIRMED
+
+- **Severity:** HIGH risk/design weakness; current invalid data was not demonstrated.
+- **Impact:** Direct, future, script, import, or defective write paths can persist negative or arithmetically inconsistent financial/inventory rows while satisfying the schema.
+- **Root cause:** Important row-local domain constraints live mainly in services/DTOs, not in database constraints.
+- **Scope:** Product, inventory movement, sales/payments, purchase orders, expenses, and expense payments.
+- **Independent GitHub Issue:** **Yes**, as a row-invariant database slice, separate from atomicity and concurrency.
+- **Grouping:** Cluster with 006–008; distinct invariant and acceptance evidence.
+- **Evidence:** `backend/prisma/schema.prisma:157-170,186-200,231-283,388-401,454-489`; targeted migration search found no committed `CHECK` constraints.
+
+### AUDIT-FINDING-010 — CONFIRMED
+
+- **Severity:** HIGH
+- **Impact:** Operators following the runbook may deploy without the documented migration behavior, fail production provisioning, or execute a development/demo seed path in production.
+- **Root cause:** Runbook, versioned scripts, CI, and external platform configuration do not have one verified deployment contract.
+- **Scope:** Production migration ownership, provisioning, Railway/Supabase deployment, Swagger readiness check, and rollback operations.
+- **Independent GitHub Issue:** **Yes** — production migration/provisioning authority.
+- **Grouping:** Related to 011, 019, and 020, but keep separate because evidence and closure criteria differ.
+- **Evidence:** `docs/runbooks/runbook-despliegue-produccion.md:25-28,69-83,108-110,330-389`; `backend/package.json:9-15,22,28-29`; `backend/prisma/seed.ts:403-439`; `backend/src/main.ts:49-64`; `.github/workflows/ci.yml:53-63`.
+
+### AUDIT-FINDING-012 — CONFIRMED
+
+- **Severity:** MEDIUM
+- **Impact:** POS cashier barcode/SKU lookup reaches the registered controller, which excludes CASHIER, while the detached duplicate controller and its tests advertise CASHIER access. The exact HTTP 403 is statically supported but not runtime-executed.
+- **Root cause:** Parallel search implementations were retained without one authoritative registered route contract.
+- **Scope:** Product search, POS, role authorization, API response shape, and related tests.
+- **Independent GitHub Issue:** **Yes** — POS product-search runtime contract.
+- **Grouping:** Related to contract drift (013) and stale guidance (020), not merged.
+- **Evidence:** `backend/src/products/products.module.ts:9-13`; `backend/src/products/products-search.controller.ts:19-149`; `backend/src/products/products.controller.ts:107-129`; `backend/src/products/products-search.controller.spec.ts:32-46`; `frontend/src/hooks/useProducts.ts:62-79`; `frontend/src/app/pos/page.tsx:206,468`.
+
+### AUDIT-FINDING-013 — CONFIRMED
+
+- **Severity:** MEDIUM
+- **Impact:** Multiple frontend representations of users, organizations, roles, decimals, and mutation payloads allow compile-time agreement inside each app while wire behavior drifts or backend validation rejects requests.
+- **Root cause:** No single authoritative/generated API contract; request and response types are manually reconstructed.
+- **Scope:** Frontend/backend seam, especially products/POS, auth/org switching, billing, admin, and monetary resources.
+- **Independent GitHub Issue:** **Yes** — API contract authority and wire-shape governance.
+- **Grouping:** Related to 004 and 014, but retain separate acceptance boundaries.
+- **Evidence:** `frontend/src/types/index.ts:1-681,450-458`; `frontend/src/contexts/AuthContext.tsx:23-40`; `frontend/src/hooks/useAdmin.ts:6-42`; `frontend/src/lib/auth.ts:1-7`; `frontend/src/app/pos/page.tsx:302-307`; `frontend/src/hooks/useProducts.ts:82-100`.
+
+### AUDIT-FINDING-014 — CONFIRMED
+
+- **Severity:** MEDIUM
+- **Impact:** Validation arrays violate the declared error shape, and unexpected library/internal `Error.message` values can cross the API boundary; parser errors create an attacker-reachable example. A specific secret/path disclosure was not proven.
+- **Root cause:** Catch-all error handling does not separate canonical public responses from protected diagnostic details.
+- **Scope:** All backend endpoints using the global filter, especially imports.
+- **Independent GitHub Issue:** **Yes** — canonical public error and diagnostic model.
+- **Grouping:** Related to 013; not duplicate. Keep security disclosure scope explicit.
+- **Evidence:** `backend/src/common/filters/http-exception.filter.ts:11-26,42-55,79-99`; `backend/src/imports/imports.service.ts:861-869,1042-1045`; `frontend/src/lib/api.ts:25-77`.
+
+### AUDIT-FINDING-015 — CONFIRMED
+
+- **Severity:** MEDIUM
+- **Impact:** Four complete frontend test files cannot fail CI through Vitest, suppressing valid assertions in sales, admin organizations, organization switching, and charts. One excluded auth test asserts an obsolete localStorage token contract.
+- **Root cause:** Whole-file quarantine is unconditional and lacks current classification/revalidation governance.
+- **Scope:** Frontend CI and the four excluded suites.
+- **Independent GitHub Issue:** **Yes**, but a testing-governance issue, not a product-regression issue.
+- **Grouping:** Same testing cluster as 018; keep separate.
+- **Evidence:** `frontend/vitest.config.ts:4-28`; `.github/workflows/ci.yml:86-92`; `frontend/src/contexts/AuthContext.switch.test.tsx:50-90`; `frontend/src/contexts/AuthContext.session.test.tsx:233-275`; `docs/design-system/KNOWN_TEST_FAILURES.md:51-75`.
+
+### AUDIT-FINDING-016 — CONFIRMED
+
+- **Severity:** MEDIUM
+- **Impact:** Settings failures can appear as permanent loading, empty payment history, or authoritative `BASIC`/`ACTIVE` billing state without a successful response.
+- **Root cause:** Frontend query states do not consistently distinguish loading, error, empty, partial, and authoritative success.
+- **Scope:** `/settings/locale`, `/settings/advanced`, and `/settings/billing`; broader generalization is not made.
+- **Independent GitHub Issue:** **Yes** — frontend query-state handling.
+- **Grouping:** Related to 013 but not merged; hidden navigation is not part of this confirmed problem.
+- **Evidence:** `frontend/src/app/settings/(locale)/locale/page.tsx:9-17`; `frontend/src/app/settings/(advanced)/advanced/page.tsx:20-41`; `frontend/src/app/settings/(billing)/billing/page.tsx:66-79,134-145,322-367`.
+
+### AUDIT-FINDING-017 — CONFIRMED
+
+- **Severity:** MEDIUM; production performance severity remains workload-dependent.
+- **Impact:** Broad report ranges are materialized and aggregated in Node; caches are process-local, and sales invalidation clears dashboard keys but not cited financial keys. Production cardinalities, plans, and latency are unknown.
+- **Root cause:** Reporting query cost, aggregation, response, and cache-coherence ownership accumulated in one boundary.
+- **Scope:** Reports, dashboard, economic exports, sales/expense invalidation, and multi-instance behavior.
+- **Independent GitHub Issue:** **Yes, conditionally** — create only with a bounded measurement/optimization scope.
+- **Grouping:** Reporting read-model/cost/cache cluster; not merged with external observability investigation 019.
+- **Evidence:** `backend/src/reports/reports.service.ts:565-621,679-763,915-981,1118-1179,1269-1311`; `backend/src/common/services/cache.service.ts:9-67`; `backend/src/sales/sales.service.ts:278,578`.
+
+### AUDIT-FINDING-018 — CONFIRMED
+
+- **Severity:** MEDIUM
+- **Impact:** No CI-blocking test proves the real POS/API/backend composition with `/api` routing, cookies, CSRF, guards, DTOs, error serialization, and transactional behavior together.
+- **Root cause:** Test layers stop below the deployed composition boundary and E2E commands are outside default CI.
+- **Scope:** POS sale, authentication, CSRF, org authorization, bootstrap, product search, and critical transaction behavior.
+- **Independent GitHub Issue:** **Yes** — critical-path composition testing.
+- **Grouping:** Testing cluster with 015; separate issue because closure evidence differs.
+- **Evidence:** `backend/package.json:17,21,102-104`; `.github/workflows/ci.yml:61-63`; `backend/test/tax-precedence.e2e-spec.ts:23-49,89-112`; `backend/test/app.e2e-spec.ts:10-23`; `frontend/src/app/pos/page.behavior.test.tsx:187-253,490-511`; `backend/src/sales/sales.service.int.spec.ts:33-50,145-261`.
+
+### AUDIT-FINDING-020 — CONFIRMED
+
+- **Severity:** LOW
+- **Impact:** Humans and agents may make incorrect changes, misclassify tests, follow unsafe runbook instructions, or revive retired behavior.
+- **Root cause:** No maintained documentation authority or complete capability-retirement process.
+- **Scope:** AGENTS/CLAUDE, READMEs, architecture/runbook docs, auth/search residuals, and policy/test references.
+- **Independent GitHub Issue:** **Yes, but low priority** — documentation authority and capability retirement.
+- **Grouping:** Related to 010, 012, and 019; do not absorb their runtime or external-control-plane evidence.
+- **Evidence:** `AGENTS.md:55-83`; `CLAUDE.md:55-83`; `frontend/src/lib/session.ts:1-21`; `frontend/src/lib/auth.ts:1-7`; `backend/src/products/products.module.ts:9-13`; `backend/src/auth/auth.service.ts:32-56`; `backend/src/auth/dto/auth.dto.ts:33-52`; `backend/src/common/guards/cookie-csrf.guard.ts:19`.
+
+## False Positives
+
+The following interpretations are rejected, while the narrower findings above remain valid:
+
+| Original signal/claim | Classification | Reason |
+|---|---|---|
+| Missing public `/auth/register` is a current feature defect | FALSE POSITIVE | Current UI says registration is disabled and `AuthController` has no register route. Residual code/docs are covered by 020. |
+| `products-search.controller.ts` is live because it has decorators/tests | FALSE POSITIVE | `ProductsModule` registers only `ProductsController`; its live-role mismatch is instead 012. |
+| Client-side route guards alone expose tenant data | FALSE POSITIVE | Backend authorization remains enforced; absence of Next middleware is not independently a data-exposure finding. |
+| Billing scheduler is accidentally broken | FALSE POSITIVE | The daily scheduler is explicitly a manual-billing no-op by design. |
+| All duplicated types are defects | FALSE POSITIVE | The finding is limited to concrete runtime/wire drift, not every view-specific type. |
+| All large frontend/backend files are automatically bad | FALSE POSITIVE | Findings use demonstrated state coupling, unbounded work, or proof gaps—not line count alone. |
+| Production database is already out of sync | FALSE POSITIVE | No live database or `_prisma_migrations` state was inspected. |
+| Dependency versions have confirmed CVEs | FALSE POSITIVE | No advisory evidence was available and no audit command was run. |
+| Existing E2E/controller tests are worthless | FALSE POSITIVE | They provide useful partial coverage; 018 identifies the missing production-composition proof. |
+| Hidden settings routes are definitely an accidental navigation defect | FALSE POSITIVE | Tests intentionally assert their absence from navigation; intent remains a product-policy question. |
+
+## Needs Investigation
+
+### AUDIT-FINDING-011 — NEEDS INVESTIGATION
+
+The repository inconsistency is confirmed, but its runtime/deployment consequence is not.
+
+**Confirmed facts:**
+
+- `backend/prisma/schema.prisma:424-438` declares `PaymentRecord.method` as `PaymentMethod`.
+- `backend/prisma/migrations/20260501195935_add_payment_record_and_org_index/migration.sql:5-15` creates it as `TEXT`.
+- No later committed conversion was found.
+- `20260423020000_multi_tenant_fase0/migration.sql:82-126` adds required `organizationId` columns without an in-script backfill/default.
+
+**Missing evidence required:**
+
+1. Replay all migrations on a disposable empty PostgreSQL database and record success/failure.
+2. Inspect the resulting PostgreSQL type for `PaymentRecord.method` and compare it with generated Prisma metadata.
+3. Execute representative Prisma `PaymentRecord` reads/writes against the clean replay.
+4. Apply the multi-tenant migration to a representative populated pre-multi-tenant database and record whether it succeeds.
+5. Under explicit operational authorization, inspect deployed `_prisma_migrations` records and relevant PostgreSQL catalog types.
+
+**Severity:** Potentially HIGH, but conditional until this evidence exists.  
+**GitHub treatment:** Create an investigation issue, not a confirmed production-incident issue.
+
+### AUDIT-FINDING-019 — NEEDS INVESTIGATION
+
+Repository policy drift is confirmed, but hosted behavior is not observable from the repository.
+
+**Confirmed facts:**
+
+- CI targets `master`: `.github/workflows/ci.yml:3-7`.
+- Contributor guidance targets `main`: `docs/guias/03-flujo-git-y-convenciones.md:5-20,68-69`.
+- CI omits lint and backend E2E despite broader documentation claims.
+- Local Docker uses PostgreSQL 15 while CI uses PostgreSQL 17.
+- No versioned Railway/Vercel configuration exists.
+
+**Missing evidence required:**
+
+1. Actual GitHub default branch, branch protection, required checks, and merge rules.
+2. Railway production branch, build/start command, migration/pre-deploy hook, Node version, health check, and rollback settings.
+3. Vercel production branch/build settings and environment scoping.
+4. Supabase PostgreSQL major version and migration state.
+5. Alerting, retention, correlation, and ownership for production observability.
+
+**Severity:** LOW with potential escalation only if missing controls are proven.  
+**GitHub treatment:** Create an investigation/governance issue; do not claim production failure yet.
+
+## Duplicate / Merge
+
+No finding is a complete duplicate that should be closed. The following are **related clusters**, not automatic merges:
+
+### Session and tenant authorization lifecycle
+
+- 001 refresh-token recovery lineage
+- 002 password-change session invalidation
+- 003 suspension guard and revocation scope
+
+Recommended GitHub boundary: one issue with three explicit acceptance slices. They share session/tenant lifecycle ownership and should be addressed together to avoid fixing one scope while leaving the others inconsistent.
+
+### Financial, inventory, and tenant invariant ownership
+
+- 006 partial-write atomicity
+- 007 concurrent-write protection
+- 008 cross-table tenant ownership
+- 009 row-level value constraints
+
+Recommended GitHub boundary: one umbrella program or four bounded issues/slices. Do not collapse them into one issue if reviewability or migration risk requires separate ownership; fixing one does not prove the others.
+
+### Contract/runtime truth
+
+- 004 audit actor contract
+- 012 live POS search contract
+- 013 API contract authority
+- 014 public error contract
+- 020 documentation/capability retirement
+
+Recommended treatment: keep concrete runtime defects separate from governance. A documentation update cannot prove audit persistence or cashier POS behavior.
+
+### Testing proof
+
+- 015 excessive/unmanaged quarantine
+- 018 missing deployed-composition proof
+
+Recommended treatment: related testing program, separate issues and closure criteria.
+
+### Deployment and migration authority
+
+- 010 confirmed runbook/script contradiction
+- 011 migration-chain investigation
+- 019 hosted control-plane investigation
+- 020 stale guidance
+
+Recommended treatment: link, do not merge. Each requires a different evidence source and owner.
+
+## Recommended GitHub Issues
+
+The following issue set represents **independent trackable problems**, not necessarily one issue per original finding.
+
+### Issue
+
+#### Session and tenant authorization lifecycle is not consistently scoped
+
+**Finding(s):** 001, 002, 003  
+**Problem:** Refresh reuse recovery is user-wide, password changes do not revoke sessions, and organization suspension combines pre-auth status enforcement with global-user revocation.  
+**Impact:** Cross-session/organization crossover risk, persistent compromised sessions, and unrelated-organization logout/availability impact.  
+**Evidence:** `backend/src/auth/auth.service.ts:289-391,415-426,478-496,528-555`; `backend/src/common/guards/organization-status.guard.ts:10-39`; `backend/src/app.module.ts:73-90`.  
+**Suggested Labels:** `security`, `bug`, `architecture`  
+**SDD Candidate:** YES
+
+### Issue
+
+#### Restore durable tenant-authorized import jobs
+
+**Finding(s):** 005  
+**Problem:** Import job state is process-local and continuation checks user identity without current organization membership/status.  
+**Impact:** Lost recovery state after restart/scaling, ambiguous partial imports, and stale cross-organization continuation.  
+**Evidence:** `backend/src/imports/imports.service.ts:71-99,216-220,984-997`; `backend/src/imports/multi-sheet-import.service.ts:80-111,625-645`; `backend/src/imports/imports.controller.ts:139-178`.  
+**Suggested Labels:** `bug`, `security`, `architecture`, `technical-debt`  
+**SDD Candidate:** YES
+
+### Issue
+
+#### Ensure audit-decorated mutations produce durable actor-scoped records
+
+**Finding(s):** 004  
+**Problem:** `AuditInterceptor` expects `request.user.sub`, while authenticated requests expose `userId`, causing the interceptor to skip audit writes.  
+**Impact:** Missing accountability and incident evidence for security-relevant mutations.  
+**Evidence:** `backend/src/common/interfaces/request-user.interface.ts:3-10`; `backend/src/auth/jwt.strategy.ts:56-63,83-91`; `backend/src/common/interceptors/audit.interceptor.ts:142-176`.  
+**Suggested Labels:** `security`, `bug`, `audit`  
+**SDD Candidate:** YES
+
+### Issue
+
+#### Make financial and inventory invariants atomic, concurrent-safe, and tenant-consistent
+
+**Finding(s):** 006, 007, 008, 009  
+**Problem:** Related writes can commit partially, competing writers validate stale state, and the database does not enforce key tenant/value invariants.  
+**Impact:** Possible stock/ledger divergence, overpaid expenses, duplicate returns, cross-tenant relationships, and invalid persisted financial values.  
+**Evidence:** `backend/src/products/products.service.ts:180-203,369-407`; `backend/src/expenses/expenses.service.ts:392-455`; `backend/src/sales/sales.service.ts:454-515`; `backend/prisma/schema.prisma:157-200,231-291,359-405,454-491`.  
+**Suggested Labels:** `bug`, `security`, `database`, `architecture`  
+**SDD Candidate:** YES
+
+### Issue
+
+#### Establish one production migration and provisioning authority
+
+**Finding(s):** 010  
+**Problem:** The runbook claims migrations occur in prebuild and directs production toward a development/demo seed, while versioned scripts do neither safely.  
+**Impact:** Schema/application mismatch, failed provisioning, demo data, or unsafe bootstrap behavior.  
+**Evidence:** `docs/runbooks/runbook-despliegue-produccion.md:25-28,69-83,330-389`; `backend/package.json:9-15,22,28-29`; `backend/prisma/seed.ts:403-439`.  
+**Suggested Labels:** `bug`, `devops`, `documentation`, `technical-debt`  
+**SDD Candidate:** YES
+
+### Issue
+
+#### Reconcile Prisma migration history with the current schema
+
+**Finding(s):** 011  
+**Problem:** Current Prisma metadata declares an enum while the committed creation migration declares TEXT, and populated upgrade assumptions are undocumented.  
+**Impact:** Potential clean-replay or upgrade failure; live impact remains unverified.  
+**Evidence:** `backend/prisma/schema.prisma:424-438`; `backend/prisma/migrations/20260501195935_add_payment_record_and_org_index/migration.sql:5-15`; `backend/prisma/migrations/20260423020000_multi_tenant_fase0/migration.sql:82-126`.  
+**Suggested Labels:** `database`, `devops`, `investigation`  
+**SDD Candidate:** MAYBE — first complete the explicit investigation.
+
+### Issue
+
+#### Align POS cashier product search with the registered API contract
+
+**Finding(s):** 012  
+**Problem:** POS calls a registered search route that excludes CASHIER, while detached tests cover an unregistered cashier-enabled controller.  
+**Impact:** Cashier barcode/SKU lookup may be rejected during checkout and tests provide false confidence.  
+**Evidence:** `backend/src/products/products.module.ts:9-13`; `backend/src/products/products.controller.ts:107-129`; `backend/src/products/products-search.controller.ts:19-149`; `frontend/src/hooks/useProducts.ts:62-79`.  
+**Suggested Labels:** `bug`, `backend`, `security`, `testing`  
+**SDD Candidate:** YES
+
+### Issue
+
+#### Establish authoritative frontend/backend API contracts
+
+**Finding(s):** 013  
+**Problem:** Request/response types, roles, organizations, and decimal wire shapes are manually duplicated across applications and already disagree.  
+**Impact:** Runtime contract drift, broad invalid payloads, and costly cross-application changes.  
+**Evidence:** `frontend/src/types/index.ts:1-681`; `frontend/src/contexts/AuthContext.tsx:23-40`; `frontend/src/hooks/useAdmin.ts:6-42`; `frontend/src/hooks/useProducts.ts:82-100`; `frontend/src/app/pos/page.tsx:302-307`.  
+**Suggested Labels:** `architecture`, `technical-debt`, `monorepo`  
+**SDD Candidate:** YES
+
+### Issue
+
+#### Define a canonical public error and diagnostic model
+
+**Finding(s):** 014  
+**Problem:** Public errors expose inconsistent message types and arbitrary unexpected exception text.  
+**Impact:** Client incompatibility and possible disclosure of parser/internal details.  
+**Evidence:** `backend/src/common/filters/http-exception.filter.ts:11-26,42-55,79-99`; `backend/src/imports/imports.service.ts:861-869,1042-1045`; `frontend/src/lib/api.ts:25-77`.  
+**Suggested Labels:** `security`, `bug`, `backend`, `api`  
+**SDD Candidate:** YES
+
+### Issue
+
+#### Govern frontend test quarantine and restore suppressed proof
+
+**Finding(s):** 015  
+**Problem:** Four complete frontend test files are globally excluded, including valid assertions and one obsolete security expectation, without current lifecycle metadata.  
+**Impact:** Regressions in critical UI/org/auth surfaces can bypass CI; obsolete tests can misdirect future changes.  
+**Evidence:** `frontend/vitest.config.ts:4-28`; `.github/workflows/ci.yml:86-92`; `frontend/src/contexts/AuthContext.switch.test.tsx:50-90`; `docs/design-system/KNOWN_TEST_FAILURES.md:51-75`.  
+**Suggested Labels:** `testing`, `technical-debt`, `ci`  
+**SDD Candidate:** YES
+
+### Issue
+
+#### Add CI-blocking proof at the critical frontend/API composition seam
+
+**Finding(s):** 018  
+**Problem:** Existing tests cover isolated UI/services and partial HTTP modules, but no CI-blocking test proves the real POS/API/bootstrap/security/transaction seam.  
+**Impact:** Cross-layer drift can reach merge without detection in the revenue-critical flow.  
+**Evidence:** `.github/workflows/ci.yml:61-63`; `backend/test/app.e2e-spec.ts:10-23`; `backend/test/tax-precedence.e2e-spec.ts:23-49,89-112`; `frontend/src/app/pos/page.behavior.test.tsx:187-253,490-511`; `backend/src/sales/sales.service.int.spec.ts:33-50,145-261`.  
+**Suggested Labels:** `testing`, `ci`, `architecture`, `reliability`  
+**SDD Candidate:** YES
+
+### Issue
+
+#### Fix settings query-state handling for failure and authoritative business data
+
+**Finding(s):** 016  
+**Problem:** Settings pages collapse query failures into loading, empty, or default billing states.  
+**Impact:** Administrators can see false plan/status/payment information or remain without recovery.  
+**Evidence:** `frontend/src/app/settings/(locale)/locale/page.tsx:9-17`; `frontend/src/app/settings/(advanced)/advanced/page.tsx:20-41`; `frontend/src/app/settings/(billing)/billing/page.tsx:66-79,134-145,322-367`.  
+**Suggested Labels:** `bug`, `frontend`, `reliability`  
+**SDD Candidate:** MAYBE
+
+### Issue
+
+#### Bound report workloads and define cache coherence
+
+**Finding(s):** 017  
+**Problem:** Report endpoints materialize broad ranges in Node and use process-local caches with incomplete cited invalidation.  
+**Impact:** Volume-dependent latency/memory growth and potentially stale financial responses.  
+**Evidence:** `backend/src/reports/reports.service.ts:565-621,679-763,915-981,1118-1179,1269-1311`; `backend/src/common/services/cache.service.ts:9-67`; `backend/src/sales/sales.service.ts:278,578`.  
+**Suggested Labels:** `performance`, `backend`, `architecture`  
+**SDD Candidate:** MAYBE — measure representative workloads first.
+
+### Issue
+
+#### Verify effective hosted release and operational controls
+
+**Finding(s):** 019  
+**Problem:** Repository policy names conflicting branches/checks and cannot establish hosted migration hooks, runtime parity, rollback, protection, or alerting.  
+**Impact:** Release and incident behavior may differ from documented expectations; current production failure is not proven.  
+**Evidence:** `.github/workflows/ci.yml:3-7,45-63,78-102`; `docs/guias/03-flujo-git-y-convenciones.md:5-20,68-69`; `docs/runbooks/runbook-despliegue-produccion.md:119-124,307-328`; `backend/docker-compose.yml:1-5`.  
+**Suggested Labels:** `investigation`, `devops`, `ci`, `documentation`  
+**SDD Candidate:** MAYBE — investigation first.
+
+### Issue
+
+#### Establish documentation authority and complete retired-capability cleanup
+
+**Finding(s):** 020  
+**Problem:** Active-looking guidance and residual auth/search artifacts preserve retired or incorrect runtime contracts.  
+**Impact:** Incorrect engineering changes, false audit conclusions, unsafe operations, and accidental re-exposure of retired behavior.  
+**Evidence:** `AGENTS.md:55-83`; `CLAUDE.md:55-83`; `frontend/src/lib/session.ts:1-21`; `backend/src/products/products.module.ts:9-13`; `backend/src/auth/auth.service.ts:32-56`; `docs/runbooks/runbook-despliegue-produccion.md:108-110`.  
+**Suggested Labels:** `documentation`, `technical-debt`, `maintenance`  
+**SDD Candidate:** NO

--- a/docs/sdd/project-baseline.md
+++ b/docs/sdd/project-baseline.md
@@ -1,0 +1,485 @@
+# Project Baseline — MeperPOS
+
+> **Documento de referencia**: estado actual del monorepo, verificado contra el código.
+> **Fecha**: 2026-09-02 · **Rol**: fuente de verdad para la siguiente fase de auditoría (Audit Findings).
+> **Convenciones**: `FACT` = confirmado directamente en el repositorio; `INFERENCE` = inferencia razonable basada en evidencia; `UNKNOWN` = no pudo confirmarse.
+> Este documento describe **qué existe y cómo funciona**. No contiene juicios, recomendaciones ni propuestas de cambio.
+
+---
+
+## 1. Overview
+
+`MeperPOS` es un sistema full-stack de gestión de inventario con módulo Point of Sale (POS), orientado a un negocio colombiano (moneda COP, locale `es-CO`, zona horaria `America/Bogota`).
+
+- [FACT] Estructura de monorepo con **dos aplicaciones npm independientes** (sin workspace tooling raíz):
+  - `backend/` — API REST NestJS 11 + Prisma 6 + PostgreSQL (puerto 3001).
+  - `frontend/` — SPA Next.js 16 (App Router) + React 19 + TypeScript + Tailwind v4 (puerto 3000).
+- [FACT] El backend es **multi-tenant por organización** (`Organization`), con roles por organización, planes (`BASIC`/`PRO`), estados de facturación y límites por plan.
+- [FACT] Autenticación JWT híbrida: access token en memoria + cookie httpOnly + refresh token rotativo (detalle en §11).
+- [FACT] Alcance funcional (según módulos y páginas): inventario/Productos, POS/Ventas, Compras/Órdenes de compra, Proveedores, Gastos/Expensas, Clientes, Categorías, Reportes/Financiero, Tareas, Settings por organización, Administración SuperAdmin, import/export, impresión de recibos.
+- [FACT] La documentación raíz (`AGENTS.md`/`CLAUDE.md`) está **sustancialmente desactualizada** frente al código actual (ver §17 y contradicciones en §16).
+- [UNKNOWN] Estado real de bases de datos desplegadas y volúmenes de datos; configuración actual de plataformas (Railway/Vercel/Supabase/Cloudinary) no está versionada.
+
+---
+
+## 2. Repository Structure
+
+```
+MeperPOS/
+├── backend/                      # API NestJS (app npm independiente)
+│   ├── prisma/
+│   │   ├── schema.prisma         # 23 modelos + 15 enums (fuente de datos)
+│   │   ├── migrations/           # 29 migraciones (20260119 → 20260901)
+│   │   ├── seed.ts               # Seed demo dev (SuperAdmin + 2 orgs faker)
+│   │   └── seed-org.ts           # Seed determinista por organización
+│   ├── src/
+│   │   ├── main.ts               # Bootstrap (ValidationPipe, filtro global, Swagger dev)
+│   │   ├── app.module.ts         # Módulo raíz; APP_GUARD Throttler→CSRF→OrgStatus
+│   │   ├── app-configuration.ts  # helmet + cookieParser + prefijo /api
+│   │   ├── admin/                # Plataforma SuperAdmin (orgs, planes, métricas)
+│   │   ├── auth/                 # Login, refresh, selección de org, JWT, cookies
+│   │   ├── billing/              # Estado de facturación, PaymentRecord, scheduler (no-op)
+│   │   ├── cash-registers/       # Cajas registradoras
+│   │   ├── categories/           # Categorías de producto
+│   │   ├── cloudinary/           # Subida de imágenes (Cloudinary + fallback local)
+│   │   ├── common/               # Guards, decorators, interceptors, filtros, cache, sequences, utils
+│   │   ├── config/               # runtime-env (validación JWT_SECRET)
+│   │   ├── customers/            # Clientes
+│   │   ├── expenses/             # Gastos + expense-categories + pagos parciales
+│   │   ├── exports/              # Exportación CSV/XLSX/PDF
+│   │   ├── imports/              # Importación Excel (productos; multi-sheet)
+│   │   ├── plan-limits/          # Cuotas por plan (BASIC/PRO)
+│   │   ├── prisma/               # PrismaService (@Global)
+│   │   ├── products/             # CRUD productos + search + upload
+│   │   ├── purchase-orders/      # Órdenes de compra (confirm/receive/cancel)
+│   │   ├── receipts/             # PDF recibo 80mm (jsPDF)
+│   │   ├── reports/              # Reportes + agregador financiero + golden fixtures
+│   │   ├── sales/                # Ventas multi-pago, numeración, recibos
+│   │   ├── settings/             # Engine JSON tipado en Organization.settings
+│   │   ├── suppliers/            # Proveedores
+│   │   ├── tasks/                # Tareas + TaskEvent (timeline inmutable)
+│   │   ├── testing/              # two-org-fixture (tests de integración)
+│   │   └── users/                # Gestión de usuarios de la organización
+│   ├── test/
+│   │   ├── jest-e2e.json         # Config E2E
+│   │   ├── *.e2e-spec.ts         # 3 specs E2E
+│   │   └── fixtures/             # receipts/ + reports-golden/ (golden baselines)
+│   ├── docker-compose.yml        # Solo Postgres local (dev)
+│   ├── scripts/                  # Helpers operativos (ping-supabase, validate-*, etc.)
+│   ├── package.json              # Scripts + jest config + dotenv-cli
+│   └── .env / .env.development / .env.production / .env.example
+├── frontend/
+│   ├── src/
+│   │   ├── app/                  # App Router (rutas/páginas)
+│   │   ├── components/           # ui/, layout/, auth/, pos/, expenses/, etc.
+│   │   ├── contexts/             # AuthContext, ThemeContext, ToastContext
+│   │   ├── hooks/                # 1 archivo por dominio (TanStack Query)
+│   │   ├── lib/                  # api.ts, utils.ts, auth.ts, session.ts, etc.
+│   │   └── types/                # types/index.ts (interfaces duplicadas a mano)
+│   ├── next.config.ts            # React Compiler, Turbopack, image loader, security headers
+│   ├── vitest.config.ts          # jsdom + Testing Library + quarantine list
+│   └── package.json              # Scripts dev/build/start/lint/test
+├── docs/                         # Documentación del proyecto (ver §15)
+├── openspec/                     # OpenSpec config + changes/multi-tenant-completion
+├── .github/workflows/ci.yml      # CI (2 jobs: backend + frontend)
+├── AGENTS.md / CLAUDE.md         # Byte-idénticos y desactualizados
+├── README.md / README.en.md      # Docs de alto nivel (parcialmente desactualizados)
+├── .gitignore
+└── node_modules/                 # Solo .vite/ cache — no es workspace install
+```
+
+---
+
+## 3. Technology Stack
+
+| Capa | Tecnología | Evidencia |
+|---|---|---|
+| Backend framework | NestJS 11 (`@nestjs/common`, core, cli) | `backend/package.json` |
+| ORM | Prisma 6.19 (`@prisma/client`, `prisma`) | `backend/package.json`, `schema.prisma` |
+| Base de datos | PostgreSQL (local docker v15, CI v17, prod Supabase) | `docker-compose.yml`, `ci.yml`, runbook |
+| AuthN | passport-jwt + @nestjs/jwt + bcryptjs; cookies httpOnly | `backend/src/auth/` |
+| AuthZ | Guards + decorators `@Roles` + `@PlanLimit`; OrgStatus/CSRF | `backend/src/common/` |
+| Validación | class-validator + class-transformer (DTOs) | `main.ts` |
+| Frontend | Next.js 16.1.3 App Router + React 19.2.3 | `frontend/package.json` |
+| Estilos | Tailwind v4 (PostCSS, sin tailwind.config) + CSS variables + React Compiler | `frontend/` |
+| Estado servidor | TanStack Query v5 (`@tanstack/react-query`) | `frontend/package.json` |
+| Estado cliente | Context: Auth, Theme, Toast | `frontend/src/contexts/` |
+| Forms | react-hook-form + zod (declarados, **sin uso en código**) | `frontend/package.json` (ver §16) |
+| HTTP | Axios (instancia singleton con interceptores) | `frontend/src/lib/api.ts` |
+| Testing backend | Jest 30 + ts-jest (+ supertest) | `backend/package.json` |
+| Testing frontend | Vitest 4 + Testing Library + jsdom | `frontend/package.json` |
+| Doc API | Swagger (solo `NODE_ENV !== production`, `/api/docs`) | `backend/src/main.ts` |
+| Integración imágenes | Cloudinary (con fallback local) | `backend/src/cloudinary/` |
+| Exports | exceljs (XLSX), @fast-csv/format (CSV), jspdf (PDF) | `backend/package.json` |
+
+[FACT] Node: CI usa Node 22. No hay `.nvmrc`/`engines` (ver §16).
+
+---
+
+## 4. Monorepo Architecture
+
+- [FACT] **No existe workspace monorepo**: no hay `package.json` raíz, ni pnpm/yarn/lerna/turbo. `backend/` y `frontend/` son paquetes npm independientes con su propio `package-lock.json`.
+- [FACT] **Comunicación**: frontend consume backend únicamente por HTTP (Axios → `/api`), con `NEXT_PUBLIC_API_URL` (default `http://localhost:3001/api`). No hay paquete compartido de tipos/contratos.
+- [FACT] Prefijo global de API: `app.setGlobalPrefix('api')` en `backend/src/app-configuration.ts`.
+- [FACT] Los scripts backend cargan env por archivo con `dotenv-cli -e` (`.env.development` para dev/test, `.env.production` para build/prod).
+- [INFERENCE] La separación en dos apps independientes es intencional para deploys separados (Vercel + Railway), a costa de tipos duplicados manualmente.
+- [FACT] `openspec/` (config + change `multi-tenant-completion`) existe en el repo y se usa para el flujo SDD híbrido engram+openspec (`openspec/config.yaml`).
+
+---
+
+## 5. Frontend Architecture
+
+### 5.1 Páginas / Routing (App Router)
+
+- [FACT] Rutas (archivos verificados en `frontend/src/app/`):
+  `/` (redirect auth), `/login`, `/register` (deshabilitado), `/dashboard`, `/pos`, `/inventory`, `/sales` + `/sales/[id]`, `/customers`, `/categories`, `/suppliers`, `/purchase-orders` + `/new` + `/[id]`, `/expenses`, `/reports`, `/tasks`, `/profile`, `/users` (redirect a `/settings/team`), `/admin` + `/admin/organizations` + `/[id]`, `/settings` (grupo: general, invoicing, team, data, billing, locale, advanced).
+- [FACT] **No existe middleware** de Next: el guard de rutas es 100% cliente (`AuthContext` + `DashboardLayout` + mapa `routeRoleMap` en `components/layout/DashboardLayout.tsx`).
+- [FACT] No hay `loading.tsx`/`error.tsx`/`not-found.tsx` de ruta; los estados de carga/error son inline por página.
+- [FACT] Patrón de página: casi todas son componentes cliente grandes de un solo archivo que poseen estado, mutaciones, modales y paginación (`pos/page.tsx` 1486 líneas, `tasks/page.tsx` 1095, `inventory/page.tsx` 906, `expenses/page.tsx` 743). No hay split container/presentational.
+- [FACT] Layout de dashboard: `DashboardLayout` + `Sidebar` (320px desktop, drawer mobile), renderizados explícitamente por cada página; offset `lg:ml-[320px]`.
+- [FACT] Zona admin: `app/admin/layout.tsx` con shell propio (solo SUPER_ADMIN), top nav (Ir al Panel, Dashboard, Organizaciones).
+- [FACT] Modales pesados se cargan lazy con `next/dynamic` + `prefetchOnIdle`.
+
+### 5.2 Componentes
+
+- [FACT] `components/ui/` — primitivas compartidas: Button, Input, Select, Modal, Card, Badge, ConfirmDialog, ImageUpload, Table, Pagination, FilterBar, LoadingState, EmptyState, DynamicFallback, BentoSelect, CurrencyInput, MetricCard, Stepper. Todas aceptan `className` y usan `cn()`.
+- [FACT] `components/layout/`: DashboardLayout, Sidebar. `components/providers/`: QueryProvider. `components/auth/`: AuthCard, OrganizationSwitcher, OrganizationSelectModal. `components/billing/`: PlanLimitBanner.
+- [FACT] Componentes por dominio: `pos/` (PaymentConfirmationModal, PaymentMethodCards, QuickAmountButtons, MobileCartDrawer, MobileCartFloatingBar, ThermalReceipt), `products/ProductCard`, `purchase-orders/`, `expenses/`, `imports/`, `dashboard/`, `categories/`, `users/UsersManagementPage`.
+- [FACT] `DashboardLayout` muestra `PlanLimitBanner` (conexión backend plan-limits).
+
+### 5.3 Estado / Data fetching
+
+- [FACT] TanStack Query: un `QueryClient` (`QueryProvider`) con `staleTime: 60_000`, `refetchOnWindowFocus: false`. Mutaciones invalidan sus query keys.
+- [FACT] Hooks por recurso en `hooks/` (21 archivos): useProducts, useCustomers, useCategories, useSuppliers, useSales, useReports, usePurchaseOrders, useExpenses, useTasks, useUsers, useSettings, useAdmin, useBilling, usePlanLimits, useImport, useProfile, usePausedSales, useReceipt, etc.
+- [FACT] Contexts: `AuthContext` (sesión, organización, login/logout/switch), `ThemeContext` (dark/light con `localStorage.theme` y `prefers-color-scheme`), `ToastContext` (notificaciones 3.5 s).
+- [FACT] localStorage: `theme`, `user` (solo caché de display), `pos_favorite_product_ids`, `paused_sales`, `selectedOrganizationId`. Los tokens legacy `token`/`refreshToken` se eliminan activamente.
+
+### 5.4 API client
+
+- [FACT] `src/lib/api.ts` — `ApiClient` singleton axios: baseURL `NEXT_PUBLIC_API_URL || http://localhost:3001/api`, `withCredentials: true`, inyecta `Authorization: Bearer` (token en memoria) y `X-Organization-Id`; en verbos mutantes envía `x-csrf-token`; en 401 (excepto endpoints auth y retries) hace refresh single-flight y reintenta una vez; expone helpers `get/postWithFormData/put/patch/delete/upload/exportData/downloadData` y `getApiErrorMessage`.
+- [FACT] `src/lib/session.ts` — token de acceso solo en memoria (se pierde al recargar; se restaura vía refresh cookie).
+- [FACT] `src/lib/auth.ts` — tipos de rol + `getEffectiveRoles`/`hasAnyRole`; jerarquía OWNER⊃ADMIN⊃MEMBER⊃CASHIER; SUPER_ADMIN hereda todo.
+- [FACT] `src/lib/utils.ts` — `cn()`, `formatCurrency` (COP), `formatDate/formatDateTime`, helpers fecha Bogotá, `resolveTaxFields`, `PAYMENT_METHOD_LABELS`.
+
+### 5.5 Validación (frontend)
+
+- [FACT] react-hook-form + zod + @hookform/resolvers están **instalados pero no importados en ningún archivo de src/** (grep sin coincidencias). La validación es imperativa manual en handlers (`profile`, `login`, formularios `<form onSubmit>`).
+- [FACT] No hay schemas zod en el frontend.
+
+### 5.6 Tipos
+
+- [FACT] `src/types/index.ts` (681 líneas): interfaces manuales de dominio (Product, Category, Customer, Sale, Settings, PurchaseOrder, Expense, etc.). Sin paquete compartido con backend — duplicadas a mano.
+- [FACT] Roles duplicados en tres lugares con formas que no coinciden del todo: `lib/auth.ts` (`AppRole` incl. SUPER_ADMIN), `types/index.ts` (`User` sin SUPER_ADMIN/OWNER consistentes), `AuthContext.tsx` (interfaces propias User/Organization). (Observación, no juicio.)
+
+### 5.7 Manejo de errores
+
+- [FACT] Errores de API → `useToast().error(getApiErrorMessage(error, fallback))`; lecturas fallidas inline; sin ErrorBoundary global ni `error.tsx`.
+- [FACT] Tipos de UI de estado: `LoadingState`, `EmptyState`, `DynamicFallback` (spinner para lazy modals).
+
+---
+
+## 6. Backend Architecture
+
+### 6.1 Bootstrap / Config
+
+- [FACT] `main.ts`: `validateJwtSecretOrExit` (prod aborta si JWT_SECRET falta o < 32 chars), `NestFactory.create`, `configureApp` (helmet sin CSP, cookieParser, prefijo `/api`), CORS inline con `CORS_ORIGIN`, ValidationPipe global `{ whitelist, forbidNonWhitelisted, transform, enableImplicitConversion }`, `HttpExceptionFilter` global, Swagger solo dev.
+- [FACT] `app.module.ts`: ConfigModule global, ThrottlerModule global (100 req/min), módulos globales `CacheModule`, `PrismaModule`, `CloudinaryModule` (`@Global()`), y módulos de dominio.
+- [FACT] Guards globales vía `APP_GUARD` en orden: **ThrottlerGuard → CookieCsrfGuard → OrganizationStatusGuard**. No hay JwtAuthGuard global (auth por ruta).
+- [FACT] `GET /api/health` (`app.controller.ts`): `SELECT 1` → 503 si falla. `GET /` responde texto.
+
+### 6.2 Inventario de módulos (routes/roles/dominio)
+
+| Módulo | Prefijo | Roles (ruta) | Responsabilidad principal |
+|---|---|---|---|
+| auth | `auth` | login público, resto JWT | Login, refresh, logout, profile, change-password, select-organization, select-org |
+| users | `users` | ADMIN | CRUD usuarios org, toggle-active, reset-password, PlanLimit('users') |
+| admin | `admin` | SUPER_ADMIN | Orgs CRUD, status/plan, members, transfer-owner, metrics |
+| categories | `categories` | ADMIN, MEMBER | CRUD categorías |
+| products | `products` | ADMIN, MEMBER (+CASHIER en quick-search) | CRUD, low-stock, search, upload, concurrencia `version` |
+| customers | `customers` | ADMIN, MEMBER, CASHIER | CRUD clientes, búsqueda por documento |
+| sales | `sales` | ADMIN, MEMBER, CASHIER | Crear venta multi-pago, listar (scoping por rol), force-close, receipt |
+| reports | `reports` | ADMIN | Dashboard KPIs, económico, cash flow, inventario, top-selling, etc. |
+| settings | `settings` | ADMIN | GET/PUT settings org, logo, organización, receipt-prefix |
+| exports | `exports` | ADMIN | Export CSV/XLSX/PDF por entidad |
+| imports | `imports` | ADMIN, CASHIER | Templates + import Excel (full multi-sheet) |
+| cloudinary | (uso servicio) | — | Subida imágenes con fallback local |
+| cash-registers | `cash-registers` | ADMIN | CRUD cajas, PlanLimit('cashRegisters') |
+| billing | `billing` | ADMIN/OWNER (+SUPER_ADMIN en payments) | Estado facturación, payment records |
+| plan-limits | `plan-limits` | JWT | GET status de límites |
+| suppliers | `suppliers` | ADMIN, MEMBER | CRUD proveedores |
+| purchase-orders | `purchase-orders` | ADMIN, MEMBER | PO DRAFT→PENDING→RECEIVED; receive crea movimientos |
+| expenses | `expenses` | ADMIN | Gastos, pagos parciales, soft-delete, recibos Cloudinary |
+| expense-categories | `expense-categories` | ADMIN | CRUD categorías de gasto |
+| tasks | `tasks` | todos los roles | Tareas + timeline TaskEvent |
+
+Nota [FACT]: **`products-search.controller.ts` es código muerto no registrado**; el search real vive en `ProductsController` (ADMIN/MEMBER). No hay ruta pública `register` (solo método de servicio).
+
+### 6.3 Patrón controller típico
+
+- [FACT] Stack estándar por controller: `@UseGuards(JwtAuthGuard, RolesGuard, OrganizationRequiredGuard[, PlanLimitGuard])` + interceptor `AdminOrganizationInterceptor` + `@Roles(...)`; decoradores `@CurrentUser`, `@AuditAction`, `@PlanLimit`.
+- [FACT] Scoping por organización: los services reciben `organizationId` del JWT y usan `findFirst({ id, organizationId })` (guarda de fila por tenant).
+- [FACT] Scoping por rol en ventas: `buildScopeFilter` — ADMIN ve todas; no-ADMIN solo las propias (deny-by-default).
+- [FACT] Service → `PrismaService` directo (no hay capa repository separada).
+
+### 6.4 Flujo de una petición autenticada (entrada → persistencia → respuesta)
+
+1. [FACT] HTTP → Express: helmet → cookie-parser → prefijo `/api` (`app-configuration.ts`).
+2. [FACT] Guards globales `APP_GUARD`: Throttler (100/min; login 10/min) → CookieCsrf (double-submit; omite GET/HEAD y si hay Bearer) → OrganizationStatus (bloquea escrituras si `SUSPENDED`).
+3. [FACT] Guards de ruta: JwtAuthGuard (valida JWT + usuario activo + tokenVersion + membresía org) → RolesGuard (hereda roles: OWNER→ADMIN→MEMBER→CASHIER) → OrganizationRequiredGuard (exige orgId salvo SuperAdmin) → PlanLimitGuard (si aplica).
+4. [FACT] Interceptores: `AdminOrganizationInterceptor` (SuperAdmin elige org por header `x-organization-id`); `AuditInterceptor` donde hay `@AuditAction` (escribe `AuditLog` post-éxito, fire-and-forget).
+5. [FACT] Controller valida DTO (ValidationPipe) → Service → PrismaService (transacciones `$transaction`, secuencias con `SELECT ... FOR UPDATE`) → respuesta.
+6. [FACT] Errores → `HttpExceptionFilter` con forma `{ success:false, error:{ code, message, details?, statusCode, timestamp, path } }`.
+
+---
+
+## 7. Domain Map
+
+| Dominio | Propósito | Backend | Frontend | Datos |
+|---|---|---|---|---|
+| Identidad/AuthN | Login, refresh, selección org, sesión | auth | contexts/AuthContext, api.ts, login | User, RefreshToken, cookies |
+| Multi-tenant | Aislamiento por organización, roles, planes, estados | admin, plan-limits, billing, guards | admin/, settings/(billing), PlanLimitBanner | Organization, OrganizationUser, PaymentRecord |
+| Usuarios | Miembros y roles de la org | users | settings/(team) → UsersManagementPage | User, OrganizationUser |
+| Productos/Catálogo | CRUD, stock, precios, promociones, impuestos | products, categories | inventory/, categories/, pos (búsqueda) | Product, Category, InventoryMovement |
+| Ventas/POS | Carrito, pagos mixtos, numeración, impresión | sales, receipts, cash-registers | pos/, sales/, sales/[id] | Sale, SaleItem, Payment, SaleItem.costPriceSnapshot |
+| Clientes | Cartera de clientes y segmentos | customers | customers/ | Customer |
+| Compras | Órdenes de compra y recepción | purchase-orders, suppliers | purchase-orders/, suppliers/ | PurchaseOrder, PurchaseOrderItem, Supplier |
+| Gastos | Egresos con pagos parciales y categorías | expenses, expense-categories | expenses/ | Expense, ExpensePayment, ExpenseCategory |
+| Reportes/Financiero | KPIs, económico, cash flow, inventario | reports, exports | reports/, dashboard/ | Sale+SaleItem, InventoryMovement, Expense, Customer |
+| Tareas | Gestión interna con timeline | tasks | tasks/ | Task, TaskEvent |
+| Configuración | Parametrización por org | settings | settings/* | Organization.settings (JSON tipado) |
+| Datos externos | Import/export, imágenes, recibos | imports, exports, cloudinary, receipts | settings/(data), components/imports | Jobs en memoria (imports); Cloudinary/local uploads |
+
+---
+
+## 8. Data Architecture
+
+### 8.1 Modelo de datos
+
+- [FACT] **23 modelos / 15 enums** en `backend/prisma/schema.prisma` (591 líneas). Todos los PK son `String @default(uuid())`.
+- [FACT] Modelos: Organization (raíz tenant), User, OrganizationUser, RefreshToken, OrganizationSequence, CashRegister, Category, Product, InventoryMovement, Customer, Sale, Payment, SaleItem, Task, TaskEvent, Supplier, PurchaseOrder, PurchaseOrderItem, AuditLog, PaymentRecord, ExpenseCategory, Expense, ExpensePayment.
+- [FACT] Enums: OrgStatus, PlanType, BillingStatus, OrgRole, PromotionType, MovementType, CustomerSegment, PaymentMethod, SupplierAccountType, ExpensePaymentStatus, PaymentRecordStatus, SaleStatus, TaskStatus, TaskEventType, PurchaseOrderStatus.
+- [FACT] Multi-tenant: **`organizationId` NOT NULL en todos los modelos de dominio**; FK a Organization con `onDelete: Cascade`. Membresía vía `OrganizationUser` (`@@unique([userId, organizationId])`, `role OrgRole`, `isPrimaryOwner`).
+- [FACT] Money: `Decimal`; productos/ventas `Decimal(10,2)`, órdenes/gastos `Decimal(12,2)`; stock `Int`.
+- [FACT] Unicidad e índices **por organización**: `Product(organizationId,sku)`, `Sale(organizationId,saleNumber)`, `InventoryMovement(organizationId,productId,createdAt)`, etc.
+
+### 8.2 Concurrencia y numeración
+
+- [FACT] Concurrencia optimista en `Product.version` (update con `where { id, version }`, `version: { increment: 1 }`). Recepción de PO usa el mismo patrón sobre stock/costo.
+- [FACT] Decremento de stock en venta: `updateMany` atómico con guard `stock >= qty` dentro de transacción Serializable.
+- [FACT] Numeración de ventas (SALE) y órdenes (PO) por org/año: `OrganizationSequence` + raw `SELECT ... FOR UPDATE` en `SequenceService`, dentro de `$transaction` Serializable.
+
+### 8.3 Transacciones y raw SQL
+
+- [FACT] `$transaction` interactivo (Serializable, maxWait 5000, timeout 10000) en sales, purchase-orders, expenses, tasks; array-form en auth/admin. P2028 → `ServiceUnavailableException`.
+- [FACT] Raw SQL solo en 4 puntos: sequence FOR UPDATE, low-stock list, dashboard low-stock count, health `SELECT 1`.
+
+### 8.4 Migraciones
+
+- [FACT] **29 migraciones** (20260119 → 20260901 `refresh_token_org_binding`); `migration_lock.toml` provider postgresql. Incluye: migración multi-tenant (agrega `organizationId` a ~15 tablas, reemplaza unicidades globales por compuestas, introduce OrganizationUser/OrganizationSequence/RefreshToken, **drop de tabla `Settings`**, drop de secuencias autoincrement en favor de OrganizationSequence), backfill de categorías de gasto por org, backfill PlanType, enum growth (CASHIER/INVENTORY_USER), `SaleItem.costPriceSnapshot`.
+- [UNKNOWN] Estado de sync de la BD viva con `_prisma_migrations` (no inspeccionable read-only).
+
+### 8.5 Seeds
+
+- [FACT] `seed.ts`: guard `NODE_ENV==='development'`; crea SuperAdmin `admin@sistema.com/admin123`; en dev crea 2 orgs demo (Cafetería Demo BASIC + Supermercado Demo PRO) con productos/categorías/clientes/ventas/sequences/caja/expense categories.
+- [FACT] `seed-org.ts`: dirigido por `SEED_ORG_SLUG/ID` o `TARGET_EMAIL`; catálogo determinista idempotente (upserts); guard dev/test o `SEED_ALLOW_NON_DEV=true`.
+
+---
+
+## 9. API Architecture
+
+- [FACT] Endpoints agrupados por módulo bajo prefijo global `/api` (ver tabla §6.2 y mapa de endpoints consumidos por hooks en §10).
+- [FACT] Contratos de entrada: DTOs `class-validator`, ValidationPipe global whitelist + forbidNonWhitelisted + transform.
+- [FACT] Formato de error unificado (HttpExceptionFilter): `{ success:false, error:{ code, message, details?, statusCode, timestamp, path } }`. Códigos: clase de excepción en mayúsculas (UNAUTHORIZED, BAD_REQUEST, ...) o mapeos Prisma (DUPLICATE_RECORD P2002, NOT_FOUND P2025, FOREIGN_KEY_ERROR P2003, DATABASE_ERROR).
+- [FACT] Paginación estándar: respuesta `{ data, meta: { total, page, limit, totalPages } }`.
+- [FACT] Descarga de archivos: `@Res()` streaming (PDF recibos, CSV/XLSX exports con BOM `\uFEFF` en CSV).
+- [FACT] Swagger en `/api/docs` solo con `NODE_ENV !== 'production'`; `docs/authorization-matrix.md` validada por `matrix-coverage.spec.ts` contra el documento OpenAPI.
+
+---
+
+## 10. Frontend ↔ Backend Flows
+
+### 10.1 Mapa de endpoints consumidos por hooks del frontend
+
+| Recurso | Endpoints (método y path bajo /api) | Hook frontend |
+|---|---|---|
+| Productos | GET `/products`, `/products/{id}`, `/products/low-stock`, `/products/search`, `/products/quick-search`; POST `/products`, `/products/upload`, `/products/{id}/upload`; PUT `/products/{id}` (+`/deactivate`, `/reactivate`); DELETE `/products/{id}` | useProducts |
+| Categorías | CRUD `/categories` | useCategories |
+| Clientes | CRUD `/customers`; GET `/customers/document/{doc}` | useCustomers |
+| Proveedores | CRUD `/suppliers` | useSuppliers |
+| Ventas | GET `/sales`, `/sales/{id}`, `/sales/number/{n}`; POST `/sales`; PUT `/sales/{id}`; POST `/sales/{id}/receipt` | useSales, useReceipt |
+| Reportes | GET `/reports/dashboard`, `/reports/economic`, `/reports/economic/cash`, `/reports/economic/inventory`, `/reports/sales/payment-method`, `/reports/sales/category`, `/reports/sales/category-daily`, `/reports/products/top-selling`, `/reports/customers/statistics`, `/reports/sales/daily` | useReports |
+| Órdenes de compra | CRUD `/purchase-orders`; POST `/{id}/confirm|receive|cancel` | usePurchaseOrders |
+| Gastos | `/expenses` list/detail/summary/monthly/history + create/patch/delete/payments/duplicate/upload; `/expense-categories` CRUD | useExpenses |
+| Tareas | GET `/tasks`, `/tasks/assignees`, `/tasks/{id}/timeline`; POST `/tasks`; PUT `/tasks/{id}` + `/status`; DELETE `/tasks/{id}` | useTasks |
+| Usuarios | `/users` CRUD + toggle-active/reset-password | useUsers |
+| Settings | GET/PUT `/settings`; POST `/settings/logo`; PATCH `/settings/organization`, `/settings/receipt-prefix` | useSettings |
+| Admin | `/admin/metrics`; `/admin/organizations` + `/{id}` + status/plan/members | useAdmin |
+| Billing/Plan | GET `/billing/status`, `/billing/payments`; POST `/billing/payments`; GET `/plan-limits/status` | useBilling, usePlanLimits |
+| Import | POST `/imports/full|products`; GET `/imports/{jobId}/status`; POST `/imports/{jobId}/retry-row`; GET `/imports/*-template` | useImport |
+| Export | POST `/exports/{type}`; GET `/exports/inventory?format=json` | useExportData/useSettings |
+| Auth | POST `/auth/login`, `/auth/refresh`, `/auth/logout`, `/auth/select-organization`, `/auth/select-org`, `/auth/change-password`; GET/PUT `/auth/profile` | AuthContext, useProfile |
+
+### 10.2 Contratos y serialización
+
+- [FACT] **No hay tipos compartidos**: el frontend mantiene interfaces manuales (`src/types/index.ts`) que replican las respuestas del backend; el backend genera su propio shape desde Prisma/DTOs. Riesgo de drift es una observación, no juicio.
+- [FACT] Fechas: se serializan ISO; el frontend convierte a es-CO con helpers de zona Bogotá; los reportes backend agrupan por día Bogotá.
+- [FACT] Montos: el backend envía Decimal (serializado por JSON como string o number según contexto); el frontend usa `formatCurrency` (COP, 0 decimales) y helpers `safeDecimalNumber`/`formatReportMoney`.
+- [FACT] Errores: el frontend interpreta `getApiErrorMessage` sobre la forma unificada del filtro de excepciones.
+
+### 10.3 Flujo ejemplo (funcionalidad transversal)
+
+**Crear una venta desde el POS (frontend → backend → DB):**
+1. [FACT] `pos/page.tsx` arma `CartItem[]`; al confirmar invoca `useCreateSale` (hooks/useSales) → `api.post('/sales', payload)`.
+2. [FACT] Axios inyecta `Authorization: Bearer` (token en memoria) y `X-Organization-Id`; verbo mutante envía `x-csrf-token`.
+3. [FACT] Backend: guards globales (throttler → CSRF → org status) → `SalesController` → `JwtAuthGuard`/Roles/OrgRequired → DTO validado → `SalesService.create`.
+4. [FACT] `SalesService.create` (Serializable tx): valida org/productos/impuestos/promociones; `SequenceService.nextNumber` (SALE); `sale.create`; por item `saleItem.create` + `product.updateMany` (stock decrement con guard); `inventoryMovement.create` (SALE, previous/new stock); `payment.create` por método; post-commit limpia `cache.clear('dashboard:')`.
+5. [FACT] Respuesta → sale hidratada; frontend invalida queries `sales`, `products`, `dashboard`.
+6. [FACT] Impresión: `POST /sales/{id}/receipt` genera PDF 80mm (ReceiptsService/jsPDF) o el frontend usa `useReceipt.printThermalReceipt` (HTML térmico local).
+
+---
+
+## 11. Authentication & Authorization
+
+### 11.1 Autenticación
+
+- [FACT] Login `POST /api/auth/login` (rate limit 10/min): verifica bcrypt (`BCRYPT_ROUNDS=12`), valida `active`, devuelve access token + emite cookies httpOnly + refresh token.
+- [FACT] Tokens: access JWT 30 min (claims: sub, email, organizationId, role, tokenVersion) HS256; refresh token opaco 40 bytes (guardado SHA-256) 7 días, **cookie-only**, rotación con revocación, grace 60 s para tabs concurrentes, ligado a `organizationId`.
+- [FACT] Cookies (`cookies.helper.ts`): `access_token` (httpOnly, path `/`), `refresh_token` (httpOnly, path `/api/auth`), `csrf_token` (leíble por JS). Prod: `SameSite=None; Secure`; dev: `SameSite=Lax`.
+- [FACT] Frontend guarda el access token **solo en memoria** (`session.ts`) y lo restaura con refresh single-flight en 401; elimina keys legacy de localStorage.
+- [FACT] `POST /auth/refresh` renueva; `POST /auth/logout` revoca; `POST /auth/change-password` rota tokenVersion.
+- [FACT] **No existe ruta pública de registro** (`register` solo método de servicio; frontend `/register` deshabilitado "contacta un admin").
+- [FACT] Org: multi-org → pre-auth JWT (5 min) + `POST /auth/select-organization`; switch en sesión → `POST /auth/select-org` (revoca y reemite ligado a nueva org).
+
+### 11.2 Autorización
+
+- [FACT] Roles: `OrgRole` OWNER/ADMIN/MEMBER/CASHIER/INVENTORY_USER (+ SuperAdmin como flag `User.isSuperAdmin`, no enum). OWNER se mapea legacy a ADMIN en validateUser.
+- [FACT] Jerarquía en RolesGuard: OWNER→[OWNER,ADMIN,MEMBER,CASHIER]; ADMIN→[ADMIN,MEMBER,CASHIER]; MEMBER→[MEMBER,CASHIER].
+- [FACT] Enforcement: decoradores `@Roles` por ruta/controller; scoping de datos por servicio (sales por rol; resto org-scoped); `OrganizationStatusGuard` bloquea escrituras a orgs SUSPENDED; `OrganizationRequiredGuard` exige orgId salvo SuperAdmin; `AdminOrganizationInterceptor` permite a SuperAdmin impersonar org por header.
+- [FACT] Plan limits: `@PlanLimit(type)` + PlanLimitGuard; BASIC max 3 users/100 products/50 customers/1 cash-register; PRO ilimitado + `hasForceClose`.
+- [FACT] `docs/authorization-matrix.md` (viviente) + CI (`matrix-coverage.spec.ts`) contra OpenAPI; `docs/url-identifier-policy.md` documenta que los IDs en URL nunca son authz.
+
+---
+
+## 12. Integrations
+
+| Integración | Uso | Módulo(s) | Notas |
+|---|---|---|---|
+| Cloudinary | Imágenes de productos, logos, recibos de gasto | cloudinary, products, settings, expenses | Fallback local (`CLOUDINARY_FALLBACK_LOCAL=true` o error de red). Frontend custom image loader apunta a Cloudinary. [FACT] `uuid` se importa en cloudinary.service.ts sin estar en dependencies (transitivo — ver §16) |
+| Excel (exceljs) | Export XLSX + import multi-sheet | exports, imports | Import con jobs **en memoria** (Map) — se pierden en restart |
+| CSV (@fast-csv) | Export CSV con BOM | exports | |
+| PDF (jsPDF) | Recibos térmicos 80mm y export PDF | receipts, exports | Golden fixtures PDF |
+| Supabase Postgres | BD producción | prisma | Sin código en repo (solo scripts/runbook) |
+| Railway / Vercel | Hosting API / frontend | — | Sin config versionada |
+| Pasarela de pagos | — | — | [FACT] No existe gateway; PaymentRecord es bookkeeping manual |
+
+---
+
+## 13. Testing
+
+### Backend (Jest 30)
+
+- [FACT] Config unit en `backend/package.json` (rootDir `src`, `*.spec.ts`, ts-jest, node env). `test:e2e` con `test/jest-e2e.json`.
+- [FACT] Scripts: `test`, `test:watch`, `test:cov`, `test:e2e` — todos con `dotenv -e .env.development`.
+- [FACT] 85 specs unitarias (`*.spec.ts` en `backend/src`); **15 specs de integración** (`*.int.spec.ts`) que requieren BD dev real (usando `src/testing/two-org-fixture.ts`); **3 e2e specs** (`test/*.e2e-spec.ts`).
+- [FACT] Áreas cubiertas: auth (7), products (4), sales, expenses (7), imports (13+ incl. engine), reports (6 + golden), settings (4), common guards (4), users (4), billing, admin, tasks, plan-limits, suppliers, purchase-orders, customers, categories. Cloudinary **sin specs**.
+- [FACT] Golden fixtures: recibos PDF (`test/fixtures/receipts/`) y reportes (`reports-golden/`) con scripts de regeneración (`fixtures:receipts`, `fixtures:reports-golden`, `fixtures:reports-timing`).
+
+### Frontend (Vitest 4)
+
+- [FACT] `vitest.config.ts`: jsdom, setup jest-dom + RTL cleanup, alias `@`, **quarantine list de 4 suites** que fallan (excluidas de CI): `sales/page.behavior`, `admin/organizations/[id]/page`, `AuthContext.switch`, `dashboard/CategoryStackedChart`.
+- [FACT] 66 archivos de test (`*.test.ts/tsx`, incl. suites `*.evidence/behavior/characterization`): unit de lib/hooks, componentes ui/dominio, páginas, contratos de tema en globals.css, auth.
+- [FACT] CI no corre cobertura; `openspec/config.yaml` declara coverage threshold 0 y frontend coverage null.
+
+### CI (`.github/workflows/ci.yml`)
+
+- [FACT] 2 jobs en Node 22: backend (Postgres 17 service, prisma generate/migrate deploy, build, `npm run test`) y frontend (`tsc --noEmit`, `npm run test`, `next build`, **security-header check** con `next start`).
+- [FACT] Triggers: pull_request + push a `master`. No corre lint, no publica artefactos, no hace deploy.
+
+---
+
+## 14. Infrastructure & Deployment
+
+- [FACT] Prod: **frontend Vercel** (`meperpos.vercel.app`), **API Railway** (`meperpos-api.up.railway.app`), **BD Supabase Postgres**, imágenes Cloudinary (evidencia: CSP en `next.config.ts`, `docs/secrets-rotation.md`, `docs/runbooks/runbook-despliegue-produccion.md`).
+- [FACT] `backend/docker-compose.yml`: solo Postgres local dev (postgres:15, `admin/admin123/inventario_db`). No hay Dockerfile/Procfile/nginx en el repo.
+- [FACT] Env backend: `.env.development`/`.env.production` vía dotenv-cli; vars: DATABASE_URL, DIRECT_URL, JWT_SECRET (≥32 chars, fail-fast prod), PORT, CORS_ORIGIN, CLOUDINARY_*, CLOUDINARY_FALLBACK_LOCAL, PRISMA_QUERY_LOG/DUMP, SEED_ALLOW_NON_DEV. Env frontend: solo `NEXT_PUBLIC_API_URL`.
+- [FACT] Observabilidad: `GET /api/health` (`SELECT 1`); Nest Logger en 3 archivos; console disperso; **scheduler billing diario es no-op intencional**; audit vía AuditLog. No hay Sentry/Prometheus/Terminus/logging estructurado.
+- [FACT] Scripts operativos: `backend/scripts/` (ping-supabase, diagnose-network, validate-*, phase2-bootstrap.sql), `backend/fix-sequences.js`, `backend/reset-kevin-password.js`, `frontend/scripts/build-size.mjs` (guard de tamaño de bundle con baseline).
+
+---
+
+## 15. Important Dependencies
+
+- Backend (prod): `@nestjs/*` (common/core/config/jwt/passport/platform-express/schedule/swagger/throttler), `@prisma/client`, `bcryptjs`, `class-transformer`, `class-validator`, `cloudinary`, `cookie-parser`, `exceljs`, `helmet`, `jspdf`, `multer`, `passport`, `passport-jwt`, `@fast-csv/format`, `streamifier`, `rxjs`.
+- Backend (dev): jest 30, ts-jest, supertest, typescript 5.9, eslint 9 + typescript-eslint, prettier, prisma, dotenv-cli, @faker-js/faker, pg, pdf-parse, ts-node, ts-loader.
+- Frontend (prod): next 16.1.3 (exact), react 19.2.3, @tanstack/react-query ^5, axios, clsx, tailwind-merge, lucide-react, react-hook-form + zod + @hookform/resolvers (**sin uso**).
+- Frontend (dev): vitest ^4, @testing-library/react/jest-dom/user-event, jsdom, typescript, tailwindcss ^4, eslint-config-next, babel-plugin-react-compiler.
+
+---
+
+## 16. Main Application Flows
+
+1. **Auth + selección de organización**: login → (multi-org: pre-auth + select-organization) → restore silencioso vía refresh → org-scope en cada request (`X-Organization-Id`).
+2. **POS venta**: cart cliente → POST /sales → tx Serializable (secuencia + venta + items + stock + movimientos + pagos) → invalidación queries → recibo PDF/thermal.
+3. **Inventario**: CRUD productos con concurrencia `version`, activación/desactivación, import/export, subida imágenes, low-stock.
+4. **Compra**: PO draft → confirm (PENDING) → receive (stock + costPriceSnapshot + PURCHASE movements) → parcial/total; vínculo con gasto.
+5. **Gastos**: creación con pagos parciales → estado PAID/PARTIAL → soft-delete; categorías; recibo Cloudinary.
+6. **Reportes/dashboard**: queries agregadas org-scoped con fecha Bogotá + caché 5 min + agregador financiero con costPriceSnapshot (COGS) y cancelaciones.
+7. **Multi-tenant/admin**: creación de org (siembra sequences/caja/categorías de gasto), planes y límites, suspensión revoca tokens, SuperAdmin management.
+8. **Tareas**: CRUD con transiciones de estado validadas y timeline inmutable TaskEvent.
+
+---
+
+## 17. Known Constraints
+
+- [FACT] Sin workspace de npm: tipos y contratos duplicados a mano entre frontend y backend.
+- [FACT] Sin registro público de usuarios (solo admin crea; SuperAdmin siembra).
+- [FACT] Sin middleware/route-guard en Next: seguridad de rutas solo cliente (SUPER_ADMIN bypass del mapa; rutas protegidas también por backend).
+- [FACT] Imports en memoria (no persistidos): jobs perdidos en restart/instancia múltiple.
+- [FACT] Scheduler de billing es no-op por diseño; estado de facturación cambia solo por acción manual/admin.
+- [FACT] Sin gateway de pagos; PaymentRecord manual.
+- [FACT] Guardas CSRF: doble submit con cookie `csrf_token`; CSRF exempt incluye path muerto `/api/auth/register`.
+- [FACT] `HttpExceptionFilter` no reenvuelve arrays de errores de validación (`message` puede ser `string[]`).
+- [FACT] `products-search.controller.ts` es código muerto (no registrado); CASHIER recibe 403 en `/products/search` del controller principal.
+- [FACT] `uuid` importado en `cloudinary.service.ts` pero no declarado en dependencies (dependencia transitiva no declarada).
+- [FACT] React-hook-form/zod instalados sin uso en frontend.
+- [FACT] 4 suites de test frontend en quarantine (fallan).
+- [FACT] Migraciones tempranas duplicadas (`_init`/`implementaciones`) sugieren reset inicial; BD viva no verificable read-only.
+
+---
+
+## 18. Unknowns
+
+- Estado real (migrado/sync) de las BD de desarrollo y producción; volúmenes de datos.
+- Configuración actual de Railway/Vercel/Supabase/Cloudinary (no versionada).
+- Contenido exacto de `.env.example` y archivos `.env*` (no legibles por política).
+- Alcance completo de `PaymentRecord`/`CashRegister`/`RefreshToken.organizationId` en runtime (módulos recientes, cableado parcialmente verificado).
+- Rama por defecto real del remoto (docs dicen `main`; CI usa `master`; existe `development`).
+- Estado de los artifacts locales `.codegraph/`, `node_modules/.vite` y su impacto (no funcional).
+- Documentación `docs/arquitectura/guia-maestra-proyecto.md` contiene descripciones aspiracionales/stale (Redis, PWA/mobile, rol legacy) — no se verificó su vigencia real.
+- Por qué `/settings/billing|locale|advanced` no aparecen en el nav de settings (4 entradas vs 7 grupos).
+
+---
+
+## Apéndice A — Archivos de referencia clave
+
+| Área | Archivo(s) |
+|---|---|
+| Schema DB | `backend/prisma/schema.prisma` |
+| Migraciones | `backend/prisma/migrations/` (29) |
+| Bootstrap backend | `backend/src/main.ts`, `backend/src/app-configuration.ts`, `backend/src/app.module.ts` |
+| Guards/interceptores | `backend/src/common/guards/*`, `backend/src/common/interceptors/*` |
+| Auth | `backend/src/auth/` (service, controller, jwt.strategy, cookies.helper, constants) |
+| Ventas | `backend/src/sales/sales.service.ts` |
+| Productos | `backend/src/products/products.service.ts` (+ search dead) |
+| Reportes | `backend/src/reports/reports.service.ts`, `financial-aggregator.ts` |
+| Settings | `backend/src/settings/` (schema, defaults, validator, migration) |
+| Plan limits | `backend/src/plan-limits/` |
+| CI | `.github/workflows/ci.yml` |
+| Frontend cliente API | `frontend/src/lib/api.ts`, `frontend/src/lib/session.ts` |
+| Frontend routing | `frontend/src/app/**/page.tsx`, `frontend/src/components/layout/DashboardLayout.tsx`, `Sidebar.tsx` |
+| Hooks | `frontend/src/hooks/` |
+| Tipos | `frontend/src/types/index.ts` |
+| Config frontend | `frontend/next.config.ts`, `frontend/vitest.config.ts`, `frontend/src/app/globals.css` |
+| Runbook/ops | `docs/runbooks/runbook-despliegue-produccion.md`, `docs/secrets-rotation.md` |
+| AuthZ | `docs/authorization-matrix.md`, `docs/url-identifier-policy.md` |
+| SDD | `openspec/config.yaml`, `openspec/changes/multi-tenant-completion/` |


### PR DESCRIPTION
## Summary

Slice 2 of 2 for #114 — record org-entry audit for select-organization under policy C+.

- Wire AuditInterceptor + AUTH_ORG_SELECTED on /auth/select-organization (multi-org user completing login through org selection writes a durable org-scoped row)
- LOGIN_SUCCESS writes via response actor when org is resolved and validated (single-org auto-resolved, or multi-org with validated organizationId)
- Multi-org-without-selection and superadmin (null org) warn-skip; never writes an incorrect-org or FK-violation row
- Adds auth-login-audit.int.spec.ts HTTP proof for the full R-LOGIN matrix (R-LOGIN-1..5)

## Dependency

Stacked after PR #127 (needs the aligned interceptor at runtime; diff is independent).

## Test Plan

- [x] auth-login-audit.int.spec.ts: 6 HTTP cases (single-org row, multi+orgId row, membership-401 zero-row, multi-no-select zero-row, selectOrganization row, superadmin zero-row)
- [x] Full backend suite: 854/854 passing (verified independently)

Refs #114