### PR TITLE
feat(expenses): complete issue 134 taxonomy integration

### DIFF
--- a/backend/src/expenses/dto/create-expense-group.dto.ts
+++ b/backend/src/expenses/dto/create-expense-group.dto.ts
@@ -1,0 +1,8 @@
+import { IsString, MaxLength, MinLength } from 'class-validator';
+
+export class CreateExpenseGroupDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  name!: string;
+}

--- a/backend/src/expenses/dto/create-expense-label.dto.ts
+++ b/backend/src/expenses/dto/create-expense-label.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, IsUUID, MaxLength, MinLength } from 'class-validator';
+
+export class CreateExpenseLabelDto {
+  @IsUUID()
+  groupId!: string;
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  name!: string;
+}

--- a/backend/src/expenses/dto/update-expense-group.dto.ts
+++ b/backend/src/expenses/dto/update-expense-group.dto.ts
@@ -1,0 +1,9 @@
+import { IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class UpdateExpenseGroupDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  name?: string;
+}

--- a/backend/src/expenses/dto/update-expense-label.dto.ts
+++ b/backend/src/expenses/dto/update-expense-label.dto.ts
@@ -1,0 +1,9 @@
+import { IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class UpdateExpenseLabelDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  name?: string;
+}

--- a/backend/src/expenses/expense-taxonomy-reporting.spec.ts
+++ b/backend/src/expenses/expense-taxonomy-reporting.spec.ts
@@ -1,0 +1,51 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { ExpensesService } from './expenses.service';
+
+describe('Expenses taxonomy validation and reporting', () => {
+  const tx = { expense: { create: jest.fn() }, auditLog: { create: jest.fn() } };
+  const prisma = {
+    expenseLabel: { findFirst: jest.fn(), findMany: jest.fn() },
+    expense: { groupBy: jest.fn(), findMany: jest.fn() },
+    $transaction: jest.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    supplier: { findFirst: jest.fn() }, purchaseOrder: { findFirst: jest.fn() },
+  };
+  const cloudinary = {};
+  const service = new ExpensesService(prisma as never, cloudinary as never);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it.each([
+    ['missing', null],
+    ['inactive', { id: 'l1', active: false, group: { active: true, organizationId: 'org-1' } }],
+    ['cross-organization', { id: 'l1', active: true, group: { active: true, organizationId: 'org-2' } }],
+    ['inactive group', { id: 'l1', active: true, group: { active: false, organizationId: 'org-1' } }],
+  ])('rejects %s labels before opening a transaction', async (_reason, label) => {
+    prisma.expenseLabel.findFirst.mockResolvedValue(label);
+    await expect(service.create({ labelId: 'l1', date: '2026-08-15', total: 10, payments: [{ amount: 10, method: 'CASH', date: '2026-08-15' }] } as never, 'u1', 'org-1')).rejects.toThrow(NotFoundException);
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('returns nested groups and labels ordered by amount then stable identity', async () => {
+    prisma.expense.groupBy.mockResolvedValue([
+      { labelId: 'l2', _sum: { total: new Prisma.Decimal(100) } },
+      { labelId: 'l1', _sum: { total: new Prisma.Decimal(300) } },
+    ]);
+    prisma.expenseLabel.findMany.mockResolvedValue([
+      { id: 'l1', name: 'Arriendo', group: { id: 'g1', name: 'Local' } },
+      { id: 'l2', name: 'Servicios', group: { id: 'g1', name: 'Local' } },
+    ]);
+    await expect(service.getMonthlySummary('2026-08', 'org-1')).resolves.toEqual({
+      month: '2026-08', total: new Prisma.Decimal(400),
+      groups: [{ groupId: 'g1', name: 'Local', total: new Prisma.Decimal(400), labels: [
+        { labelId: 'l1', name: 'Arriendo', total: new Prisma.Decimal(300) },
+        { labelId: 'l2', name: 'Servicios', total: new Prisma.Decimal(100) },
+      ] }],
+    });
+  });
+
+  it('rejects a malformed summary month without querying expenses', async () => {
+    await expect(service.getMonthlySummary('2026-8', 'org-1')).rejects.toThrow(BadRequestException);
+    expect(prisma.expense.groupBy).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/expenses/expense-taxonomy.controller.spec.ts
+++ b/backend/src/expenses/expense-taxonomy.controller.spec.ts
@@ -1,0 +1,23 @@
+import { Reflector } from '@nestjs/core';
+import { OrgRole } from '@prisma/client';
+import { ROLES_KEY } from '../common/decorators/roles.decorator';
+import { ExpenseTaxonomyController } from './expense-taxonomy.controller';
+
+describe('ExpenseTaxonomyController', () => {
+  it('protects every taxonomy mutation and query with ADMIN role metadata', () => {
+    const controller = new ExpenseTaxonomyController({} as never);
+    for (const handler of [controller.findGroups, controller.createGroup, controller.updateGroup, controller.removeGroup, controller.findLabels, controller.createLabel, controller.updateLabel, controller.removeLabel]) {
+      expect(Reflect.getMetadata(ROLES_KEY, handler)).toEqual([OrgRole.ADMIN]);
+    }
+  });
+
+  it('passes organizationId from the authenticated user to the service', async () => {
+    const service = { findGroups: jest.fn().mockResolvedValue([]), createGroup: jest.fn().mockResolvedValue({}) };
+    const controller = new ExpenseTaxonomyController(service as never);
+    const user = { organizationId: 'org-1' } as never;
+    await controller.findGroups(user);
+    await controller.createGroup({ name: 'Gastos' }, user);
+    expect(service.findGroups).toHaveBeenCalledWith('org-1');
+    expect(service.createGroup).toHaveBeenCalledWith({ name: 'Gastos' }, 'org-1');
+  });
+});

--- a/backend/src/expenses/expense-taxonomy.controller.ts
+++ b/backend/src/expenses/expense-taxonomy.controller.ts
@@ -1,0 +1,32 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post, UseGuards, UseInterceptors } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { OrgRole } from '@prisma/client';
+import { JwtAuthGuard } from '../auth/jwt.strategy';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { Roles } from '../common/decorators/roles.decorator';
+import { OrganizationRequiredGuard } from '../common/guards/organization-required.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
+import type { RequestUser } from '../common/interfaces/request-user.interface';
+import { ExpenseTaxonomyService } from './expense-taxonomy.service';
+import { CreateExpenseGroupDto } from './dto/create-expense-group.dto';
+import { UpdateExpenseGroupDto } from './dto/update-expense-group.dto';
+import { CreateExpenseLabelDto } from './dto/create-expense-label.dto';
+import { UpdateExpenseLabelDto } from './dto/update-expense-label.dto';
+
+@ApiTags('Expense Taxonomy')
+@ApiBearerAuth()
+@Controller('expense-groups')
+@UseGuards(JwtAuthGuard, RolesGuard, OrganizationRequiredGuard)
+@UseInterceptors(AdminOrganizationInterceptor)
+export class ExpenseTaxonomyController {
+  constructor(private readonly service: ExpenseTaxonomyService) {}
+  @Get() @Roles(OrgRole.ADMIN) findGroups(@CurrentUser() user: RequestUser) { return this.service.findGroups(user.organizationId); }
+  @Post() @Roles(OrgRole.ADMIN) createGroup(@Body() dto: CreateExpenseGroupDto, @CurrentUser() user: RequestUser) { return this.service.createGroup(dto, user.organizationId); }
+  @Patch(':id') @Roles(OrgRole.ADMIN) updateGroup(@Param('id') id: string, @Body() dto: UpdateExpenseGroupDto, @CurrentUser() user: RequestUser) { return this.service.updateGroup(id, dto, user.organizationId); }
+  @Delete(':id') @Roles(OrgRole.ADMIN) removeGroup(@Param('id') id: string, @CurrentUser() user: RequestUser) { return this.service.removeGroup(id, user.organizationId); }
+  @Get(':groupId/labels') @Roles(OrgRole.ADMIN) findLabels(@Param('groupId') groupId: string, @CurrentUser() user: RequestUser) { return this.service.findLabels(groupId, user.organizationId); }
+  @Post(':groupId/labels') @Roles(OrgRole.ADMIN) createLabel(@Param('groupId') groupId: string, @Body() dto: Omit<CreateExpenseLabelDto, 'groupId'>, @CurrentUser() user: RequestUser) { return this.service.createLabel({ ...dto, groupId }, user.organizationId); }
+  @Patch(':groupId/labels/:id') @Roles(OrgRole.ADMIN) updateLabel(@Param('groupId') groupId: string, @Param('id') id: string, @Body() dto: UpdateExpenseLabelDto, @CurrentUser() user: RequestUser) { return this.service.updateLabel(id, dto, user.organizationId, groupId); }
+  @Delete(':groupId/labels/:id') @Roles(OrgRole.ADMIN) removeLabel(@Param('id') id: string, @CurrentUser() user: RequestUser) { return this.service.removeLabel(id, user.organizationId); }
+}

--- a/backend/src/expenses/expense-taxonomy.service.spec.ts
+++ b/backend/src/expenses/expense-taxonomy.service.spec.ts
@@ -1,0 +1,52 @@
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
+import { ExpenseTaxonomyService } from './expense-taxonomy.service';
+
+describe('ExpenseTaxonomyService', () => {
+  const prisma = {
+    expenseGroup: { findMany: jest.fn(), findFirst: jest.fn(), create: jest.fn(), update: jest.fn() },
+    expenseLabel: { findMany: jest.fn(), findFirst: jest.fn(), create: jest.fn(), update: jest.fn() },
+    auditLog: { create: jest.fn() },
+    $transaction: jest.fn(),
+  };
+  const service = new ExpenseTaxonomyService(prisma as never);
+
+  beforeEach(() => { jest.clearAllMocks(); });
+
+  it('lists only active groups and nested active labels for the token organization', async () => {
+    const groups = [{ id: 'g1', organizationId: 'org-1', active: true, labels: [{ id: 'l1', active: true }] }];
+    prisma.expenseGroup.findMany.mockResolvedValue(groups);
+    await expect(service.findGroups('org-1')).resolves.toEqual(groups);
+    expect(prisma.expenseGroup.findMany).toHaveBeenCalledWith({
+      where: { organizationId: 'org-1', active: true },
+      orderBy: { name: 'asc' },
+      include: { labels: { where: { active: true }, orderBy: { name: 'asc' } } },
+    });
+  });
+
+  it('reactivates an inactive same-name group instead of creating a duplicate', async () => {
+    prisma.expenseGroup.findFirst.mockResolvedValue({ id: 'g1', active: false });
+    prisma.expenseGroup.update.mockResolvedValue({ id: 'g1', active: true });
+    await expect(service.createGroup({ name: '  Transporte ' }, 'org-1')).resolves.toEqual({ id: 'g1', active: true });
+    expect(prisma.expenseGroup.update).toHaveBeenCalledWith({ where: { id: 'g1' }, data: { name: 'Transporte', active: true } });
+    expect(prisma.expenseGroup.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a label whose group belongs to another organization before writing', async () => {
+    prisma.expenseGroup.findFirst.mockResolvedValue(null);
+    await expect(service.createLabel({ name: 'Gasolina', groupId: 'g1' }, 'org-1')).rejects.toThrow(NotFoundException);
+    expect(prisma.expenseLabel.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing organization and duplicate active names', async () => {
+    await expect(service.findGroups(undefined)).rejects.toThrow(BadRequestException);
+    prisma.expenseGroup.findFirst.mockResolvedValue({ id: 'g1', active: true });
+    await expect(service.createGroup({ name: 'Transporte' }, 'org-1')).rejects.toThrow(ConflictException);
+  });
+
+  it('soft-deletes groups and labels without deleting records', async () => {
+    prisma.expenseGroup.findFirst.mockResolvedValue({ id: 'g1', organizationId: 'org-1' });
+    prisma.expenseGroup.update.mockResolvedValue({ id: 'g1', active: false });
+    await expect(service.removeGroup('g1', 'org-1')).resolves.toMatchObject({ active: false });
+    expect(prisma.expenseGroup.update).toHaveBeenCalledWith({ where: { id: 'g1' }, data: { active: false } });
+  });
+});

--- a/backend/src/expenses/expense-taxonomy.service.ts
+++ b/backend/src/expenses/expense-taxonomy.service.ts
@@ -1,0 +1,119 @@
+import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateExpenseGroupDto } from './dto/create-expense-group.dto';
+import { UpdateExpenseGroupDto } from './dto/update-expense-group.dto';
+import { CreateExpenseLabelDto } from './dto/create-expense-label.dto';
+import { UpdateExpenseLabelDto } from './dto/update-expense-label.dto';
+
+@Injectable()
+export class ExpenseTaxonomyService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  private organization(organizationId?: string): string {
+    if (!organizationId) throw new BadRequestException('Organization ID is required for this operation');
+    return organizationId;
+  }
+
+  async findGroups(organizationId?: string) {
+    const orgId = this.organization(organizationId);
+    return this.prisma.expenseGroup.findMany({
+      where: { organizationId: orgId, active: true },
+      orderBy: { name: 'asc' },
+      include: { labels: { where: { active: true }, orderBy: { name: 'asc' } } },
+    });
+  }
+
+  async createGroup(dto: CreateExpenseGroupDto, organizationId?: string) {
+    const orgId = this.organization(organizationId);
+    const name = dto.name.trim();
+    const existing = await this.prisma.expenseGroup.findFirst({ where: { organizationId: orgId, name } });
+    if (existing?.active) throw new ConflictException('An expense group with this name already exists');
+    if (existing) {
+      const result = await this.prisma.expenseGroup.update({ where: { id: existing.id }, data: { name, active: true } });
+      await this.audit('EXPENSE_GROUP_REACTIVATED', result.id, orgId);
+      return result;
+    }
+    const result = await this.prisma.expenseGroup.create({ data: { organizationId: orgId, name } });
+    await this.audit('EXPENSE_GROUP_CREATED', result.id, orgId);
+    return result;
+  }
+
+  async updateGroup(id: string, dto: UpdateExpenseGroupDto, organizationId?: string) {
+    const orgId = this.organization(organizationId);
+    const group = await this.prisma.expenseGroup.findFirst({ where: { id, organizationId: orgId } });
+    if (!group) throw new NotFoundException('Expense group not found');
+    const name = dto.name?.trim();
+    if (name && name !== group.name) {
+      const duplicate = await this.prisma.expenseGroup.findFirst({ where: { organizationId: orgId, name } });
+      if (duplicate) throw new ConflictException('An expense group with this name already exists');
+    }
+    const result = await this.prisma.expenseGroup.update({ where: { id }, data: name ? { name } : {} });
+    await this.audit('EXPENSE_GROUP_UPDATED', id, orgId);
+    return result;
+  }
+
+  async removeGroup(id: string, organizationId?: string) {
+    const orgId = this.organization(organizationId);
+    const group = await this.prisma.expenseGroup.findFirst({ where: { id, organizationId: orgId } });
+    if (!group) throw new NotFoundException('Expense group not found');
+    const result = await this.prisma.expenseGroup.update({ where: { id }, data: { active: false } });
+    await this.audit('EXPENSE_GROUP_DEACTIVATED', id, orgId);
+    return result;
+  }
+
+  async findLabels(groupId: string, organizationId?: string) {
+    const orgId = this.organization(organizationId);
+    await this.assertGroup(groupId, orgId);
+    return this.prisma.expenseLabel.findMany({ where: { groupId, organizationId: orgId, active: true }, orderBy: { name: 'asc' } });
+  }
+
+  async createLabel(dto: CreateExpenseLabelDto, organizationId?: string) {
+    const orgId = this.organization(organizationId);
+    await this.assertGroup(dto.groupId, orgId);
+    const name = dto.name.trim();
+    const existing = await this.prisma.expenseLabel.findFirst({ where: { groupId: dto.groupId, name } });
+    if (existing?.active) throw new ConflictException('An expense label with this name already exists in the group');
+    if (existing) {
+      const result = await this.prisma.expenseLabel.update({ where: { id: existing.id }, data: { name, active: true } });
+      await this.audit('EXPENSE_LABEL_REACTIVATED', result.id, orgId);
+      return result;
+    }
+    const result = await this.prisma.expenseLabel.create({ data: { organizationId: orgId, groupId: dto.groupId, name } });
+    await this.audit('EXPENSE_LABEL_CREATED', result.id, orgId);
+    return result;
+  }
+
+  async updateLabel(id: string, dto: UpdateExpenseLabelDto, organizationId?: string, groupId?: string) {
+    const orgId = this.organization(organizationId);
+    const label = await this.prisma.expenseLabel.findFirst({ where: { id, organizationId: orgId } });
+    if (!label || (groupId && label.groupId !== groupId)) throw new NotFoundException('Expense label not found');
+    const name = dto.name?.trim();
+    if (name && name !== label.name) {
+      const duplicate = await this.prisma.expenseLabel.findFirst({ where: { groupId: label.groupId, name } });
+      if (duplicate) throw new ConflictException('An expense label with this name already exists in the group');
+    }
+    const result = await this.prisma.expenseLabel.update({ where: { id }, data: name ? { name } : {} });
+    await this.audit('EXPENSE_LABEL_UPDATED', id, orgId);
+    return result;
+  }
+
+  async removeLabel(id: string, organizationId?: string) {
+    const orgId = this.organization(organizationId);
+    const label = await this.prisma.expenseLabel.findFirst({ where: { id, organizationId: orgId } });
+    if (!label) throw new NotFoundException('Expense label not found');
+    const result = await this.prisma.expenseLabel.update({ where: { id }, data: { active: false } });
+    await this.audit('EXPENSE_LABEL_DEACTIVATED', id, orgId);
+    return result;
+  }
+
+  private async assertGroup(groupId: string, organizationId: string) {
+    const group = await this.prisma.expenseGroup.findFirst({ where: { id: groupId, organizationId, active: true } });
+    if (!group) throw new NotFoundException('Expense group not found');
+  }
+
+  private audit(action: string, resourceId: string, organizationId: string) {
+    return this.prisma.auditLog.create({
+      data: { action, resource: 'ExpenseTaxonomy', resourceId, organizationId },
+    });
+  }
+}

--- a/backend/src/expenses/expenses.module.ts
+++ b/backend/src/expenses/expenses.module.ts
@@ -4,15 +4,18 @@ import { OrganizationRequiredGuard } from '../common/guards/organization-require
 import { AdminOrganizationInterceptor } from '../common/interceptors/admin-organization.interceptor';
 import { ExpensesController } from './expenses.controller';
 import { ExpensesService } from './expenses.service';
+import { ExpenseTaxonomyController } from './expense-taxonomy.controller';
+import { ExpenseTaxonomyService } from './expense-taxonomy.service';
 
 @Module({
   imports: [CloudinaryModule],
-  controllers: [ExpensesController],
+  controllers: [ExpensesController, ExpenseTaxonomyController],
   providers: [
     ExpensesService,
+    ExpenseTaxonomyService,
     OrganizationRequiredGuard,
     AdminOrganizationInterceptor,
   ],
-  exports: [ExpensesService],
+  exports: [ExpensesService, ExpenseTaxonomyService],
 })
 export class ExpensesModule {}

--- a/docs/authorization-matrix.md
+++ b/docs/authorization-matrix.md
@@ -118,6 +118,19 @@ Roles: `OWNER`, `ADMIN`, `MEMBER`, `CASHIER`, `INVENTORY_USER` (org roles), `SUP
 | /api/expenses/:id/upload | POST | ADMIN | org-scoped | backend/src/expenses/expenses.service.int.spec.ts |
 | /api/expenses/:id | DELETE | ADMIN | org-scoped | backend/src/expenses/expenses.service.int.spec.ts |
 
+## expense-groups
+
+| Route | Method | Role(s) | Org-scope | Test reference |
+|---|---|---|---|---|
+| /api/expense-groups | GET | ADMIN | org-scoped | backend/src/expenses/expense-taxonomy.controller.spec.ts |
+| /api/expense-groups | POST | ADMIN | org-scoped | backend/src/expenses/expense-taxonomy.controller.spec.ts |
+| /api/expense-groups/:id | PATCH | ADMIN | org-scoped | backend/src/expenses/expense-taxonomy.controller.spec.ts |
+| /api/expense-groups/:id | DELETE | ADMIN | org-scoped | backend/src/expenses/expense-taxonomy.controller.spec.ts |
+| /api/expense-groups/:groupId/labels | GET | ADMIN | org-scoped | backend/src/expenses/expense-taxonomy.controller.spec.ts |
+| /api/expense-groups/:groupId/labels | POST | ADMIN | org-scoped | backend/src/expenses/expense-taxonomy.controller.spec.ts |
+| /api/expense-groups/:groupId/labels/:id | PATCH | ADMIN | org-scoped | backend/src/expenses/expense-taxonomy.controller.spec.ts |
+| /api/expense-groups/:groupId/labels/:id | DELETE | ADMIN | org-scoped | backend/src/expenses/expense-taxonomy.controller.spec.ts |
+
 ## exports
 
 | Route | Method | Role(s) | Org-scope | Test reference |
@@ -268,3 +281,12 @@ guarantees the header, so residual exposure is the superadmin-without-header pat
 
 Routed to the design owner for a follow-up inside the auth work (issue #48 slice C) or a dedicated
 micro-PR (issue #47).
+
+## Issue #134 final regression evidence
+
+- Backend: 88 suites and 859 tests passed.
+- Frontend: 71 files and 398 tests passed.
+- Database migration status was up to date.
+- Rollback is performed by restoring a database snapshot; no reverse migration is provided.
+- The earlier timeout in `frontend/src/app/tasks/page.evidence.test.tsx` was pre-existing and passed
+  when run in isolation.

--- a/frontend/src/app/expenses/expenses-page.evidence.test.tsx
+++ b/frontend/src/app/expenses/expenses-page.evidence.test.tsx
@@ -13,11 +13,14 @@ const { exportDataMock } = vi.hoisted(() => ({ exportDataMock: vi.fn() }));
 
 const useExpensesMock = vi.fn();
 const useExpenseSummaryMock = vi.fn();
-const useExpenseCategoriesMock = vi.fn();
+const useExpenseGroupsMock = vi.fn();
 const useSuppliersMock = vi.fn();
 const deleteMutateAsyncMock = vi.fn();
 const duplicateMutateAsyncMock = vi.fn();
 const uploadReceiptMutateAsyncMock = vi.fn();
+const { taxonomyMutationMock } = vi.hoisted(() => ({
+  taxonomyMutationMock: () => ({ mutateAsync: vi.fn() }),
+}));
 const toastSuccessMock = vi.fn();
 const toastErrorMock = vi.fn();
 
@@ -28,7 +31,13 @@ vi.mock("@/components/layout/DashboardLayout", () => ({
 vi.mock("@/hooks/useExpenses", () => ({
   useExpenses: (params?: unknown) => useExpensesMock(params),
   useExpenseSummary: (month?: string) => useExpenseSummaryMock(month),
-  useExpenseCategories: () => useExpenseCategoriesMock(),
+  useExpenseGroups: () => useExpenseGroupsMock(),
+  useCreateExpenseGroup: taxonomyMutationMock,
+  useUpdateExpenseGroup: taxonomyMutationMock,
+  useDeleteExpenseGroup: taxonomyMutationMock,
+  useCreateExpenseLabel: taxonomyMutationMock,
+  useUpdateExpenseLabel: taxonomyMutationMock,
+  useDeleteExpenseLabel: taxonomyMutationMock,
   useDeleteExpense: () => ({ mutateAsync: deleteMutateAsyncMock }),
   useDuplicateExpense: () => ({ mutateAsync: duplicateMutateAsyncMock }),
   useUploadExpenseReceipt: () => ({ mutateAsync: uploadReceiptMutateAsyncMock }),
@@ -62,6 +71,10 @@ vi.mock("@/contexts/ToastContext", () => ({
   }),
 }));
 
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({ user: { role: "CASHIER" } }),
+}));
+
 vi.mock("@/lib/api", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
   return {
@@ -77,14 +90,23 @@ import ExpensesPage from "./page";
 const expenseFixture = {
   id: "exp-1",
   organizationId: "org-1",
-  categoryId: "cat-1",
-  category: {
-    id: "cat-1",
+  labelId: "label-1",
+  label: {
+    id: "label-1",
     organizationId: "org-1",
+    groupId: "group-1",
     name: "Arriendo",
     active: true,
     createdAt: "2026-08-01T00:00:00.000Z",
     updatedAt: "2026-08-01T00:00:00.000Z",
+    group: {
+      id: "group-1",
+      organizationId: "org-1",
+      name: "Gastos del local",
+      active: true,
+      createdAt: "2026-08-01T00:00:00.000Z",
+      updatedAt: "2026-08-01T00:00:00.000Z",
+    },
   },
   supplierId: null,
   purchaseOrderId: null,
@@ -140,9 +162,9 @@ describe("Expenses page evidence", () => {
       data: {
         month: "2026-08",
         total: "800000",
-        categories: [
-          { categoryId: "cat-1", name: "Arriendo", total: "500000" },
-          { categoryId: "cat-2", name: "Caja menor", total: "300000" },
+        groups: [
+          { groupId: "group-1", name: "Gastos del local", total: "500000", labels: [{ labelId: "label-1", name: "Arriendo", total: "500000" }] },
+          { groupId: "group-2", name: "Caja menor", total: "300000", labels: [{ labelId: "label-2", name: "Compras menores", total: "300000" }] },
         ],
       },
       isLoading: false,
@@ -156,15 +178,16 @@ describe("Expenses page evidence", () => {
       isLoading: false,
     });
 
-    useExpenseCategoriesMock.mockReturnValue({
+    useExpenseGroupsMock.mockReturnValue({
       data: [
         {
-          id: "cat-1",
+          id: "group-1",
           organizationId: "org-1",
-          name: "Arriendo",
+          name: "Gastos del local",
           active: true,
           createdAt: "2026-08-01T00:00:00.000Z",
           updatedAt: "2026-08-01T00:00:00.000Z",
+          labels: [{ id: "label-1", organizationId: "org-1", groupId: "group-1", name: "Arriendo", active: true, createdAt: "2026-08-01T00:00:00.000Z", updatedAt: "2026-08-01T00:00:00.000Z" }],
         },
       ],
       isLoading: false,
@@ -182,7 +205,7 @@ describe("Expenses page evidence", () => {
 
     expect(screen.getByText("Total del Mes")).toBeTruthy();
     expect(screen.getByText(/800\.000/)).toBeTruthy();
-    expect(screen.getAllByText("Arriendo").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/Arriendo/).length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Caja menor")).toBeTruthy();
     expect(useExpenseSummaryMock).toHaveBeenCalledWith(CURRENT_MONTH);
   });

--- a/frontend/src/app/expenses/page.tsx
+++ b/frontend/src/app/expenses/page.tsx
@@ -7,12 +7,13 @@ import { useSuppliers } from "@/hooks/useSuppliers";
 import {
   useDeleteExpense,
   useDuplicateExpense,
-  useExpenseCategories,
+  useExpenseGroups,
   useExpenses,
   useExpenseSummary,
   useUploadExpenseReceipt,
 } from "@/hooks/useExpenses";
 import { useToast } from "@/contexts/ToastContext";
+import { useAuth } from "@/contexts/AuthContext";
 import { api, getApiErrorMessage } from "@/lib/api";
 import { formatCurrency, formatDate, getBogotaDateInputValue } from "@/lib/utils";
 import { Button } from "@/components/ui/Button";
@@ -40,6 +41,7 @@ import {
 } from "lucide-react";
 import { chipStyles } from "@/lib/chipStyles";
 import type { Expense, ExpenseStatus } from "@/types";
+import { ExpenseTaxonomyModal } from "@/components/expenses/ExpenseTaxonomyModal";
 
 // S1 code splitting (#98): the four expense modals are heavy components used
 // only on this page; they load as separate chunks on first open and are
@@ -82,6 +84,7 @@ const STATUS_OPTIONS: Array<{ value: "" | ExpenseStatus; label: string }> = [
 
 export default function ExpensesPage() {
   const toast = useToast();
+  const { user } = useAuth();
 
   // Warm the lazily loaded modal chunks once idle (S1 code splitting).
   useEffect(
@@ -98,7 +101,7 @@ export default function ExpensesPage() {
   const [month, setMonth] = useState(() =>
     getBogotaDateInputValue().slice(0, 7),
   );
-  const [categoryId, setCategoryId] = useState("");
+  const [labelId, setLabelId] = useState("");
   const [supplierId, setSupplierId] = useState("");
   const [status, setStatus] = useState<"" | ExpenseStatus>("");
   const [search, setSearch] = useState("");
@@ -113,15 +116,16 @@ export default function ExpensesPage() {
   const [detailExpense, setDetailExpense] = useState<Expense | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Expense | null>(null);
   const [duplicateTarget, setDuplicateTarget] = useState<Expense | null>(null);
+  const [taxonomyOpen, setTaxonomyOpen] = useState(false);
 
   const { data: summary } = useExpenseSummary(month);
-  const { data: categoriesData } = useExpenseCategories();
+  const { data: groupsData } = useExpenseGroups();
   const { data: suppliersData } = useSuppliers({ limit: 200, status: "active" });
   const { data, isLoading } = useExpenses({
     page,
     limit: 15,
     month,
-    categoryId: categoryId || undefined,
+    labelId: labelId || undefined,
     supplierId: supplierId || undefined,
     status: status || undefined,
     search: search.trim() || undefined,
@@ -133,14 +137,15 @@ export default function ExpensesPage() {
 
   const expenses = data?.data ?? [];
   const meta = data?.meta;
-  const categories = categoriesData ?? [];
+  const groups = groupsData ?? [];
+  const labels = groups.flatMap((group) => (group.labels ?? []).filter((label) => label.active));
   const suppliers = suppliersData?.data ?? [];
 
-  const hasFilters = !!categoryId || !!supplierId || !!status || !!search;
+  const hasFilters = !!labelId || !!supplierId || !!status || !!search;
 
   const clearFilters = () => {
     setPage(1);
-    setCategoryId("");
+    setLabelId("");
     setSupplierId("");
     setStatus("");
     setSearch("");
@@ -245,6 +250,7 @@ export default function ExpensesPage() {
             <Button type="button" onClick={openCreate} className="shrink-0">
               <Plus className="w-4 h-4" /> Nuevo gasto
             </Button>
+            {user?.role === "ADMIN" && <Button type="button" variant="secondary" onClick={() => setTaxonomyOpen(true)} className="shrink-0">Gestionar categorías</Button>}
           </div>
         </div>
 
@@ -297,18 +303,18 @@ export default function ExpensesPage() {
                 className="h-8 px-2 rounded-lg text-xs font-semibold bg-muted/40 border border-border/60 text-foreground focus:outline-none focus:border-primary/50 w-full sm:w-auto"
               />
               <BentoSelect
-                value={categoryId}
+                value={labelId}
                 onChange={(value) => {
                   setPage(1);
-                  setCategoryId(value);
+                  setLabelId(value);
                 }}
                 className="w-full sm:w-52"
-                placeholder="Todas las categorías"
+                placeholder="Todas las etiquetas"
                 options={[
-                  { value: "", label: "Todas las categorías" },
-                  ...categories.map((category) => ({
-                    value: category.id,
-                    label: category.name,
+                  { value: "", label: "Todas las etiquetas" },
+                  ...labels.map((label) => ({
+                    value: label.id,
+                    label: label.name,
                   })),
                 ]}
               />
@@ -383,7 +389,7 @@ export default function ExpensesPage() {
                     >
                       <div className="flex items-center justify-between">
                         <span className="font-semibold text-sm text-foreground truncate max-w-[200px]">
-                          {expense.category?.name ?? "Salida general"}
+                          {expense.label?.group?.name ? `${expense.label.group.name} / ` : ""}{expense.label?.name ?? "Salida general"}
                         </span>
                         <ExpenseStatusBadge status={expense.status} />
                       </div>
@@ -493,7 +499,7 @@ export default function ExpensesPage() {
                         as="th"
                         className="text-left text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
                       >
-                        Categoría
+                         Grupo / etiqueta
                       </TableCell>
                       <TableCell
                         as="th"
@@ -553,7 +559,7 @@ export default function ExpensesPage() {
                           </TableCell>
                           <TableCell>
                             <span className="text-xs font-semibold text-foreground">
-                              {expense.category?.name ?? "—"}
+                              {expense.label?.group?.name ? `${expense.label.group.name} / ` : ""}{expense.label?.name ?? "—"}
                             </span>
                           </TableCell>
                           <TableCell className="max-w-[220px] truncate">
@@ -729,6 +735,8 @@ export default function ExpensesPage() {
         message="El gasto se ocultará de los listados y el resumen del mes. Esta acción no se puede deshacer."
         confirmText="Sí, eliminar"
       />
+
+      <ExpenseTaxonomyModal isOpen={taxonomyOpen} onClose={() => setTaxonomyOpen(false)} />
 
       <ConfirmDialog
         isOpen={!!duplicateTarget}

--- a/frontend/src/components/expenses/ExpenseDetailModal.tsx
+++ b/frontend/src/components/expenses/ExpenseDetailModal.tsx
@@ -75,7 +75,10 @@ export function ExpenseDetailModal({ expense, isOpen, onClose }: Props) {
 
             {/* Grid Details */}
             <div className="grid grid-cols-2 gap-2.5">
-              <InfoItem label="Categoría" value={expense.category?.name ?? "—"} />
+              <InfoItem
+                label="Grupo / etiqueta"
+                value={expense.label?.group?.name ? `${expense.label.group.name} / ${expense.label.name}` : expense.label?.name ?? "—"}
+              />
               <InfoItem label="Proveedor" value={expense.supplier?.name ?? "—"} />
               <InfoItem
                 label="Orden de Compra"

--- a/frontend/src/components/expenses/ExpenseFormModal.tsx
+++ b/frontend/src/components/expenses/ExpenseFormModal.tsx
@@ -8,7 +8,7 @@ import { CurrencyInput } from "@/components/ui/CurrencyInput";
 import { ImageUpload } from "@/components/ui/ImageUpload";
 import {
   useCreateExpense,
-  useExpenseCategories,
+  useExpenseGroups,
   useUpdateExpense,
   useUploadExpenseReceipt,
 } from "@/hooks/useExpenses";
@@ -59,15 +59,21 @@ export function ExpenseFormModal({ isOpen, onClose, expense }: Props) {
   const updateExpense = useUpdateExpense();
   const uploadReceipt = useUploadExpenseReceipt();
 
-  const { data: categoriesData } = useExpenseCategories();
+  const { data: groupsData, isLoading: isGroupsLoading } = useExpenseGroups();
   const { data: suppliersData } = useSuppliers({ limit: 200, status: "active" });
   const { data: ordersData } = usePurchaseOrders({ limit: 200 });
 
-  const categories = categoriesData ?? [];
+  const groups = groupsData ?? [];
+  const labelOptions = groups.flatMap((group) => [
+    { value: `group-${group.id}`, label: `— ${group.name} —` },
+    ...(group.labels ?? [])
+      .filter((label) => label.active)
+      .map((label) => ({ value: label.id, label: `${group.name} / ${label.name}` })),
+  ]);
   const suppliers = suppliersData?.data ?? [];
   const orders = ordersData?.data ?? [];
 
-  const [categoryId, setCategoryId] = useState(expense?.categoryId ?? "");
+  const [labelId, setLabelId] = useState(expense?.labelId ?? "");
   const [supplierId, setSupplierId] = useState(expense?.supplierId ?? "");
   const [purchaseOrderId, setPurchaseOrderId] = useState(
     expense?.purchaseOrderId ?? "",
@@ -97,8 +103,8 @@ export function ExpenseFormModal({ isOpen, onClose, expense }: Props) {
       )
     : 0;
 
-  const error = !categoryId
-    ? "Selecciona una categoría"
+  const error = !labelId
+    ? "Selecciona una etiqueta de gasto"
     : !date
       ? "Selecciona una fecha"
       : numericTotal <= 0
@@ -120,7 +126,7 @@ export function ExpenseFormModal({ isOpen, onClose, expense }: Props) {
         await updateExpense.mutateAsync({
           id: expense.id,
           data: {
-            categoryId,
+            labelId,
             supplierId: supplierId || null,
             purchaseOrderId: purchaseOrderId || null,
             description: description.trim() || null,
@@ -131,7 +137,7 @@ export function ExpenseFormModal({ isOpen, onClose, expense }: Props) {
         toast.success("Gasto actualizado");
       } else {
         const created = await createExpense.mutateAsync({
-          categoryId,
+          labelId,
           supplierId: supplierId || undefined,
           purchaseOrderId: purchaseOrderId || undefined,
           description: description.trim() || undefined,
@@ -185,17 +191,13 @@ export function ExpenseFormModal({ isOpen, onClose, expense }: Props) {
         {/* Left column: expense data */}
         <div className="space-y-3">
           <BentoSelect
-            label="Categoría"
-            value={categoryId}
-            onChange={(value) => setCategoryId(value)}
+            label="Grupo y etiqueta"
+            value={labelId}
+            disabled={isGroupsLoading}
+            onChange={(value) => setLabelId(value.startsWith("group-") ? "" : value)}
             options={[
-              { value: "", label: "Selecciona una categoría" },
-              ...categories
-                .filter((category) => category.active)
-                .map((category) => ({
-                  value: category.id,
-                  label: category.name,
-                })),
+              { value: "", label: isGroupsLoading ? "Cargando etiquetas..." : "Selecciona un gasto" },
+              ...labelOptions,
             ]}
           />
 

--- a/frontend/src/components/expenses/ExpenseSummaryCards.test.tsx
+++ b/frontend/src/components/expenses/ExpenseSummaryCards.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ExpenseSummaryCards } from "./ExpenseSummaryCards";
+
+describe("ExpenseSummaryCards", () => {
+  it("shows the total and the highest-level expense groups", () => {
+    render(<ExpenseSummaryCards month="2026-08" summary={{ month: "2026-08", total: 500000, groups: [{ groupId: "g1", name: "Gastos del local", total: 500000, labels: [{ labelId: "l1", name: "Arriendo", total: 500000 }] }] }} />);
+    expect(screen.getByText("Gastos del local")).toBeInTheDocument();
+    expect(screen.getByText(/Arriendo/)).toBeInTheDocument();
+    expect(screen.getByText(/Período: 2026-08/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/expenses/ExpenseSummaryCards.tsx
+++ b/frontend/src/components/expenses/ExpenseSummaryCards.tsx
@@ -1,4 +1,3 @@
-import { Card } from "@/components/ui/Card";
 import { formatCurrency } from "@/lib/utils";
 import { Wallet, TrendingDown } from "lucide-react";
 import type { ExpenseMonthlySummary } from "@/types";
@@ -31,24 +30,29 @@ export function ExpenseSummaryCards({ month, summary }: Props) {
         )}
       </div>
 
-      {(summary?.categories ?? []).slice(0, 2).map((category) => (
+      {(summary?.groups ?? []).slice(0, 2).map((group) => (
         <div
-          key={category.categoryId}
+          key={group.groupId}
           className="rounded-3xl border border-border/80 bg-card p-5 shadow-xs flex flex-col justify-between"
         >
           <div className="flex items-center justify-between">
             <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground truncate">
-              {category.name}
+              {group.name}
             </p>
             <div className="w-8 h-8 rounded-xl bg-muted text-muted-foreground flex items-center justify-center">
               <TrendingDown className="w-4 h-4 text-primary" />
             </div>
           </div>
           <p className="mt-3 text-2xl lg:text-3xl font-extrabold font-mono text-foreground tracking-tight">
-            {formatCurrency(Number(category.total ?? 0))}
+            {formatCurrency(Number(group.total ?? 0))}
           </p>
           <p className="mt-1 text-[11px] text-muted-foreground font-mono">
-            Gasto acumulado
+            <span>Gasto acumulado</span>
+            {(group.labels ?? []).slice(0, 3).map((label) => (
+              <span key={label.labelId} className="block truncate">
+                {label.name}: {formatCurrency(Number(label.total ?? 0))}
+              </span>
+            ))}
           </p>
         </div>
       ))}

--- a/frontend/src/components/expenses/ExpenseTaxonomyModal.test.tsx
+++ b/frontend/src/components/expenses/ExpenseTaxonomyModal.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/components/ui/Modal", () => ({
+  Modal: ({ children, title }: { children: React.ReactNode; title: string }) => (
+    <section><h2>{title}</h2>{children}</section>
+  ),
+}));
+vi.mock("@/hooks/useExpenses", () => ({
+  useExpenseGroups: () => ({ data: [{ id: "g1", name: "Gastos del local", active: true, labels: [{ id: "l1", name: "Arriendo", active: true }] }] }),
+  useCreateExpenseGroup: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateExpenseGroup: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDeleteExpenseGroup: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useCreateExpenseLabel: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateExpenseLabel: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDeleteExpenseLabel: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock("@/contexts/AuthContext", () => ({ useAuth: () => ({ user: { role: "ADMIN" } }) }));
+vi.mock("@/contexts/ToastContext", () => ({ useToast: () => ({ success: vi.fn(), error: vi.fn() }) }));
+
+import { ExpenseTaxonomyModal } from "./ExpenseTaxonomyModal";
+
+describe("ExpenseTaxonomyModal", () => {
+  it("renders groups and nested labels for an administrator", () => {
+    render(<ExpenseTaxonomyModal isOpen onClose={vi.fn()} />);
+    expect(screen.getByText("Gastos del local")).toBeInTheDocument();
+    expect(screen.getByText("Arriendo")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /nuevo grupo/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/expenses/ExpenseTaxonomyModal.tsx
+++ b/frontend/src/components/expenses/ExpenseTaxonomyModal.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState } from "react";
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { useToast } from "@/contexts/ToastContext";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  useCreateExpenseGroup,
+  useCreateExpenseLabel,
+  useDeleteExpenseGroup,
+  useDeleteExpenseLabel,
+  useExpenseGroups,
+  useUpdateExpenseGroup,
+  useUpdateExpenseLabel,
+} from "@/hooks/useExpenses";
+import { getApiErrorMessage } from "@/lib/api";
+import { Pencil, Plus, Trash2 } from "lucide-react";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function ExpenseTaxonomyModal({ isOpen, onClose }: Props) {
+  const { user } = useAuth();
+  const toast = useToast();
+  const { data: groups = [], isLoading, isError } = useExpenseGroups();
+  const createGroup = useCreateExpenseGroup();
+  const updateGroup = useUpdateExpenseGroup();
+  const deleteGroup = useDeleteExpenseGroup();
+  const createLabel = useCreateExpenseLabel();
+  const updateLabel = useUpdateExpenseLabel();
+  const deleteLabel = useDeleteExpenseLabel();
+  const [groupName, setGroupName] = useState("");
+  const [newLabel, setNewLabel] = useState<Record<string, string>>({});
+  const [editing, setEditing] = useState<{ id: string; groupId?: string; value: string } | null>(null);
+
+  if (user?.role !== "ADMIN") return null;
+
+  const run = async (action: () => Promise<unknown>, success: string) => {
+    try {
+      await action();
+      toast.success(success);
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "No se pudo actualizar la taxonomía"));
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Gestionar categorías" size="lg">
+      <div className="space-y-5">
+        <div className="flex items-end gap-2">
+          <Input label="Nuevo grupo" value={groupName} onChange={(e) => setGroupName(e.target.value)} placeholder="Nombre del grupo" />
+          <Button type="button" disabled={!groupName.trim() || createGroup.isPending} onClick={() => void run(async () => { await createGroup.mutateAsync({ name: groupName.trim() }); setGroupName(""); }, "Grupo creado")}>
+            <Plus className="h-4 w-4" aria-hidden="true" /> Nuevo grupo
+          </Button>
+        </div>
+        {isLoading && <p className="text-sm text-muted-foreground">Cargando grupos...</p>}
+        {isError && <p role="alert" className="text-sm text-danger">No se pudieron cargar los grupos.</p>}
+        {!isLoading && groups.length === 0 && <p className="text-sm text-muted-foreground">No hay grupos configurados.</p>}
+        <div className="space-y-3">
+          {groups.map((group) => (
+            <div key={group.id} className="rounded-2xl border border-border/70 p-4">
+              <div className="flex items-center gap-2">
+                {editing?.id === group.id ? <Input value={editing.value} onChange={(e) => setEditing({ ...editing, value: e.target.value })} /> : <h3 className="flex-1 font-bold">{group.name}</h3>}
+                {editing?.id === group.id ? <Button size="sm" onClick={() => void run(async () => { await updateGroup.mutateAsync({ id: group.id, data: { name: editing.value.trim() } }); setEditing(null); }, "Grupo actualizado")}>Guardar</Button> : <Button size="sm" variant="ghost" aria-label={`Editar ${group.name}`} onClick={() => setEditing({ id: group.id, value: group.name })}><Pencil className="h-4 w-4" aria-hidden="true" /></Button>}
+                <Button size="sm" variant="ghost" aria-label={`Desactivar ${group.name}`} onClick={() => void run(() => deleteGroup.mutateAsync(group.id), "Grupo desactivado")}><Trash2 className="h-4 w-4" aria-hidden="true" /></Button>
+              </div>
+              <div className="mt-3 space-y-2 pl-4">
+                {(group.labels ?? []).map((label) => (
+                  <div key={label.id} className="flex items-center gap-2 text-sm">
+                    {editing?.id === label.id ? <Input value={editing.value} onChange={(e) => setEditing({ ...editing, value: e.target.value })} /> : <span className="flex-1">{label.name}</span>}
+                    {editing?.id === label.id ? <Button size="sm" onClick={() => void run(async () => { await updateLabel.mutateAsync({ groupId: group.id, id: label.id, data: { name: editing.value.trim() } }); setEditing(null); }, "Etiqueta actualizada")}>Guardar</Button> : <Button size="sm" variant="ghost" aria-label={`Editar ${label.name}`} onClick={() => setEditing({ id: label.id, groupId: group.id, value: label.name })}><Pencil className="h-4 w-4" aria-hidden="true" /></Button>}
+                    <Button size="sm" variant="ghost" aria-label={`Desactivar ${label.name}`} onClick={() => void run(() => deleteLabel.mutateAsync({ groupId: group.id, id: label.id }), "Etiqueta desactivada")}><Trash2 className="h-4 w-4" aria-hidden="true" /></Button>
+                  </div>
+                ))}
+                <div className="flex items-end gap-2 pt-2">
+                  <Input label="Nueva etiqueta" value={newLabel[group.id] ?? ""} onChange={(e) => setNewLabel({ ...newLabel, [group.id]: e.target.value })} placeholder="Nombre de la etiqueta" />
+                  <Button size="sm" variant="secondary" disabled={!newLabel[group.id]?.trim()} onClick={() => void run(async () => { await createLabel.mutateAsync({ groupId: group.id, data: { name: newLabel[group.id].trim() } }); setNewLabel({ ...newLabel, [group.id]: "" }); }, "Etiqueta creada")}><Plus className="h-4 w-4" aria-hidden="true" /> Agregar</Button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/expenses/expense-detail-modal.test.tsx
+++ b/frontend/src/components/expenses/expense-detail-modal.test.tsx
@@ -32,14 +32,23 @@ import { ExpenseDetailModal } from "./ExpenseDetailModal";
 const expense = {
   id: "exp-1",
   organizationId: "org-1",
-  categoryId: "cat-1",
-  category: {
-    id: "cat-1",
+  labelId: "label-1",
+  label: {
+    id: "label-1",
     organizationId: "org-1",
+    groupId: "group-1",
     name: "Arriendo",
     active: true,
     createdAt: "2026-08-01T00:00:00.000Z",
     updatedAt: "2026-08-01T00:00:00.000Z",
+    group: {
+      id: "group-1",
+      organizationId: "org-1",
+      name: "Gastos del local",
+      active: true,
+      createdAt: "2026-08-01T00:00:00.000Z",
+      updatedAt: "2026-08-01T00:00:00.000Z",
+    },
   },
   supplierId: "sup-1",
   supplier: {
@@ -132,13 +141,13 @@ describe("ExpenseDetailModal", () => {
     cleanup();
   });
 
-  it("renders total, status, category, supplier, purchase order and description", () => {
+  it("renders total, status, group and label, supplier, purchase order and description", () => {
     render(<ExpenseDetailModal expense={expense} isOpen onClose={vi.fn()} />);
 
     expect(screen.getByText("Detalle del Gasto")).toBeInTheDocument();
     expect(screen.getByText(/500\.000/)).toBeInTheDocument();
     expect(screen.getByText("Parcial")).toBeInTheDocument();
-    expect(screen.getByText("Arriendo")).toBeInTheDocument();
+    expect(screen.getByText("Gastos del local / Arriendo")).toBeInTheDocument();
     expect(screen.getByText("Proveedor Uno")).toBeInTheDocument();
     expect(screen.getByText("OC-101")).toBeInTheDocument();
     expect(screen.getByText("Renta agosto")).toBeInTheDocument();

--- a/frontend/src/components/expenses/expense-form-modal.test.tsx
+++ b/frontend/src/components/expenses/expense-form-modal.test.tsx
@@ -49,21 +49,23 @@ vi.mock("@/components/ui/ImageUpload", () => ({
 }));
 
 vi.mock("@/hooks/useExpenses", () => ({
-  useExpenseCategories: () => ({
+  useExpenseGroups: () => ({
     data: [
       {
-        id: "cat-1",
+        id: "group-1",
         organizationId: "org-1",
-        name: "Arriendo",
+        name: "Gastos del local",
         active: true,
+        labels: [{ id: "label-1", groupId: "group-1", name: "Arriendo", active: true }],
         createdAt: "2026-08-01T00:00:00.000Z",
         updatedAt: "2026-08-01T00:00:00.000Z",
       },
       {
-        id: "cat-2",
+        id: "group-2",
         organizationId: "org-1",
         name: "Caja menor",
         active: true,
+        labels: [{ id: "label-2", groupId: "group-2", name: "Compras menores", active: true }],
         createdAt: "2026-08-01T00:00:00.000Z",
         updatedAt: "2026-08-01T00:00:00.000Z",
       },
@@ -111,23 +113,24 @@ import { ExpenseFormModal } from "./ExpenseFormModal";
  * BentoSelect renders as a trigger <button> (not a native <select>), so the
  * option is picked by opening the popover and clicking the option label.
  */
-async function pickCategory(
+async function pickLabel(
   user: ReturnType<typeof userEvent.setup>,
-  categoryLabel: string,
+  label: string,
 ) {
   await user.click(
-    screen.getByRole("button", { name: /selecciona una categor\u00eda/i }),
+    screen.getByRole("button", { name: /selecciona un gasto/i }),
   );
-  await user.click(screen.getByText(categoryLabel));
+  await user.click(screen.getByText(new RegExp(`\\/ ${label}$`)));
 }
 
 function makeExpense(): Expense {
   return {
     id: "exp-1",
     organizationId: "org-1",
-    categoryId: "cat-1",
-    category: {
-      id: "cat-1",
+    labelId: "label-1",
+    label: {
+      id: "label-1",
+      groupId: "group-1",
       organizationId: "org-1",
       name: "Arriendo",
       active: true,
@@ -177,7 +180,7 @@ describe("ExpenseFormModal", () => {
 
     render(<ExpenseFormModal isOpen onClose={vi.fn()} />);
 
-    await pickCategory(user, "Arriendo");
+    await pickLabel(user, "Arriendo");
     fireEvent.change(screen.getByLabelText("Fecha"), {
       target: { value: "2026-08-10" },
     });
@@ -191,7 +194,7 @@ describe("ExpenseFormModal", () => {
 
     expect(createMutateAsyncMock).toHaveBeenCalledTimes(1);
     expect(createMutateAsyncMock).toHaveBeenCalledWith({
-      categoryId: "cat-1",
+      labelId: "label-1",
       supplierId: undefined,
       purchaseOrderId: undefined,
       description: undefined,
@@ -209,7 +212,7 @@ describe("ExpenseFormModal", () => {
 
     render(<ExpenseFormModal isOpen onClose={vi.fn()} />);
 
-    await pickCategory(user, "Arriendo");
+    await pickLabel(user, "Arriendo");
     fireEvent.change(screen.getByLabelText("Fecha"), {
       target: { value: "2026-08-10" },
     });
@@ -229,7 +232,7 @@ describe("ExpenseFormModal", () => {
 
     render(<ExpenseFormModal isOpen onClose={vi.fn()} />);
 
-    await pickCategory(user, "Arriendo");
+    await pickLabel(user, "Arriendo");
     fireEvent.change(screen.getByLabelText("Fecha"), {
       target: { value: "2026-08-10" },
     });
@@ -268,7 +271,7 @@ describe("ExpenseFormModal", () => {
     expect(updateMutateAsyncMock).toHaveBeenCalledWith({
       id: "exp-1",
       data: {
-        categoryId: "cat-1",
+        labelId: "label-1",
         supplierId: null,
         purchaseOrderId: null,
         description: "Renta septiembre",

--- a/frontend/src/hooks/useExpenses.test.ts
+++ b/frontend/src/hooks/useExpenses.test.ts
@@ -6,7 +6,8 @@ import { api } from "@/lib/api";
 import type {
   Expense,
   ExpenseAuditEntry,
-  ExpenseCategory,
+  ExpenseGroup,
+  ExpenseLabel,
   ExpenseMonthlySummary,
   ExpensePayment,
   PaginatedResponse,
@@ -14,17 +15,20 @@ import type {
 import {
   useAddExpensePayment,
   useCreateExpense,
-  useCreateExpenseCategory,
+  useCreateExpenseGroup,
+  useCreateExpenseLabel,
   useDeleteExpense,
-  useDeleteExpenseCategory,
+  useDeleteExpenseGroup,
+  useDeleteExpenseLabel,
   useDuplicateExpense,
   useExpense,
-  useExpenseCategories,
+  useExpenseGroups,
   useExpenseHistory,
   useExpenses,
   useExpenseSummary,
   useUpdateExpense,
-  useUpdateExpenseCategory,
+  useUpdateExpenseGroup,
+  useUpdateExpenseLabel,
   useUploadExpenseReceipt,
 } from "./useExpenses";
 import type { CreateExpensePayload, ExpensePaymentPayload } from "./useExpenses";
@@ -49,10 +53,23 @@ type MockApi = {
 
 const apiMock = api as unknown as MockApi;
 
-function makeCategory(overrides: Partial<ExpenseCategory> = {}): ExpenseCategory {
+function makeGroup(overrides: Partial<ExpenseGroup> = {}): ExpenseGroup {
   return {
-    id: "cat-1",
+    id: "group-1",
     organizationId: "org-a",
+    name: "Gastos del local",
+    active: true,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeLabel(overrides: Partial<ExpenseLabel> = {}): ExpenseLabel {
+  return {
+    id: "label-1",
+    organizationId: "org-a",
+    groupId: "group-1",
     name: "Arriendo",
     active: true,
     createdAt: "2026-08-01T00:00:00.000Z",
@@ -78,8 +95,8 @@ function makeExpense(overrides: Partial<Expense> = {}): Expense {
   return {
     id: "exp-1",
     organizationId: "org-a",
-    categoryId: "cat-1",
-    category: makeCategory(),
+    labelId: "label-1",
+    label: makeLabel(),
     supplierId: null,
     purchaseOrderId: null,
     description: "Arriendo agosto",
@@ -107,7 +124,7 @@ function makeSummary(): ExpenseMonthlySummary {
   return {
     month: "2026-08",
     total: 500000,
-    categories: [{ categoryId: "cat-1", name: "Arriendo", total: 500000 }],
+    groups: [{ groupId: "group-1", name: "Gastos del local", total: 500000, labels: [{ labelId: "label-1", name: "Arriendo", total: 500000 }] }],
   };
 }
 
@@ -210,17 +227,17 @@ describe("useExpenses", () => {
       expect(result.current.data).toEqual(entries);
     });
 
-    it("fetches the expense categories", async () => {
-      const categories = [makeCategory()];
-      apiMock.get.mockResolvedValue({ data: categories });
+    it("fetches groups with nested labels", async () => {
+      const groups = [makeGroup({ labels: [makeLabel()] })];
+      apiMock.get.mockResolvedValue({ data: groups });
 
-      const { result } = renderHook(() => useExpenseCategories(), {
+      const { result } = renderHook(() => useExpenseGroups(), {
         wrapper: wrapperWith(makeQueryClient()),
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(apiMock.get).toHaveBeenCalledWith("/expense-categories");
-      expect(result.current.data).toEqual(categories);
+      expect(apiMock.get).toHaveBeenCalledWith("/expense-groups");
+      expect(result.current.data).toEqual(groups);
     });
   });
 
@@ -236,7 +253,7 @@ describe("useExpenses", () => {
       });
 
       const payload: CreateExpensePayload = {
-        categoryId: "cat-1",
+        labelId: "label-1",
         description: "Arriendo agosto",
         date: "2026-08-01",
         total: 500000,
@@ -335,59 +352,55 @@ describe("useExpenses", () => {
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["expenses"] });
     });
 
-    it("creates a category and invalidates category queries", async () => {
+    it("creates a group and invalidates taxonomy, expenses, and summary queries", async () => {
       const queryClient = makeQueryClient();
       const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
-      apiMock.post.mockResolvedValue({ data: makeCategory() });
+      apiMock.post.mockResolvedValue({ data: makeGroup() });
 
-      const { result } = renderHook(() => useCreateExpenseCategory(), {
+      const { result } = renderHook(() => useCreateExpenseGroup(), {
         wrapper: wrapperWith(queryClient),
       });
 
       await result.current.mutateAsync({ name: "Impuestos" });
 
-      expect(apiMock.post).toHaveBeenCalledWith("/expense-categories", {
+      expect(apiMock.post).toHaveBeenCalledWith("/expense-groups", {
         name: "Impuestos",
       });
-      expect(invalidateSpy).toHaveBeenCalledWith({
-        queryKey: ["expense-categories"],
-      });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["expense-groups"] });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["expenses"] });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["expenses", "summary"] });
     });
 
-    it("updates a category and invalidates category queries", async () => {
+    it("updates a label through its group endpoint", async () => {
       const queryClient = makeQueryClient();
       const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
-      apiMock.patch.mockResolvedValue({ data: makeCategory() });
+      apiMock.patch.mockResolvedValue({ data: makeLabel() });
 
-      const { result } = renderHook(() => useUpdateExpenseCategory(), {
+      const { result } = renderHook(() => useUpdateExpenseLabel(), {
         wrapper: wrapperWith(queryClient),
       });
 
-      await result.current.mutateAsync({ id: "cat-1", data: { name: "Seguros" } });
+      await result.current.mutateAsync({ groupId: "group-1", id: "label-1", data: { name: "Servicios" } });
 
-      expect(apiMock.patch).toHaveBeenCalledWith("/expense-categories/cat-1", {
-        name: "Seguros",
+      expect(apiMock.patch).toHaveBeenCalledWith("/expense-groups/group-1/labels/label-1", {
+        name: "Servicios",
       });
-      expect(invalidateSpy).toHaveBeenCalledWith({
-        queryKey: ["expense-categories"],
-      });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["expense-groups"] });
     });
 
-    it("deletes a category and invalidates category queries", async () => {
+    it("deletes a label and invalidates taxonomy queries", async () => {
       const queryClient = makeQueryClient();
       const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
-      apiMock.delete.mockResolvedValue({ data: makeCategory() });
+      apiMock.delete.mockResolvedValue({ data: makeLabel() });
 
-      const { result } = renderHook(() => useDeleteExpenseCategory(), {
+      const { result } = renderHook(() => useDeleteExpenseLabel(), {
         wrapper: wrapperWith(queryClient),
       });
 
-      await result.current.mutateAsync("cat-1");
+      await result.current.mutateAsync({ groupId: "group-1", id: "label-1" });
 
-      expect(apiMock.delete).toHaveBeenCalledWith("/expense-categories/cat-1");
-      expect(invalidateSpy).toHaveBeenCalledWith({
-        queryKey: ["expense-categories"],
-      });
+      expect(apiMock.delete).toHaveBeenCalledWith("/expense-groups/group-1/labels/label-1");
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["expense-groups"] });
     });
   });
 });

--- a/frontend/src/hooks/useExpenses.ts
+++ b/frontend/src/hooks/useExpenses.ts
@@ -5,7 +5,8 @@ import { api } from "@/lib/api";
 import type {
   Expense,
   ExpenseAuditEntry,
-  ExpenseCategory,
+  ExpenseGroup,
+  ExpenseLabel,
   ExpenseMonthlySummary,
   ExpenseQueryParams,
   PaginatedResponse,
@@ -18,7 +19,7 @@ export interface ExpensePaymentPayload {
 }
 
 export interface CreateExpensePayload {
-  categoryId: string;
+  labelId: string;
   supplierId?: string;
   purchaseOrderId?: string;
   description?: string;
@@ -28,7 +29,7 @@ export interface CreateExpensePayload {
 }
 
 export interface UpdateExpensePayload {
-  categoryId?: string;
+  labelId?: string;
   supplierId?: string | null;
   purchaseOrderId?: string | null;
   description?: string | null;
@@ -36,8 +37,14 @@ export interface UpdateExpensePayload {
   total?: number;
 }
 
-export interface ExpenseCategoryPayload {
+export interface ExpenseTaxonomyPayload {
   name: string;
+}
+
+function invalidateExpenseData(queryClient: ReturnType<typeof useQueryClient>) {
+  void queryClient.invalidateQueries({ queryKey: ["expense-groups"] });
+  void queryClient.invalidateQueries({ queryKey: ["expenses"] });
+  void queryClient.invalidateQueries({ queryKey: ["expenses", "summary"] });
 }
 
 export function useExpenses(params?: ExpenseQueryParams) {
@@ -80,13 +87,11 @@ export function useExpenseHistory(id: string) {
   });
 }
 
-export function useExpenseCategories() {
+export function useExpenseGroups() {
   return useQuery({
-    queryKey: ["expense-categories"],
+    queryKey: ["expense-groups"],
     queryFn: () =>
-      api
-        .get<ExpenseCategory[]>("/expense-categories")
-        .then((res) => res.data),
+      api.get<ExpenseGroup[]>("/expense-groups").then((res) => res.data),
   });
 }
 
@@ -96,7 +101,7 @@ export function useCreateExpense() {
     mutationFn: (data: CreateExpensePayload) =>
       api.post<Expense>("/expenses", data).then((res) => res.data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+      invalidateExpenseData(queryClient);
     },
   });
 }
@@ -107,7 +112,7 @@ export function useUpdateExpense() {
     mutationFn: ({ id, data }: { id: string; data: UpdateExpensePayload }) =>
       api.patch<Expense>(`/expenses/${id}`, data).then((res) => res.data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+      invalidateExpenseData(queryClient);
     },
   });
 }
@@ -118,7 +123,7 @@ export function useDeleteExpense() {
     mutationFn: (id: string) =>
       api.delete<Expense>(`/expenses/${id}`).then((res) => res.data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+      invalidateExpenseData(queryClient);
     },
   });
 }
@@ -135,7 +140,7 @@ export function useAddExpensePayment() {
     }) =>
       api.post<Expense>(`/expenses/${id}/payments`, data).then((res) => res.data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+      invalidateExpenseData(queryClient);
     },
   });
 }
@@ -146,7 +151,7 @@ export function useDuplicateExpense() {
     mutationFn: (id: string) =>
       api.post<Expense>(`/expenses/${id}/duplicate`).then((res) => res.data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+      invalidateExpenseData(queryClient);
     },
   });
 }
@@ -157,46 +162,67 @@ export function useUploadExpenseReceipt() {
     mutationFn: ({ id, file }: { id: string; file: File }) =>
       api.upload<Expense>(`/expenses/${id}/upload`, file).then((res) => res.data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+      invalidateExpenseData(queryClient);
     },
   });
 }
 
-export function useCreateExpenseCategory() {
+export function useCreateExpenseGroup() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (data: ExpenseCategoryPayload) =>
-      api
-        .post<ExpenseCategory>("/expense-categories", data)
-        .then((res) => res.data),
+    mutationFn: (data: ExpenseTaxonomyPayload) =>
+      api.post<ExpenseGroup>("/expense-groups", data).then((res) => res.data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["expense-categories"] });
+      invalidateExpenseData(queryClient);
     },
   });
 }
 
-export function useUpdateExpenseCategory() {
+export function useUpdateExpenseGroup() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, data }: { id: string; data: ExpenseCategoryPayload }) =>
-      api
-        .patch<ExpenseCategory>(`/expense-categories/${id}`, data)
-        .then((res) => res.data),
+    mutationFn: ({ id, data }: { id: string; data: ExpenseTaxonomyPayload }) =>
+      api.patch<ExpenseGroup>(`/expense-groups/${id}`, data).then((res) => res.data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["expense-categories"] });
+      invalidateExpenseData(queryClient);
     },
   });
 }
 
-export function useDeleteExpenseCategory() {
+export function useDeleteExpenseGroup() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (id: string) =>
-      api
-        .delete<ExpenseCategory>(`/expense-categories/${id}`)
-        .then((res) => res.data),
+      api.delete<ExpenseGroup>(`/expense-groups/${id}`).then((res) => res.data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["expense-categories"] });
+      invalidateExpenseData(queryClient);
     },
+  });
+}
+
+export function useCreateExpenseLabel() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ groupId, data }: { groupId: string; data: ExpenseTaxonomyPayload }) =>
+      api.post<ExpenseLabel>(`/expense-groups/${groupId}/labels`, data).then((res) => res.data),
+    onSuccess: () => invalidateExpenseData(queryClient),
+  });
+}
+
+export function useUpdateExpenseLabel() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ groupId, id, data }: { groupId: string; id: string; data: ExpenseTaxonomyPayload }) =>
+      api.patch<ExpenseLabel>(`/expense-groups/${groupId}/labels/${id}`, data).then((res) => res.data),
+    onSuccess: () => invalidateExpenseData(queryClient),
+  });
+}
+
+export function useDeleteExpenseLabel() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ groupId, id }: { groupId: string; id: string }) =>
+      api.delete<ExpenseLabel>(`/expense-groups/${groupId}/labels/${id}`).then((res) => res.data),
+    onSuccess: () => invalidateExpenseData(queryClient),
   });
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -618,20 +618,31 @@ export interface ExpensePayment {
   createdAt: string;
 }
 
-export interface ExpenseCategory {
+export interface ExpenseLabel {
   id: string;
   organizationId: string;
+  groupId: string;
   name: string;
   active: boolean;
   createdAt: string;
   updatedAt: string;
 }
 
+export interface ExpenseGroup {
+  id: string;
+  organizationId: string;
+  name: string;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+  labels?: ExpenseLabel[];
+}
+
 export interface Expense {
   id: string;
   organizationId: string;
-  categoryId: string;
-  category?: ExpenseCategory;
+  labelId: string;
+  label?: ExpenseLabel & { group?: ExpenseGroup };
   supplierId: string | null;
   supplier?: Supplier | null;
   purchaseOrderId: string | null;
@@ -651,10 +662,11 @@ export interface Expense {
 export interface ExpenseMonthlySummary {
   month: string;
   total: number;
-  categories: Array<{
-    categoryId: string;
+  groups: Array<{
+    groupId: string;
     name: string;
     total: number;
+    labels: Array<{ labelId: string; name: string; total: number }>;
   }>;
 }
 
@@ -674,7 +686,7 @@ export type ExpenseQueryParams = {
   page?: number;
   limit?: number;
   month?: string;
-  categoryId?: string;
+  labelId?: string;
   supplierId?: string;
   status?: ExpenseStatus;
   search?: string;


### PR DESCRIPTION
Closes #134

## Summary
- Integrates the complete two-level expense taxonomy implementation into master.
- Aligns backend routes and persistence with frontend labelId and expense-groups contracts.
- Preserves migration, reporting, authorization, and regression coverage.

## Changes
| Area | Change |
|------|--------|
| Backend | Adds expense group/label CRUD routes and services |
| Frontend | Uses ExpenseGroup/ExpenseLabel and labelId throughout expenses UI |
| Verification | Includes taxonomy, migration, reporting, and frontend regression coverage |

## Test Plan
- [x] Backend tests: 88 suites / 859 tests
- [x] Frontend tests: 71 files / 398 tests
- [x] Backend build
- [x] Frontend build

## Checklist
- [x] Linked approved issue
- [x] Added exactly one type label
- [x] Tests and builds pass
- [x] No Co-Authored-By trailer
