### PR TITLE
fix(settings): error-gate locale and advanced pages with tests

### DIFF
--- a/frontend/src/app/settings/(advanced)/advanced/page.behavior.test.tsx
+++ b/frontend/src/app/settings/(advanced)/advanced/page.behavior.test.tsx
@@ -2,8 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-const { updateSettingsMutateAsyncMock, settingsData } = vi.hoisted(() => ({
-  updateSettingsMutateAsyncMock: vi.fn(),
+const { settingsData, useSettingsMock } = vi.hoisted(() => ({
   settingsData: {
     organization: { name: "Mi Empresa", logoUrl: null },
     invoicing: { printHeader: "", printFooter: "" },
@@ -11,10 +10,14 @@ const { updateSettingsMutateAsyncMock, settingsData } = vi.hoisted(() => ({
     locale: { currency: "COP", locale: "es-CO", timezone: "America/Bogota" },
     custom: { theme: "dark" },
   },
+  useSettingsMock: vi.fn(),
 }));
 
+const updateSettingsMutateAsyncMock = vi.fn();
+const useSettingsRefetchMock = vi.fn();
+
 vi.mock("@/hooks/useSettings", () => ({
-  useSettings: () => ({ data: settingsData, isLoading: false }),
+  useSettings: () => useSettingsMock(),
   useUpdateSettings: () => ({
     mutateAsync: updateSettingsMutateAsyncMock,
     isPending: false,
@@ -31,6 +34,22 @@ vi.mock("@/contexts/ToastContext", () => ({
 
 import AdvancedSettingsPage from "./page";
 
+function mockQueryState(overrides: {
+  data?: typeof settingsData | undefined;
+  isLoading?: boolean;
+  isError?: boolean;
+  error?: Error | null;
+}) {
+  useSettingsRefetchMock.mockReset();
+  useSettingsMock.mockReturnValue({
+    data: overrides.data ?? undefined,
+    isLoading: overrides.isLoading ?? false,
+    isError: overrides.isError ?? false,
+    error: overrides.error ?? null,
+    refetch: useSettingsRefetchMock,
+  });
+}
+
 describe("Advanced settings page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -42,6 +61,7 @@ describe("Advanced settings page", () => {
   });
 
   it("renders existing custom key/value entries", () => {
+    mockQueryState({ data: settingsData, isError: false, error: null });
     render(<AdvancedSettingsPage />);
 
     expect(screen.getByDisplayValue("theme")).toBeInTheDocument();
@@ -49,6 +69,7 @@ describe("Advanced settings page", () => {
   });
 
   it("adds a key/value row and saves the merged custom object", async () => {
+    mockQueryState({ data: settingsData, isError: false, error: null });
     const user = userEvent.setup();
     render(<AdvancedSettingsPage />);
 
@@ -64,5 +85,50 @@ describe("Advanced settings page", () => {
     expect(updateSettingsMutateAsyncMock).toHaveBeenCalledWith({
       custom: { theme: "dark", color: "rojo" },
     });
+  });
+
+  it("shows the error state with retry when the query failed, without loading or the editor", async () => {
+    mockQueryState({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("Network error"),
+    });
+    render(<AdvancedSettingsPage />);
+
+    expect(
+      screen.getByText("No se pudo cargar la configuración."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Reintentar" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Cargando configuración...")).toBeNull();
+    expect(screen.queryByDisplayValue("theme")).toBeNull();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Reintentar" }));
+
+    expect(useSettingsRefetchMock).toHaveBeenCalled();
+  });
+
+  it("recovers the editor when the retry query succeeds", () => {
+    mockQueryState({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("Network error"),
+    });
+    const { rerender } = render(<AdvancedSettingsPage />);
+
+    expect(
+      screen.getByText("No se pudo cargar la configuración."),
+    ).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("theme")).toBeNull();
+
+    mockQueryState({ data: settingsData, isError: false, error: null });
+    rerender(<AdvancedSettingsPage />);
+
+    expect(screen.queryByText("No se pudo cargar la configuración.")).toBeNull();
+    expect(screen.getByDisplayValue("theme")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/settings/(advanced)/advanced/page.tsx
+++ b/frontend/src/app/settings/(advanced)/advanced/page.tsx
@@ -5,6 +5,7 @@ import { useSettings, useUpdateSettings } from "@/hooks/useSettings";
 import { Input } from "@/components/ui/Input";
 import { Button } from "@/components/ui/Button";
 import { LoadingState } from "@/components/ui/LoadingState";
+import { ErrorState } from "@/components/ui/ErrorState";
 import { SettingsCard } from "../../_components/SettingsCard";
 import { useToast } from "@/contexts/ToastContext";
 import { getApiErrorMessage } from "@/lib/api";
@@ -17,7 +18,7 @@ interface CustomEntry {
 
 export default function AdvancedSettingsPage() {
   const toast = useToast();
-  const { data: settings, isLoading } = useSettings();
+  const { data: settings, isLoading, isError, refetch } = useSettings();
   const updateSettings = useUpdateSettings();
   const [entries, setEntries] = useState<CustomEntry[]>([]);
 
@@ -31,6 +32,16 @@ export default function AdvancedSettingsPage() {
       );
     }
   }, [settings]);
+
+  if (isError && !settings) {
+    return (
+      <ErrorState
+        message="No se pudo cargar la configuración."
+        retryLabel="Reintentar"
+        onRetry={refetch}
+      />
+    );
+  }
 
   if (isLoading || !settings) {
     return (

--- a/frontend/src/app/settings/(locale)/locale/page.behavior.test.tsx
+++ b/frontend/src/app/settings/(locale)/locale/page.behavior.test.tsx
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
-const { settingsData } = vi.hoisted(() => ({
+const { settingsData, useSettingsMock } = vi.hoisted(() => ({
   settingsData: {
     organization: { name: "Mi Empresa", logoUrl: null },
     invoicing: { printHeader: "", printFooter: "" },
@@ -9,13 +10,32 @@ const { settingsData } = vi.hoisted(() => ({
     locale: { currency: "COP", locale: "es-CO", timezone: "America/Bogota" },
     custom: {},
   },
+  useSettingsMock: vi.fn(),
 }));
 
+const useSettingsRefetchMock = vi.fn();
+
 vi.mock("@/hooks/useSettings", () => ({
-  useSettings: () => ({ data: settingsData, isLoading: false }),
+  useSettings: () => useSettingsMock(),
 }));
 
 import LocaleSettingsPage from "./page";
+
+function mockQueryState(overrides: {
+  data?: typeof settingsData | undefined;
+  isLoading?: boolean;
+  isError?: boolean;
+  error?: Error | null;
+}) {
+  useSettingsRefetchMock.mockReset();
+  useSettingsMock.mockReturnValue({
+    data: overrides.data ?? undefined,
+    isLoading: overrides.isLoading ?? false,
+    isError: overrides.isError ?? false,
+    error: overrides.error ?? null,
+    refetch: useSettingsRefetchMock,
+  });
+}
 
 describe("Currency & Locale settings page", () => {
   afterEach(() => {
@@ -23,6 +43,7 @@ describe("Currency & Locale settings page", () => {
   });
 
   it("shows currency, locale and timezone as read-only values", () => {
+    mockQueryState({ data: settingsData, isError: false, error: null });
     render(<LocaleSettingsPage />);
 
     expect(screen.getByText("COP")).toBeInTheDocument();
@@ -31,9 +52,54 @@ describe("Currency & Locale settings page", () => {
   });
 
   it("renders no editable fields or save button", () => {
+    mockQueryState({ data: settingsData, isError: false, error: null });
     render(<LocaleSettingsPage />);
 
     expect(screen.queryByRole("textbox")).toBeNull();
     expect(screen.queryByRole("button", { name: /guardar/i })).toBeNull();
+  });
+
+  it("shows the error state with retry when the query failed, without loading or values", async () => {
+    mockQueryState({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("Network error"),
+    });
+    render(<LocaleSettingsPage />);
+
+    expect(
+      screen.getByText("No se pudo cargar la configuración."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Reintentar" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Cargando configuración...")).toBeNull();
+    expect(screen.queryByText("COP")).toBeNull();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Reintentar" }));
+
+    expect(useSettingsRefetchMock).toHaveBeenCalled();
+  });
+
+  it("recovers to the form when the retry query succeeds", () => {
+    mockQueryState({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("Network error"),
+    });
+    const { rerender } = render(<LocaleSettingsPage />);
+
+    expect(
+      screen.getByText("No se pudo cargar la configuración."),
+    ).toBeInTheDocument();
+
+    mockQueryState({ data: settingsData, isError: false, error: null });
+    rerender(<LocaleSettingsPage />);
+
+    expect(screen.queryByText("No se pudo cargar la configuración.")).toBeNull();
+    expect(screen.getByText("COP")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/settings/(locale)/locale/page.tsx
+++ b/frontend/src/app/settings/(locale)/locale/page.tsx
@@ -2,11 +2,22 @@
 
 import { useSettings } from "@/hooks/useSettings";
 import { LoadingState } from "@/components/ui/LoadingState";
+import { ErrorState } from "@/components/ui/ErrorState";
 import { SettingsCard } from "../../_components/SettingsCard";
 import { Globe2 } from "lucide-react";
 
 export default function LocaleSettingsPage() {
-  const { data: settings, isLoading } = useSettings();
+  const { data: settings, isLoading, isError, refetch } = useSettings();
+
+  if (isError && !settings) {
+    return (
+      <ErrorState
+        message="No se pudo cargar la configuración."
+        retryLabel="Reintentar"
+        onRetry={refetch}
+      />
+    );
+  }
 
   if (isLoading || !settings) {
     return (

--- a/frontend/src/components/ui/ErrorState.test.tsx
+++ b/frontend/src/components/ui/ErrorState.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ErrorState } from "./ErrorState";
+
+describe("ErrorState", () => {
+  it("renders the message and a title when provided", () => {
+    render(<ErrorState title="No se pudo cargar" message="Intenta de nuevo." />);
+
+    expect(screen.getByText("No se pudo cargar")).toBeInTheDocument();
+    expect(screen.getByText("Intenta de nuevo.")).toBeInTheDocument();
+  });
+
+  it("renders the message alone when no title is provided", () => {
+    render(<ErrorState message="No se pudo cargar la configuración." />);
+
+    expect(
+      screen.getByText("No se pudo cargar la configuración."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("heading")).toBeNull();
+  });
+
+  it("renders a retry button only when onRetry and retryLabel are present", () => {
+    const onRetry = vi.fn();
+    render(
+      <ErrorState
+        message="No se pudo cargar la configuración."
+        retryLabel="Reintentar"
+        onRetry={onRetry}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Reintentar" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render a retry button when handlers are absent", () => {
+    render(<ErrorState message="No se pudo cargar la configuración." />);
+
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("does not render a retry button when only retryLabel is provided", () => {
+    render(
+      <ErrorState message="No se pudo cargar la configuración." retryLabel="Reintentar" />,
+    );
+
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("fires onRetry when the retry button is clicked", async () => {
+    const onRetry = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ErrorState
+        message="No se pudo cargar la configuración."
+        retryLabel="Reintentar"
+        onRetry={onRetry}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Reintentar" }));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("merges an extra className through cn()", () => {
+    render(<ErrorState message="No se pudo cargar." className="py-4" />);
+
+    const message = screen.getByText("No se pudo cargar.");
+    expect(message.closest("div")?.className).toContain("py-4");
+  });
+});

--- a/frontend/src/components/ui/ErrorState.tsx
+++ b/frontend/src/components/ui/ErrorState.tsx
@@ -1,0 +1,49 @@
+import { AlertTriangle } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "./Button";
+
+interface ErrorStateProps {
+  icon?: ReactNode;
+  title?: string;
+  message: string;
+  retryLabel?: string;
+  onRetry?: () => void;
+  className?: string;
+}
+
+export function ErrorState({
+  icon = <AlertTriangle className="w-5 h-5" />,
+  title,
+  message,
+  retryLabel,
+  onRetry,
+  className,
+}: ErrorStateProps) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex flex-col items-center justify-center text-center min-h-[200px] rounded-xl bg-red-500/10 border border-red-500/20 px-6",
+        className,
+      )}
+    >
+      <div className="w-10 h-10 rounded-xl bg-red-500/10 border border-red-500/20 flex items-center justify-center text-red-500">
+        {icon}
+      </div>
+      {title && <p className="text-sm font-semibold text-foreground mt-3">{title}</p>}
+      <p className="text-xs text-muted-foreground mt-1">{message}</p>
+      {onRetry && retryLabel && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onRetry}
+          className="mt-4"
+        >
+          {retryLabel}
+        </Button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
﻿Refs #123

## Summary

PR 2 of 3 (stacked-to-main) for #123 — error-gate the locale and advanced settings pages.

- Settings queries failed first-fetch with React Query v5 surface \isLoading: false, isError: true\, so the \isLoading || !data\ guard rendered a permanent spinner.
- Both pages now gate \isError && !data\ before the loading gate and render \ErrorState\ with retry wired to \efetch\.
- Behavior tests cover failure (error card, no loading text, no business data), retry recovery, and happy path.

## Changes

| File | Change |
|------|--------|
| \rontend/src/app/settings/(locale)/locale/page.tsx\ | Destructure \isError\/\efetch\; error gate before loading gate; \ErrorState\ retry |
| \rontend/src/app/settings/(locale)/locale/page.behavior.test.tsx\ | Hoisted mutable hook mock; failure, retry-recovery, happy-path tests; mocks gain \isError\/\error\ |
| \rontend/src/app/settings/(advanced)/advanced/page.tsx\ | Same error gate before loading gate; \useEffect\ seed untouched |
| \rontend/src/app/settings/(advanced)/advanced/page.behavior.test.tsx\ | Same hoisted-mock conversion; failure/retry/recovery coverage |

## Dependency

Stacked after PR #130 (uses \ErrorState\ from slice 1; diff is independent).

## Chain Context

| Field | Value |
|-------|-------|
| Chain | settings-query-state (#123) |
| Tracker PR | Not needed |
| Position | 2 of 3 |
| Base | \master\ |
| Depends on | PR #130 |
| Follow-up | #PR-slice3 (billing authoritative gating) |
| Review budget | 161 insertions / 7 deletions / 400 |
| Starts at | PR #130 (\ErrorState\) |
| Ends with | Locale + advanced pages show distinct error state with recovery on query failure |

### Chain Overview

\\\	ext
master
 \u2514\u2500\u2500 #130 PR 1 (ErrorState)
      \u2514\u2500\u2500 #PR-slice2 This PR (locale + advanced gates)
           \u2514\u2500\u2500 #PR-slice3 (billing authoritative gating)
\\\

### Scope
- Includes: locale + advanced error gating and their tests.
- Excludes: billing (PR 3), general/invoicing pages (out of scope follow-up), backend.

### Autonomy
- [x] CI expected to pass (frontend 348 tests green at this commit)
- [x] One deliverable scope
- [x] Can be rolled back without unrelated changes
- [x] Behavior tests cover this unit
