### PR TITLE
fix(settings): make billing plan/status authoritative with per-section errors and tests

### DIFF
--- a/frontend/src/app/settings/(advanced)/advanced/page.behavior.test.tsx
+++ b/frontend/src/app/settings/(advanced)/advanced/page.behavior.test.tsx
@@ -2,8 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-const { updateSettingsMutateAsyncMock, settingsData } = vi.hoisted(() => ({
-  updateSettingsMutateAsyncMock: vi.fn(),
+const { settingsData, useSettingsMock } = vi.hoisted(() => ({
   settingsData: {
     organization: { name: "Mi Empresa", logoUrl: null },
     invoicing: { printHeader: "", printFooter: "" },
@@ -11,10 +10,14 @@ const { updateSettingsMutateAsyncMock, settingsData } = vi.hoisted(() => ({
     locale: { currency: "COP", locale: "es-CO", timezone: "America/Bogota" },
     custom: { theme: "dark" },
   },
+  useSettingsMock: vi.fn(),
 }));
 
+const updateSettingsMutateAsyncMock = vi.fn();
+const useSettingsRefetchMock = vi.fn();
+
 vi.mock("@/hooks/useSettings", () => ({
-  useSettings: () => ({ data: settingsData, isLoading: false }),
+  useSettings: () => useSettingsMock(),
   useUpdateSettings: () => ({
     mutateAsync: updateSettingsMutateAsyncMock,
     isPending: false,
@@ -31,6 +34,22 @@ vi.mock("@/contexts/ToastContext", () => ({
 
 import AdvancedSettingsPage from "./page";
 
+function mockQueryState(overrides: {
+  data?: typeof settingsData | undefined;
+  isLoading?: boolean;
+  isError?: boolean;
+  error?: Error | null;
+}) {
+  useSettingsRefetchMock.mockReset();
+  useSettingsMock.mockReturnValue({
+    data: overrides.data ?? undefined,
+    isLoading: overrides.isLoading ?? false,
+    isError: overrides.isError ?? false,
+    error: overrides.error ?? null,
+    refetch: useSettingsRefetchMock,
+  });
+}
+
 describe("Advanced settings page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -42,6 +61,7 @@ describe("Advanced settings page", () => {
   });
 
   it("renders existing custom key/value entries", () => {
+    mockQueryState({ data: settingsData, isError: false, error: null });
     render(<AdvancedSettingsPage />);
 
     expect(screen.getByDisplayValue("theme")).toBeInTheDocument();
@@ -49,6 +69,7 @@ describe("Advanced settings page", () => {
   });
 
   it("adds a key/value row and saves the merged custom object", async () => {
+    mockQueryState({ data: settingsData, isError: false, error: null });
     const user = userEvent.setup();
     render(<AdvancedSettingsPage />);
 
@@ -64,5 +85,50 @@ describe("Advanced settings page", () => {
     expect(updateSettingsMutateAsyncMock).toHaveBeenCalledWith({
       custom: { theme: "dark", color: "rojo" },
     });
+  });
+
+  it("shows the error state with retry when the query failed, without loading or the editor", async () => {
+    mockQueryState({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("Network error"),
+    });
+    render(<AdvancedSettingsPage />);
+
+    expect(
+      screen.getByText("No se pudo cargar la configuración."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Reintentar" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Cargando configuración...")).toBeNull();
+    expect(screen.queryByDisplayValue("theme")).toBeNull();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Reintentar" }));
+
+    expect(useSettingsRefetchMock).toHaveBeenCalled();
+  });
+
+  it("recovers the editor when the retry query succeeds", () => {
+    mockQueryState({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("Network error"),
+    });
+    const { rerender } = render(<AdvancedSettingsPage />);
+
+    expect(
+      screen.getByText("No se pudo cargar la configuración."),
+    ).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("theme")).toBeNull();
+
+    mockQueryState({ data: settingsData, isError: false, error: null });
+    rerender(<AdvancedSettingsPage />);
+
+    expect(screen.queryByText("No se pudo cargar la configuración.")).toBeNull();
+    expect(screen.getByDisplayValue("theme")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/settings/(advanced)/advanced/page.tsx
+++ b/frontend/src/app/settings/(advanced)/advanced/page.tsx
@@ -5,6 +5,7 @@ import { useSettings, useUpdateSettings } from "@/hooks/useSettings";
 import { Input } from "@/components/ui/Input";
 import { Button } from "@/components/ui/Button";
 import { LoadingState } from "@/components/ui/LoadingState";
+import { ErrorState } from "@/components/ui/ErrorState";
 import { SettingsCard } from "../../_components/SettingsCard";
 import { useToast } from "@/contexts/ToastContext";
 import { getApiErrorMessage } from "@/lib/api";
@@ -17,7 +18,7 @@ interface CustomEntry {
 
 export default function AdvancedSettingsPage() {
   const toast = useToast();
-  const { data: settings, isLoading } = useSettings();
+  const { data: settings, isLoading, isError, refetch } = useSettings();
   const updateSettings = useUpdateSettings();
   const [entries, setEntries] = useState<CustomEntry[]>([]);
 
@@ -31,6 +32,16 @@ export default function AdvancedSettingsPage() {
       );
     }
   }, [settings]);
+
+  if (isError && !settings) {
+    return (
+      <ErrorState
+        message="No se pudo cargar la configuración."
+        retryLabel="Reintentar"
+        onRetry={refetch}
+      />
+    );
+  }
 
   if (isLoading || !settings) {
     return (

--- a/frontend/src/app/settings/(billing)/billing/page.behavior.test.tsx
+++ b/frontend/src/app/settings/(billing)/billing/page.behavior.test.tsx
@@ -1,0 +1,223 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const { statusMock, limitsMock, paymentsMock } = vi.hoisted(() => ({
+  statusMock: vi.fn(),
+  limitsMock: vi.fn(),
+  paymentsMock: vi.fn(),
+}));
+
+const statusRefetchMock = vi.fn();
+const limitsRefetchMock = vi.fn();
+const paymentsRefetchMock = vi.fn();
+
+vi.mock("@/hooks/useBilling", () => ({
+  useBillingStatus: () => statusMock(),
+  useBillingPayments: () => paymentsMock(),
+  useRegisterPayment: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/hooks/usePlanLimits", () => ({
+  usePlanLimits: () => limitsMock(),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: {
+      id: "u_1",
+      name: "Admin",
+      email: "admin@meper.app",
+      role: "SUPER_ADMIN",
+      active: true,
+    },
+  }),
+}));
+
+vi.mock("@/contexts/ToastContext", () => ({
+  useToast: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  }),
+}));
+
+import BillingSettingsPage from "./page";
+
+const statusData = {
+  id: "org_1",
+  plan: "PRO" as const,
+  status: "ACTIVE" as const,
+  trialEndsAt: null,
+  billingStatus: "PAID" as const,
+};
+
+const limitsData = {
+  organizationId: "org_1",
+  limits: [
+    { type: "users" as const, current: 2, limit: 5, exceeded: false, warningAt: 4 },
+    { type: "products" as const, current: 3, limit: 10, exceeded: false, warningAt: 8 },
+  ],
+};
+
+const paymentsData = [
+  {
+    id: "pay_1",
+    organizationId: "org_1",
+    amount: 1500000,
+    method: "CASH" as const,
+    date: "2026-01-15",
+    status: "PAID" as const,
+    createdAt: "2026-01-15T00:00:00.000Z",
+    updatedAt: "2026-01-15T00:00:00.000Z",
+  },
+];
+
+type QueryState = {
+  data?: unknown;
+  isLoading?: boolean;
+  isError?: boolean;
+  error?: Error | null;
+};
+
+const okState = (data: unknown): QueryState => ({
+  data,
+  isLoading: false,
+  isError: false,
+  error: null,
+});
+
+const failedState = (): QueryState => ({
+  data: undefined,
+  isLoading: false,
+  isError: true,
+  error: new Error("Network error"),
+});
+
+function mockQueries(
+  status: QueryState = okState(statusData),
+  limits: QueryState = okState(limitsData),
+  payments: QueryState = okState(paymentsData),
+) {
+  statusRefetchMock.mockReset();
+  limitsRefetchMock.mockReset();
+  paymentsRefetchMock.mockReset();
+  statusMock.mockReturnValue({ ...status, refetch: statusRefetchMock });
+  limitsMock.mockReturnValue({ ...limits, refetch: limitsRefetchMock });
+  paymentsMock.mockReturnValue({ ...payments, refetch: paymentsRefetchMock });
+}
+
+describe("Billing settings page", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows a full-page error when billing status fails, hiding plan/status defaults and the register form (S5)", async () => {
+    mockQueries(failedState(), okState(limitsData), okState([]));
+    render(<BillingSettingsPage />);
+
+    expect(
+      screen.getByText("No se pudo cargar la información de facturación."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Básico")).toBeNull();
+    expect(screen.queryByText("Activo")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Registrar Pago" })).toBeNull();
+    expect(screen.queryByText("No hay pagos registrados.")).toBeNull();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Reintentar" }));
+
+    expect(statusRefetchMock).toHaveBeenCalled();
+  });
+
+  it("renders the authoritative plan and status returned by billing status (S6)", () => {
+    mockQueries();
+    render(<BillingSettingsPage />);
+
+    expect(screen.getByText("Profesional")).toBeInTheDocument();
+    expect(screen.getByText("Activo")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Registrar Pago" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a limits error card when only plan-limits fail while plan and payments still render (S9)", async () => {
+    mockQueries(okState(statusData), failedState(), okState(paymentsData));
+    render(<BillingSettingsPage />);
+
+    expect(
+      screen.getByText("No se pudo cargar los límites del plan."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Uso y Límites")).toBeInTheDocument();
+    expect(screen.getByText("Profesional")).toBeInTheDocument();
+    expect(screen.getByText("Pagado")).toBeInTheDocument();
+    expect(screen.queryByText("Usuarios")).toBeNull();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Reintentar" }));
+
+    expect(limitsRefetchMock).toHaveBeenCalled();
+  });
+
+  it("shows a payments error card when only payments fail while plan and limits still render (S10)", async () => {
+    mockQueries(okState(statusData), okState(limitsData), failedState());
+    render(<BillingSettingsPage />);
+
+    expect(
+      screen.getByText("No se pudo cargar el historial de pagos."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Profesional")).toBeInTheDocument();
+    expect(screen.getByText("Usuarios")).toBeInTheDocument();
+    expect(screen.getByText("Productos")).toBeInTheDocument();
+    expect(screen.queryByText("No hay pagos registrados.")).toBeNull();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Reintentar" }));
+
+    expect(paymentsRefetchMock).toHaveBeenCalled();
+  });
+
+  it("never shows the empty-history message when the payments query failed (S7)", async () => {
+    mockQueries(okState(statusData), okState(limitsData), failedState());
+    render(<BillingSettingsPage />);
+
+    expect(
+      screen.getByText("No se pudo cargar el historial de pagos."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("No hay pagos registrados.")).toBeNull();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Reintentar" }));
+
+    expect(paymentsRefetchMock).toHaveBeenCalled();
+  });
+
+  it("keeps the empty-history message only when payments succeed with zero payments (S8)", () => {
+    mockQueries(okState(statusData), okState(limitsData), okState([]));
+    render(<BillingSettingsPage />);
+
+    expect(screen.getByText("No hay pagos registrados.")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("recovers to the full page when a retried billing-status query succeeds", () => {
+    mockQueries(failedState(), okState(limitsData), okState([]));
+    const { rerender } = render(<BillingSettingsPage />);
+
+    expect(
+      screen.getByText("No se pudo cargar la información de facturación."),
+    ).toBeInTheDocument();
+
+    mockQueries(okState(statusData), okState(limitsData), okState([]));
+    rerender(<BillingSettingsPage />);
+
+    expect(
+      screen.queryByText("No se pudo cargar la información de facturación."),
+    ).toBeNull();
+    expect(screen.getByText("Profesional")).toBeInTheDocument();
+    expect(screen.getByText("Activo")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/settings/(billing)/billing/page.tsx
+++ b/frontend/src/app/settings/(billing)/billing/page.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { Badge } from "@/components/ui/Badge";
 import { LoadingState } from "@/components/ui/LoadingState";
+import { ErrorState } from "@/components/ui/ErrorState";
 import { cn, formatCurrency, formatDate } from "@/lib/utils";
 import { useToast } from "@/contexts/ToastContext";
 import { getApiErrorMessage } from "@/lib/api";
@@ -63,9 +64,23 @@ const planConfig: Record<string, { label: string; color: string }> = {
 export default function BillingSettingsPage() {
   const { user } = useAuth();
   const toast = useToast();
-  const { data: planLimits, isLoading: limitsLoading } = usePlanLimits();
-  const { data: billingStatus, isLoading: statusLoading } = useBillingStatus();
-  const { data: payments, isLoading: paymentsLoading } = useBillingPayments();
+  const {
+    data: planLimits,
+    isLoading: limitsLoading,
+    isError: isLimitsError,
+    refetch: refetchLimits,
+  } = usePlanLimits();
+  const {
+    data: billingStatus,
+    isLoading: statusLoading,
+    refetch: refetchStatus,
+  } = useBillingStatus();
+  const {
+    data: payments,
+    isLoading: paymentsLoading,
+    isError: isPaymentsError,
+    refetch: refetchPayments,
+  } = useBillingPayments();
   const registerPayment = useRegisterPayment();
 
   const [showPaymentForm, setShowPaymentForm] = useState(false);
@@ -112,6 +127,16 @@ export default function BillingSettingsPage() {
     );
   }
 
+  if (!billingStatus) {
+    return (
+      <ErrorState
+        message="No se pudo cargar la información de facturación."
+        retryLabel="Reintentar"
+        onRetry={refetchStatus}
+      />
+    );
+  }
+
   return (
     <div className="space-y-5">
       <div className="flex items-center gap-3 mb-5">
@@ -131,16 +156,16 @@ export default function BillingSettingsPage() {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-xs text-muted-foreground uppercase tracking-wide">Plan</p>
-              <p className={cn("text-xl font-bold", planConfig[billingStatus?.plan ?? "BASIC"]?.color)}>
-                {planConfig[billingStatus?.plan ?? "BASIC"]?.label ?? billingStatus?.plan}
+              <p className={cn("text-xl font-bold", planConfig[billingStatus.plan]?.color)}>
+                {planConfig[billingStatus.plan]?.label ?? billingStatus.plan}
               </p>
             </div>
             <div className="text-right">
               <p className="text-xs text-muted-foreground uppercase tracking-wide">Estado</p>
-              <Badge variant={statusConfig[billingStatus?.status ?? "ACTIVE"].variant} className="mt-1">
+              <Badge variant={statusConfig[billingStatus.status].variant} className="mt-1">
                 <span className="flex items-center gap-1">
-                  {statusConfig[billingStatus?.status ?? "ACTIVE"].icon}
-                  {statusConfig[billingStatus?.status ?? "ACTIVE"].label}
+                  {statusConfig[billingStatus.status].icon}
+                  {statusConfig[billingStatus.status].label}
                 </span>
               </Badge>
             </div>
@@ -199,52 +224,61 @@ export default function BillingSettingsPage() {
           <h3 className="text-sm font-semibold text-foreground">Uso y Límites</h3>
         </div>
         <div className="p-5 space-y-3">
-          {planLimits?.limits.map((limit) => {
-            const pct = limit.limit > 0 ? (limit.current / limit.limit) * 100 : 0;
-            const isUnlimited = limit.limit === -1;
-            const isWarning = !limit.exceeded && limit.current >= limit.warningAt && !isUnlimited;
-            const isExceeded = limit.exceeded && !isUnlimited;
+          {isLimitsError && !planLimits ? (
+            <ErrorState
+              message="No se pudo cargar los límites del plan."
+              retryLabel="Reintentar"
+              onRetry={refetchLimits}
+              className="min-h-0"
+            />
+          ) : (
+            planLimits?.limits.map((limit) => {
+              const pct = limit.limit > 0 ? (limit.current / limit.limit) * 100 : 0;
+              const isUnlimited = limit.limit === -1;
+              const isWarning = !limit.exceeded && limit.current >= limit.warningAt && !isUnlimited;
+              const isExceeded = limit.exceeded && !isUnlimited;
 
-            return (
-              <div key={limit.type} className="space-y-1.5">
-                <div className="flex items-center justify-between text-sm">
-                  <span className="flex items-center gap-1.5 text-foreground">
-                    {typeIcons[limit.type]}
-                    {typeLabels[limit.type]}
-                  </span>
-                  <span className="font-mono text-xs">
-                    {isUnlimited ? (
-                      <span className="text-accent">Ilimitado</span>
-                    ) : (
-                      <span
-                        className={cn(
-                          isExceeded && "text-red-600 dark:text-red-400 font-semibold",
-                          isWarning && "text-amber-700 dark:text-amber-400 font-semibold"
-                        )}
-                      >
-                        {limit.current} / {limit.limit}
-                      </span>
-                    )}
-                  </span>
-                </div>
-                {!isUnlimited && (
-                  <div className="h-2 rounded-full bg-background/60 overflow-hidden">
-                    <div
-                      className={cn(
-                        "h-full rounded-full transition-all",
-                        isExceeded
-                          ? "bg-red-500"
-                          : isWarning
-                          ? "bg-amber-500"
-                          : "bg-accent"
+              return (
+                <div key={limit.type} className="space-y-1.5">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="flex items-center gap-1.5 text-foreground">
+                      {typeIcons[limit.type]}
+                      {typeLabels[limit.type]}
+                    </span>
+                    <span className="font-mono text-xs">
+                      {isUnlimited ? (
+                        <span className="text-accent">Ilimitado</span>
+                      ) : (
+                        <span
+                          className={cn(
+                            isExceeded && "text-red-600 dark:text-red-400 font-semibold",
+                            isWarning && "text-amber-700 dark:text-amber-400 font-semibold"
+                          )}
+                        >
+                          {limit.current} / {limit.limit}
+                        </span>
                       )}
-                      style={{ width: `${Math.min(pct, 100)}%` }}
-                    />
+                    </span>
                   </div>
-                )}
-              </div>
-            );
-          })}
+                  {!isUnlimited && (
+                    <div className="h-2 rounded-full bg-background/60 overflow-hidden">
+                      <div
+                        className={cn(
+                          "h-full rounded-full transition-all",
+                          isExceeded
+                            ? "bg-red-500"
+                            : isWarning
+                            ? "bg-amber-500"
+                            : "bg-accent"
+                        )}
+                        style={{ width: `${Math.min(pct, 100)}%` }}
+                      />
+                    </div>
+                  )}
+                </div>
+              );
+            })
+          )}
         </div>
       </div>
 
@@ -322,7 +356,18 @@ export default function BillingSettingsPage() {
         <div className="p-5">
           {paymentsLoading ? (
             <p className="text-sm text-muted-foreground">Cargando pagos...</p>
-          ) : payments && payments.length > 0 ? (
+          ) : isPaymentsError && !payments ? (
+            <ErrorState
+              message="No se pudo cargar el historial de pagos."
+              retryLabel="Reintentar"
+              onRetry={refetchPayments}
+              className="min-h-0"
+            />
+          ) : !payments ? null : payments.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-4">
+              No hay pagos registrados.
+            </p>
+          ) : (
             <div className="space-y-2">
               {payments.map((payment) => (
                 <div
@@ -360,10 +405,6 @@ export default function BillingSettingsPage() {
                 </div>
               ))}
             </div>
-          ) : (
-            <p className="text-sm text-muted-foreground text-center py-4">
-              No hay pagos registrados.
-            </p>
           )}
         </div>
       </div>

--- a/frontend/src/app/settings/(locale)/locale/page.behavior.test.tsx
+++ b/frontend/src/app/settings/(locale)/locale/page.behavior.test.tsx
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
-const { settingsData } = vi.hoisted(() => ({
+const { settingsData, useSettingsMock } = vi.hoisted(() => ({
   settingsData: {
     organization: { name: "Mi Empresa", logoUrl: null },
     invoicing: { printHeader: "", printFooter: "" },
@@ -9,13 +10,32 @@ const { settingsData } = vi.hoisted(() => ({
     locale: { currency: "COP", locale: "es-CO", timezone: "America/Bogota" },
     custom: {},
   },
+  useSettingsMock: vi.fn(),
 }));
 
+const useSettingsRefetchMock = vi.fn();
+
 vi.mock("@/hooks/useSettings", () => ({
-  useSettings: () => ({ data: settingsData, isLoading: false }),
+  useSettings: () => useSettingsMock(),
 }));
 
 import LocaleSettingsPage from "./page";
+
+function mockQueryState(overrides: {
+  data?: typeof settingsData | undefined;
+  isLoading?: boolean;
+  isError?: boolean;
+  error?: Error | null;
+}) {
+  useSettingsRefetchMock.mockReset();
+  useSettingsMock.mockReturnValue({
+    data: overrides.data ?? undefined,
+    isLoading: overrides.isLoading ?? false,
+    isError: overrides.isError ?? false,
+    error: overrides.error ?? null,
+    refetch: useSettingsRefetchMock,
+  });
+}
 
 describe("Currency & Locale settings page", () => {
   afterEach(() => {
@@ -23,6 +43,7 @@ describe("Currency & Locale settings page", () => {
   });
 
   it("shows currency, locale and timezone as read-only values", () => {
+    mockQueryState({ data: settingsData, isError: false, error: null });
     render(<LocaleSettingsPage />);
 
     expect(screen.getByText("COP")).toBeInTheDocument();
@@ -31,9 +52,54 @@ describe("Currency & Locale settings page", () => {
   });
 
   it("renders no editable fields or save button", () => {
+    mockQueryState({ data: settingsData, isError: false, error: null });
     render(<LocaleSettingsPage />);
 
     expect(screen.queryByRole("textbox")).toBeNull();
     expect(screen.queryByRole("button", { name: /guardar/i })).toBeNull();
+  });
+
+  it("shows the error state with retry when the query failed, without loading or values", async () => {
+    mockQueryState({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("Network error"),
+    });
+    render(<LocaleSettingsPage />);
+
+    expect(
+      screen.getByText("No se pudo cargar la configuración."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Reintentar" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Cargando configuración...")).toBeNull();
+    expect(screen.queryByText("COP")).toBeNull();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Reintentar" }));
+
+    expect(useSettingsRefetchMock).toHaveBeenCalled();
+  });
+
+  it("recovers to the form when the retry query succeeds", () => {
+    mockQueryState({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("Network error"),
+    });
+    const { rerender } = render(<LocaleSettingsPage />);
+
+    expect(
+      screen.getByText("No se pudo cargar la configuración."),
+    ).toBeInTheDocument();
+
+    mockQueryState({ data: settingsData, isError: false, error: null });
+    rerender(<LocaleSettingsPage />);
+
+    expect(screen.queryByText("No se pudo cargar la configuración.")).toBeNull();
+    expect(screen.getByText("COP")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/settings/(locale)/locale/page.tsx
+++ b/frontend/src/app/settings/(locale)/locale/page.tsx
@@ -2,11 +2,22 @@
 
 import { useSettings } from "@/hooks/useSettings";
 import { LoadingState } from "@/components/ui/LoadingState";
+import { ErrorState } from "@/components/ui/ErrorState";
 import { SettingsCard } from "../../_components/SettingsCard";
 import { Globe2 } from "lucide-react";
 
 export default function LocaleSettingsPage() {
-  const { data: settings, isLoading } = useSettings();
+  const { data: settings, isLoading, isError, refetch } = useSettings();
+
+  if (isError && !settings) {
+    return (
+      <ErrorState
+        message="No se pudo cargar la configuración."
+        retryLabel="Reintentar"
+        onRetry={refetch}
+      />
+    );
+  }
 
   if (isLoading || !settings) {
     return (

--- a/frontend/src/components/ui/ErrorState.test.tsx
+++ b/frontend/src/components/ui/ErrorState.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ErrorState } from "./ErrorState";
+
+describe("ErrorState", () => {
+  it("renders the message and a title when provided", () => {
+    render(<ErrorState title="No se pudo cargar" message="Intenta de nuevo." />);
+
+    expect(screen.getByText("No se pudo cargar")).toBeInTheDocument();
+    expect(screen.getByText("Intenta de nuevo.")).toBeInTheDocument();
+  });
+
+  it("renders the message alone when no title is provided", () => {
+    render(<ErrorState message="No se pudo cargar la configuración." />);
+
+    expect(
+      screen.getByText("No se pudo cargar la configuración."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("heading")).toBeNull();
+  });
+
+  it("renders a retry button only when onRetry and retryLabel are present", () => {
+    const onRetry = vi.fn();
+    render(
+      <ErrorState
+        message="No se pudo cargar la configuración."
+        retryLabel="Reintentar"
+        onRetry={onRetry}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Reintentar" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render a retry button when handlers are absent", () => {
+    render(<ErrorState message="No se pudo cargar la configuración." />);
+
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("does not render a retry button when only retryLabel is provided", () => {
+    render(
+      <ErrorState message="No se pudo cargar la configuración." retryLabel="Reintentar" />,
+    );
+
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("fires onRetry when the retry button is clicked", async () => {
+    const onRetry = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ErrorState
+        message="No se pudo cargar la configuración."
+        retryLabel="Reintentar"
+        onRetry={onRetry}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Reintentar" }));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("merges an extra className through cn()", () => {
+    render(<ErrorState message="No se pudo cargar." className="py-4" />);
+
+    const message = screen.getByText("No se pudo cargar.");
+    expect(message.closest("div")?.className).toContain("py-4");
+  });
+});

--- a/frontend/src/components/ui/ErrorState.tsx
+++ b/frontend/src/components/ui/ErrorState.tsx
@@ -1,0 +1,49 @@
+import { AlertTriangle } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "./Button";
+
+interface ErrorStateProps {
+  icon?: ReactNode;
+  title?: string;
+  message: string;
+  retryLabel?: string;
+  onRetry?: () => void;
+  className?: string;
+}
+
+export function ErrorState({
+  icon = <AlertTriangle className="w-5 h-5" />,
+  title,
+  message,
+  retryLabel,
+  onRetry,
+  className,
+}: ErrorStateProps) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex flex-col items-center justify-center text-center min-h-[200px] rounded-xl bg-red-500/10 border border-red-500/20 px-6",
+        className,
+      )}
+    >
+      <div className="w-10 h-10 rounded-xl bg-red-500/10 border border-red-500/20 flex items-center justify-center text-red-500">
+        {icon}
+      </div>
+      {title && <p className="text-sm font-semibold text-foreground mt-3">{title}</p>}
+      <p className="text-xs text-muted-foreground mt-1">{message}</p>
+      {onRetry && retryLabel && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onRetry}
+          className="mt-4"
+        >
+          {retryLabel}
+        </Button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
﻿Closes #123

## Summary

PR 3 of 3 (stacked-to-main) for #123 — make billing plan/status authoritative and separate payment-history failure from empty.

- Billing page gated the whole page on \illingStatus\ success; the \?? "BASIC"\ / \?? "ACTIVE"\ fallbacks are deleted so fabricated subscription state is unreachable.
- Plan-limits failure renders a per-section \ErrorState\ (retry = limits refetch) while the rest of the page still renders.
- Payment-history failure renders a distinct per-section error; \"No hay pagos registrados."\ shows only on successful \[]\.
- New behavior tests cover status failure (no defaults, no \Registrar Pago\), partial failure, empty-vs-error payments, and retry recovery.

## Changes

| File | Change |
|------|--------|
| \rontend/src/app/settings/(billing)/billing/page.tsx\ | \!billingStatus\ full-page error gate; delete \?? "BASIC"/"ACTIVE"\; limits + payments per-section error gates (D3-D5) |
| \rontend/src/app/settings/(billing)/billing/page.behavior.test.tsx\ | 7 behavior tests: S5-S10 + retry recovery across 3 hook mocks |

## Dependency

Stacked after PR #131 (uses \ErrorState\ from PR #130). Final PR of the chain.

## Chain Context

| Field | Value |
|-------|-------|
| Chain | settings-query-state (#123) |
| Tracker PR | Not needed |
| Position | 3 of 3 |
| Base | \master\ |
| Depends on | PR #130, PR #131 |
| Follow-up | None (issue #123 closes). Follow-up issue for general/invoicing settings pages sharing the bug class recommended |
| Review budget | 319 insertions / 55 deletions / 400 (single PR over? no - per-slice diffs stay under 400) |
| Starts at | PR #131 (locale + advanced gates) |
| Ends with | All three settings pages handle query failure distinctly; billing never fabricates plan/status |

### Chain Overview

\\\	ext
master
 \u2514\u2500\u2500 #130 PR 1 (ErrorState)
      \u2514\u2500\u2500 #131 PR 2 (locale + advanced gates)
           \u2514\u2500\u2500 #PR-slice3 This PR (billing authoritative gating)
\\\

### Scope
- Includes: billing authoritative gating + per-section errors + behavior tests.
- Excludes: general/invoicing pages (follow-up), backend, hooks API changes.

### Autonomy
- [x] CI expected to pass (full frontend suite 355 tests + build green at this commit)
- [x] One deliverable scope
- [x] Can be rolled back without unrelated changes
- [x] Behavior tests cover this unit
