### PR TITLE
feat(ui): add ErrorState with retry and unit test

### DIFF
--- a/frontend/src/components/ui/ErrorState.test.tsx
+++ b/frontend/src/components/ui/ErrorState.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ErrorState } from "./ErrorState";
+
+describe("ErrorState", () => {
+  it("renders the message and a title when provided", () => {
+    render(<ErrorState title="No se pudo cargar" message="Intenta de nuevo." />);
+
+    expect(screen.getByText("No se pudo cargar")).toBeInTheDocument();
+    expect(screen.getByText("Intenta de nuevo.")).toBeInTheDocument();
+  });
+
+  it("renders the message alone when no title is provided", () => {
+    render(<ErrorState message="No se pudo cargar la configuración." />);
+
+    expect(
+      screen.getByText("No se pudo cargar la configuración."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("heading")).toBeNull();
+  });
+
+  it("renders a retry button only when onRetry and retryLabel are present", () => {
+    const onRetry = vi.fn();
+    render(
+      <ErrorState
+        message="No se pudo cargar la configuración."
+        retryLabel="Reintentar"
+        onRetry={onRetry}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Reintentar" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render a retry button when handlers are absent", () => {
+    render(<ErrorState message="No se pudo cargar la configuración." />);
+
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("does not render a retry button when only retryLabel is provided", () => {
+    render(
+      <ErrorState message="No se pudo cargar la configuración." retryLabel="Reintentar" />,
+    );
+
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("fires onRetry when the retry button is clicked", async () => {
+    const onRetry = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ErrorState
+        message="No se pudo cargar la configuración."
+        retryLabel="Reintentar"
+        onRetry={onRetry}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Reintentar" }));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("merges an extra className through cn()", () => {
+    render(<ErrorState message="No se pudo cargar." className="py-4" />);
+
+    const message = screen.getByText("No se pudo cargar.");
+    expect(message.closest("div")?.className).toContain("py-4");
+  });
+});

--- a/frontend/src/components/ui/ErrorState.tsx
+++ b/frontend/src/components/ui/ErrorState.tsx
@@ -1,0 +1,49 @@
+import { AlertTriangle } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "./Button";
+
+interface ErrorStateProps {
+  icon?: ReactNode;
+  title?: string;
+  message: string;
+  retryLabel?: string;
+  onRetry?: () => void;
+  className?: string;
+}
+
+export function ErrorState({
+  icon = <AlertTriangle className="w-5 h-5" />,
+  title,
+  message,
+  retryLabel,
+  onRetry,
+  className,
+}: ErrorStateProps) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex flex-col items-center justify-center text-center min-h-[200px] rounded-xl bg-red-500/10 border border-red-500/20 px-6",
+        className,
+      )}
+    >
+      <div className="w-10 h-10 rounded-xl bg-red-500/10 border border-red-500/20 flex items-center justify-center text-red-500">
+        {icon}
+      </div>
+      {title && <p className="text-sm font-semibold text-foreground mt-3">{title}</p>}
+      <p className="text-xs text-muted-foreground mt-1">{message}</p>
+      {onRetry && retryLabel && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onRetry}
+          className="mt-4"
+        >
+          {retryLabel}
+        </Button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
﻿Closes #123

## Summary

PR 1 of 3 (stacked-to-main) for #123 — establish distinct query failure handling on settings pages.

- Adds a shared, copy-free \ErrorState\ UI component with an optional retry button wired to \onRetry\.
- Mirrors \LoadingState\/\EmptyState\ conventions; callers supply localized title/message/retryLabel.
- Shipped with a behavioral unit test (render, conditional retry button, click fires callback).

## Changes

| File | Change |
|------|--------|
| \rontend/src/components/ui/ErrorState.tsx\ | New shared error-state tile (\AlertTriangle\, red tone, optional retry button, \cn()\ merge) |
| \rontend/src/components/ui/ErrorState.test.tsx\ | Unit tests: message renders; button only with \onRetry\+\etryLabel\; click fires; absent handlers hide button |

## Chain Context

| Field | Value |
|-------|-------|
| Chain | settings-query-state (#123) |
| Tracker PR | Not needed |
| Position | 1 of 3 |
| Base | \master\ |
| Depends on | None |
| Follow-up | #PR-slice2 (locale + advanced error gates) |
| Review budget | 123 lines / 400 |
| Starts at | \master\ (770ecfa) |
| Ends with | Reusable \ErrorState\ component + unit test |

### Chain Overview

\\\	ext
master
 \u2514\u2500\u2500 #PR-slice1 This PR (ErrorState)
      \u2514\u2500\u2500 #PR-slice2 (locale + advanced gates)
           \u2514\u2500\u2500 #PR-slice3 (billing authoritative gating)
\\\

### Scope
- Includes: ErrorState component + its unit test only.
- Excludes: settings page gates (later PRs), backend, hooks API changes.

### Autonomy
- [x] CI expected to pass (frontend suite + build green at this commit)
- [x] One deliverable scope
- [x] Can be rolled back without unrelated changes
- [x] Unit test covers this unit
